### PR TITLE
Add Amp skill compatibility

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: book-to-skill
-description: "Converts a technical book (PDF or EPUB) into a structured agent skill, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a book through Amp or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from any PDF or EPUB."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Amp or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 compatibility: "Amp skill directories (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills) and Claude Code skill directories (~/.claude/skills)."
 allowed-tools:
   - shell_command
@@ -8,7 +8,7 @@ allowed-tools:
   - Write
   - Glob
   - Grep
-argument-hint: <path-to-pdf-or-epub> [skill-name-slug]
+argument-hint: <path-to-document> [skill-name-slug]
 ---
 
 # Book-to-Skill Converter
@@ -37,7 +37,7 @@ Books contain crystallized expertise: frameworks, principles, and techniques tha
 Three paths available. Route based on what the user asks:
 
 ### 1. Full Conversion (Default)
-**Trigger:** User provides a PDF path without special instructions
+**Trigger:** User provides a supported document path without special instructions
 **Action:** Run all steps below (Steps 0–9)
 **Output:** Complete skill with SKILL.md, chapters/, glossary, patterns, cheatsheet
 
@@ -68,8 +68,8 @@ Generated skills should default to `~/.config/agents/skills/` for Amp unless the
 
 ## Step 0 — Out-of-scope check
 
-If the argument is NOT a path to a PDF or EPUB file, stop and respond:
-> "book-to-skill requires a PDF or EPUB path. Usage: `book-to-skill /path/to/book.pdf [skill-name]` or `book-to-skill /path/to/book.epub [skill-name]`"
+If the argument is NOT a path to a supported document file, stop and respond:
+> "book-to-skill requires a supported document path. Usage: `book-to-skill /path/to/book.pdf [skill-name]`, `book-to-skill /path/to/book.epub [skill-name]`, or another supported format such as `.docx`, `.md`, `.txt`, `.html`, `.rtf`, `.mobi`, or `.azw3`."
 
 Throughout the workflow, treat the first argument as `BOOK_PATH` and the optional second argument as `SKILL_NAME`.
 
@@ -79,10 +79,13 @@ Throughout the workflow, treat the first argument as `BOOK_PATH` and the optiona
 
 ```bash
 test -f "$BOOK_PATH" && echo "FILE_OK" || echo "FILE_NOT_FOUND: $BOOK_PATH"
-file "$BOOK_PATH" | grep -iE "pdf|epub|zip" && echo "FORMAT_OK" || echo "FORMAT_UNKNOWN"
+case "${BOOK_PATH##*.}" in
+  pdf|PDF|epub|EPUB|docx|DOCX|txt|TXT|md|MD|markdown|MARKDOWN|rst|RST|adoc|ADOC|asciidoc|ASCIIDOC|html|HTML|htm|HTM|rtf|RTF|mobi|MOBI|azw|AZW|azw3|AZW3) echo "FORMAT_OK" ;;
+  *) echo "FORMAT_UNKNOWN" ;;
+esac
 ```
 
-Check the file extension (`.pdf` or `.epub`) or magic bytes (`%PDF` or `PK` zip header).
+Check the file extension (`.pdf`, `.epub`, `.docx`, `.txt`, `.md`, `.markdown`, `.rst`, `.adoc`, `.html`, `.htm`, `.rtf`, `.mobi`, `.azw`, `.azw3`) or magic bytes (`%PDF` or `PK` zip header for EPUB/DOCX).
 
 If the file is not found or the format is not supported, stop with a clear error message listing supported formats.
 
@@ -107,11 +110,11 @@ Store the answer as `BOOK_TYPE`:
 > "📐 Technical mode selected — using Docling for structure-aware extraction (tables, code blocks, formulas preserved as markdown). This takes ~1.5s per page, so expect a few minutes for longer books. Starting now…"
 
 **If `BOOK_TYPE=text`**, inform:
-> "📄 Text mode selected — using fast extraction (pdftotext). Ready in seconds."
+> "📄 Text mode selected — using the fastest suitable extractor for this file type. Plain text/Markdown/HTML are usually ready in seconds; PDFs use pdftotext when available."
 
 ---
 
-## Step 2 — Extract text from PDF or EPUB
+## Step 2 — Extract text from the source document
 
 Run the extraction script, passing the book type:
 
@@ -142,8 +145,14 @@ fi
 "$PYTHON_BIN" "$SCRIPT_PATH" "$BOOK_PATH" --mode <BOOK_TYPE>
 ```
 
-- `--mode technical` → uses Docling (layout-aware, preserves tables and code blocks as markdown)
-- `--mode text` → uses pdftotext → PyPDF2 → pdfminer fallback chain (fast, plain text)
+- PDF `--mode technical` → uses Docling (layout-aware, preserves tables and code blocks as markdown)
+- PDF `--mode text` → uses pdftotext → PyPDF2 → pdfminer fallback chain (fast, plain text)
+- EPUB → uses ebooklib + BeautifulSoup4, then stdlib ZIP/HTML fallback
+- DOCX → uses python-docx, then stdlib ZIP/XML fallback
+- TXT/Markdown/reStructuredText/AsciiDoc → reads directly as text
+- HTML → uses BeautifulSoup4, then stdlib HTML fallback
+- RTF → uses striprtf, then a basic regex fallback
+- MOBI/AZW/AZW3 → uses Calibre `ebook-convert` when installed
 
 This creates:
 - `<tempdir>/book_skill_work/full_text.txt` — full extracted text
@@ -158,8 +167,8 @@ Read the `output_text` path in `<tempdir>/book_skill_work/metadata.json` to unde
 Read `<tempdir>/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
 
 ```
-📖 Book detected: <filename> (<format: PDF or EPUB>)
-📄 Pages/Spine items: ~<N> | Words: ~<N> | Source tokens: ~<N>K
+📖 Source detected: <filename> (<format>)
+📄 Pages/Spine items/Sections: ~<N> | Words: ~<N> | Source tokens: ~<N>K
 
 💰 Estimated token cost (Full Conversion):
    Input  (book reading + prompts): ~<N>K tokens

--- a/SKILL.md
+++ b/SKILL.md
@@ -142,8 +142,14 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
 
-"$PYTHON_BIN" "$SCRIPT_PATH" "$BOOK_PATH" --mode <BOOK_TYPE>
+"$PYTHON_BIN" "$SCRIPT_PATH" "$BOOK_PATH" --mode <BOOK_TYPE> --install-missing ask
 ```
+
+Before extraction, the script checks optional Python packages needed for the detected format. If a better extractor is missing, it prompts the user with the available fallback, for example:
+
+> "DOCX extraction uses python-docx if installed, otherwise a stdlib ZIP/XML parser. Missing package(s) detected. Do you want to install? y=install, n=fallback"
+
+Use `--install-missing yes` to install missing Python packages without prompting, `--install-missing no` or `--no-install-missing` to always use fallbacks, or `BOOK_SKILL_INSTALL_MISSING=yes|no|ask` to set the behavior by environment variable. Non-interactive sessions default to fallback unless install mode is explicitly `yes`.
 
 - PDF `--mode technical` → uses Docling (layout-aware, preserves tables and code blocks as markdown)
 - PDF `--mode text` → uses pdftotext → PyPDF2 → pdfminer fallback chain (fast, plain text)
@@ -152,7 +158,7 @@ fi
 - TXT/Markdown/reStructuredText/AsciiDoc → reads directly as text
 - HTML → uses BeautifulSoup4, then stdlib HTML fallback
 - RTF → uses striprtf, then a basic regex fallback
-- MOBI/AZW/AZW3 → uses Calibre `ebook-convert` when installed
+- MOBI/AZW/AZW3 → uses Calibre `ebook-convert` when installed. Calibre is an external app, not a pip package, so the script reports how to install it if missing.
 
 This creates:
 - `<tempdir>/book_skill_work/full_text.txt` — full extracted text

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: book-to-skill
-description: Converts a technical book (PDF or EPUB) into a structured Claude Code skill — extracting frameworks, mental models, principles, techniques, and anti-patterns the author crystallized. Use when the user wants to study a book through Claude, apply an author's frameworks while working, or build a reusable knowledge base from any PDF or EPUB.
-when_to_use: Trigger phrases — "turn this book into a skill", "create a skill from this PDF", "create a skill from this EPUB", "I want to study X book", "add this book to my skills", "convert PDF to skill", "convert EPUB to skill", "analyze this book", "extract frameworks from this book". Accepts a path to a PDF or EPUB and optional skill name slug.
-disable-model-invocation: true
-context: fork
-agent: general-purpose
-allowed-tools: Bash(python3 *) Bash(pdftotext *) Bash(mkdir *) Bash(cp *) Bash(find *) Bash(wc *) Bash(echo *) Bash(cat *) Bash(date *) Read Write Glob Grep
+description: "Converts a technical book (PDF or EPUB) into a structured agent skill, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a book through Amp or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from any PDF or EPUB."
+compatibility: "Amp skill directories (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills) and Claude Code skill directories (~/.claude/skills)."
+allowed-tools:
+  - shell_command
+  - Read
+  - Write
+  - Glob
+  - Grep
 argument-hint: <path-to-pdf-or-epub> [skill-name-slug]
-arguments: [book_path, skill_name]
-effort: high
 ---
 
 # Book-to-Skill Converter
 
-Transform written knowledge into actionable Claude Code skills by extracting structure — not producing summaries.
+Transform written knowledge into actionable agent skills by extracting structure — not producing summaries.
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Claude can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Amp, Claude Code, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -53,18 +53,33 @@ Three paths available. Route based on what the user asks:
 
 ---
 
+## Skill Locations
+
+This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
+
+1. Amp project-local skills: `.agents/skills/`
+2. Amp global skills: `~/.config/agents/skills/`
+3. Amp legacy global skills: `~/.config/amp/skills/`
+4. Claude Code skills: `~/.claude/skills/`
+
+Generated skills should default to `~/.config/agents/skills/` for Amp unless the user asks for project-local or Claude Code output.
+
+---
+
 ## Step 0 — Out-of-scope check
 
 If the argument is NOT a path to a PDF or EPUB file, stop and respond:
-> "book-to-skill requires a PDF or EPUB path. Usage: `/book-to-skill /path/to/book.pdf [skill-name]` or `/book-to-skill /path/to/book.epub [skill-name]`"
+> "book-to-skill requires a PDF or EPUB path. Usage: `book-to-skill /path/to/book.pdf [skill-name]` or `book-to-skill /path/to/book.epub [skill-name]`"
+
+Throughout the workflow, treat the first argument as `BOOK_PATH` and the optional second argument as `SKILL_NAME`.
 
 ---
 
 ## Step 1 — Validate input
 
 ```bash
-test -f "$0" && echo "FILE_OK" || echo "FILE_NOT_FOUND: $0"
-file "$0" | grep -iE "pdf|epub|zip" && echo "FORMAT_OK" || echo "FORMAT_UNKNOWN"
+test -f "$BOOK_PATH" && echo "FILE_OK" || echo "FILE_NOT_FOUND: $BOOK_PATH"
+file "$BOOK_PATH" | grep -iE "pdf|epub|zip" && echo "FORMAT_OK" || echo "FORMAT_UNKNOWN"
 ```
 
 Check the file extension (`.pdf` or `.epub`) or magic bytes (`%PDF` or `PK` zip header).
@@ -101,23 +116,46 @@ Store the answer as `BOOK_TYPE`:
 Run the extraction script, passing the book type:
 
 ```bash
-python3 ~/.claude/skills/book-to-skill/scripts/extract.py "$0" --mode <BOOK_TYPE>
+SCRIPT_PATH=""
+for candidate in \
+  ".agents/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.claude/skills/book-to-skill/scripts/extract.py"
+do
+  if [ -f "$candidate" ]; then
+    SCRIPT_PATH="$candidate"
+    break
+  fi
+done
+
+if [ -z "$SCRIPT_PATH" ]; then
+  echo "Could not find scripts/extract.py for book-to-skill" >&2
+  exit 1
+fi
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+"$PYTHON_BIN" "$SCRIPT_PATH" "$BOOK_PATH" --mode <BOOK_TYPE>
 ```
 
 - `--mode technical` → uses Docling (layout-aware, preserves tables and code blocks as markdown)
 - `--mode text` → uses pdftotext → PyPDF2 → pdfminer fallback chain (fast, plain text)
 
 This creates:
-- `/tmp/book_skill_work/full_text.txt` — full extracted text
-- `/tmp/book_skill_work/metadata.json` — title, estimated pages, token count, size, extraction_mode
+- `<tempdir>/book_skill_work/full_text.txt` — full extracted text
+- `<tempdir>/book_skill_work/metadata.json` — title, estimated pages, token count, size, extraction_mode
 
-Read `/tmp/book_skill_work/metadata.json` to understand what was extracted.
+Read the `output_text` path in `<tempdir>/book_skill_work/metadata.json` to understand what was extracted. The extractor uses the platform temp directory by default and supports `BOOK_SKILL_WORKDIR` if an explicit work directory is needed.
 
 ---
 
 ## Step 2.5 — Pre-flight cost estimate
 
-Read `/tmp/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
+Read `<tempdir>/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
 
 ```
 📖 Book detected: <filename> (<format: PDF or EPUB>)
@@ -151,7 +189,7 @@ Wait for the user to confirm before proceeding. If they say "analyze only", swit
 
 ## Step 3 — Analyze book structure
 
-Read the first 8,000 characters of `/tmp/book_skill_work/full_text.txt` to identify:
+Read the first 8,000 characters of the extracted `full_text.txt` to identify:
 - Book **title** and **author(s)**
 - **Chapter structure** (look for "Chapter N", "PART I", numbered headings, table of contents)
 - **Core themes** and subject domain
@@ -200,14 +238,20 @@ Use the answer to weight what gets highlighted in the SKILL.md Core section.
 
 ## Step 5 — Determine skill name
 
-If `$1` was provided, use it as the skill slug.
+If `SKILL_NAME` was provided, use it as the skill slug.
 Otherwise, propose two options and let the user choose:
 - **By author-concept**: `{author-lastname}-{core-concept}` (e.g. `cialdini-influence`, `meadows-systems`)
 - **By title**: lowercase hyphens from book title (e.g. `designing-data-intensive-apps`)
 
 Default to author-concept format if the book has a strong methodological identity.
 
-Check that `~/.claude/skills/<skill_name>/` does NOT already exist.
+Choose the destination skill root:
+- **Amp default**: `~/.config/agents/skills`
+- **Amp project-local**: `.agents/skills` when the user explicitly wants the generated book skill scoped to the current workspace
+- **Amp legacy**: `~/.config/amp/skills` if that is the user's existing global skill location
+- **Claude Code**: `~/.claude/skills` if the user explicitly asks for Claude Code output
+
+Set `SKILLS_HOME` to the selected root and check that `$SKILLS_HOME/<skill_name>/` does NOT already exist.
 If it does, append `-2` or ask the user before overwriting.
 
 ---
@@ -215,7 +259,7 @@ If it does, append `-2` or ask the user before overwriting.
 ## Step 6 — Create skill directory structure
 
 ```bash
-mkdir -p ~/.claude/skills/<skill_name>/chapters
+mkdir -p "$SKILLS_HOME/<skill_name>/chapters"
 ```
 
 ---
@@ -228,9 +272,9 @@ mkdir -p ~/.claude/skills/<skill_name>/chapters
 
 For EACH chapter/major section identified in Step 3:
 
-Read the corresponding section of `/tmp/book_skill_work/full_text.txt` (use character offsets or grep for chapter headings).
+Read the corresponding section of the extracted `full_text.txt` (use character offsets or grep for chapter headings).
 
-Create `~/.claude/skills/<skill_name>/chapters/ch<NN>-<slug>.md` using the structure below.
+Create `$SKILLS_HOME/<skill_name>/chapters/ch<NN>-<slug>.md` using the structure below.
 
 **Adapt emphasis based on `BOOK_TYPE`:**
 - `technical` → prioritize "Code Examples", "Reference Tables", and "Commands & APIs" sections; preserve exact syntax
@@ -283,19 +327,19 @@ Create `~/.claude/skills/<skill_name>/chapters/ch<NN>-<slug>.md` using the struc
 ## Step 8 — Generate supporting files
 
 ### glossary.md
-Create `~/.claude/skills/<skill_name>/glossary.md`:
+Create `$SKILLS_HOME/<skill_name>/glossary.md`:
 - Every significant term from the book, alphabetically sorted
 - Format: `**Term** — definition (Ch N)`
 - Max 1,500 tokens
 
 ### patterns.md
-Create `~/.claude/skills/<skill_name>/patterns.md`:
+Create `$SKILLS_HOME/<skill_name>/patterns.md`:
 - All concrete techniques, design patterns, algorithms from the book
 - Format: `## Pattern Name\n**When to use**: ...\n**How**: ...\n**Trade-offs**: ...`
 - Max 2,000 tokens
 
 ### cheatsheet.md
-Create `~/.claude/skills/<skill_name>/cheatsheet.md`:
+Create `$SKILLS_HOME/<skill_name>/cheatsheet.md`:
 - Decision tables, comparison matrices, quick-reference rules
 - The content you'd want on a single printed page
 - Max 1,000 tokens
@@ -307,14 +351,15 @@ Create `~/.claude/skills/<skill_name>/cheatsheet.md`:
 **CRITICAL TOKEN BUDGET: Keep SKILL.md body under 4,000 tokens.**
 Compaction truncates from the END — put the most important content FIRST.
 
-Create `~/.claude/skills/<skill_name>/SKILL.md`:
+Create `$SKILLS_HOME/<skill_name>/SKILL.md`:
 
 ```markdown
 ---
 name: <skill_name>
-description: Knowledge base from "<Full Title>" by <Author(s)>. Use when applying <author>'s frameworks for <key topics, 3–6 terms>.
-when_to_use: <10–15 trigger phrases based on book topics and terms. Comma-separated.>
-allowed-tools: Read Grep
+description: "Knowledge base from \"<Full Title>\" by <Author(s)>. Use when applying <author>'s frameworks for <key topics, 3–6 terms>, studying the book, or referencing its concepts."
+allowed-tools:
+  - Read
+  - Grep
 argument-hint: [topic, framework name, or chapter number]
 ---
 
@@ -323,9 +368,9 @@ argument-hint: [topic, framework name, or chapter number]
 
 ## How to Use This Skill
 
-- **Without arguments** — `/skill-name` loads core frameworks for reference
-- **With a topic** — `/skill-name replication` → I find and read the relevant chapter
-- **With chapter** — `/skill-name ch05` → I load that specific chapter
+- **Without arguments** — load core frameworks for reference
+- **With a topic** — ask about `replication`, `pricing`, or another indexed topic; I find and read the relevant chapter
+- **With chapter** — ask for `ch05`; I load that specific chapter
 - **Browse** — ask "what chapters do you have?" to see the full index
 
 When you ask about a topic not covered in Core Frameworks below, I will read
@@ -368,7 +413,7 @@ the relevant chapter file before answering.
 
 This skill covers the book content only. For hands-on implementation in your codebase,
 combine with project-specific tools. For topics beyond this book, check related skills
-or ask Claude directly.
+or ask the agent directly.
 ```
 
 ---
@@ -376,13 +421,27 @@ or ask Claude directly.
 ## Step 10 — Cleanup and report
 
 ```bash
-rm -rf /tmp/book_skill_work
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+"$PYTHON_BIN" - <<'PY'
+import os
+import shutil
+import tempfile
+from pathlib import Path
+shutil.rmtree(
+    os.environ.get("BOOK_SKILL_WORKDIR", Path(tempfile.gettempdir()) / "book_skill_work"),
+    ignore_errors=True,
+)
+PY
 ```
 
 Then report to the user:
 
 ```
-✅ Skill created: ~/.claude/skills/<skill_name>/
+✅ Skill created: $SKILLS_HOME/<skill_name>/
 
 📚 Book: <Full Title> — <Author>
 📄 Pages: ~<N> | Chapters: <N>
@@ -396,12 +455,12 @@ Files generated:
   ─────────────────────────────────────────────────────
   Total skill size: ~X tokens (loaded on-demand, not all at once)
 
-💡 Tip: run /cost in Claude Code to see the actual token usage for this session.
+💡 Tip: check your agent's session cost/usage command to see actual token usage.
 
 Usage:
-  /<skill_name>                    → load core frameworks
-  /<skill_name> <topic>            → find and explain a topic
-  /<skill_name> ch<N>              → dive into a specific chapter
+  Ask for <skill_name>                  → load core frameworks
+  Ask <skill_name> about <topic>        → find and explain a topic
+  Ask <skill_name> for ch<N>            → dive into a specific chapter
 ```
 
 ---
@@ -415,4 +474,4 @@ Usage:
 5. **Front-load SKILL.md** — compaction keeps the first 5,000 tokens; most important content comes first
 6. **Chapter files are on-demand** — they don't count against skill budget until loaded
 7. **Never copy raw book text** — always synthesize, summarize, extract signal
-8. **Topic index is critical** — it's how Claude navigates to the right chapter file
+8. **Topic index is critical** — it's how the agent navigates to the right chapter file

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Extract text from a PDF or EPUB file for book-to-skill processing.
+Extract text from a document file for book-to-skill processing.
 
 PDF extraction tries methods in order:
   1. pdftotext (poppler-utils) — best quality
@@ -10,6 +10,13 @@ PDF extraction tries methods in order:
 EPUB extraction tries methods in order:
   1. ebooklib + BeautifulSoup4 — best quality
   2. zipfile + html.parser — stdlib fallback (no extra deps)
+
+Other supported formats:
+  - Plain text / Markdown / reStructuredText / AsciiDoc — direct read
+  - HTML — BeautifulSoup4 if available, then stdlib html.parser
+  - DOCX — python-docx if available, then stdlib ZIP/XML fallback
+  - RTF — striprtf if available, then regex fallback
+  - MOBI/AZW/AZW3 — Calibre ebook-convert if available
 
 Outputs:
   <tempdir>/book_skill_work/full_text.txt  — full extracted text
@@ -41,9 +48,159 @@ OUTPUT_META = OUTPUT_DIR / "metadata.json"
 
 WORDS_PER_TOKEN = 0.75  # approximate
 
+TEXT_EXTENSIONS = {".txt", ".text", ".md", ".markdown", ".rst", ".adoc", ".asciidoc"}
+HTML_EXTENSIONS = {".html", ".htm", ".xhtml"}
+CALIBRE_EBOOK_EXTENSIONS = {".mobi", ".azw", ".azw3"}
+SUPPORTED_EXTENSIONS = {
+    ".pdf", ".epub", ".docx", ".rtf",
+    *TEXT_EXTENSIONS,
+    *HTML_EXTENSIONS,
+    *CALIBRE_EBOOK_EXTENSIONS,
+}
+
 
 def estimate_tokens(text: str) -> int:
     return int(len(text.split()) / WORDS_PER_TOKEN)
+
+
+def supported_formats_message() -> str:
+    return ", ".join(sorted(SUPPORTED_EXTENSIONS))
+
+
+def read_text_file(path: str) -> str | None:
+    for encoding in ("utf-8-sig", "utf-8", "cp1252", "latin-1"):
+        try:
+            return Path(path).read_text(encoding=encoding)
+        except UnicodeDecodeError:
+            continue
+        except Exception:
+            return None
+    return None
+
+
+def extract_html_content(raw_html: str) -> str:
+    try:
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(raw_html, "html.parser")
+        for element in soup(["script", "style", "head"]):
+            element.decompose()
+        return soup.get_text(separator="\n")
+    except ImportError:
+        parser = _HTMLTextExtractor()
+        parser.feed(raw_html)
+        return parser.get_text()
+
+
+def extract_html_file(path: str) -> str | None:
+    raw = read_text_file(path)
+    if raw is None:
+        return None
+    return extract_html_content(raw)
+
+
+def extract_docx_with_python_docx(docx_path: str) -> str | None:
+    try:
+        import docx
+        document = docx.Document(docx_path)
+        parts = [paragraph.text for paragraph in document.paragraphs if paragraph.text]
+        for table in document.tables:
+            for row in table.rows:
+                cells = [cell.text.strip() for cell in row.cells]
+                if any(cells):
+                    parts.append("\t".join(cells))
+        return "\n".join(parts)
+    except ImportError:
+        return None
+    except Exception:
+        return None
+
+
+def extract_docx_with_zipfile(docx_path: str) -> str | None:
+    try:
+        import xml.etree.ElementTree as ET
+
+        with zipfile.ZipFile(docx_path) as zf:
+            xml_bytes = zf.read("word/document.xml")
+        root = ET.fromstring(xml_bytes)
+        namespace = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+        parts: list[str] = []
+        for paragraph in root.iter(f"{namespace}p"):
+            texts = [node.text for node in paragraph.iter(f"{namespace}t") if node.text]
+            if texts:
+                parts.append("".join(texts))
+        return "\n".join(parts) if parts else None
+    except Exception:
+        return None
+
+
+def extract_docx(docx_path: str) -> tuple[str, str]:
+    print("Trying python-docx...", end=" ", flush=True)
+    text = extract_docx_with_python_docx(docx_path)
+    if text and text.strip():
+        print("OK")
+        return text, "python-docx"
+
+    print("not available")
+    print("Trying stdlib DOCX parser...", end=" ", flush=True)
+    text = extract_docx_with_zipfile(docx_path)
+    if text and text.strip():
+        print("OK")
+        return text, "zipfile-docx"
+
+    print("FAILED")
+    print(
+        "\nERROR: Could not extract text from DOCX.\n"
+        "Install python-docx for best results:\n"
+        "  pip3 install python-docx",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def strip_rtf_fallback(raw: str) -> str:
+    raw = re.sub(r"\\'[0-9a-fA-F]{2}", " ", raw)
+    raw = re.sub(r"\\par[d]?", "\n", raw)
+    raw = re.sub(r"\\tab", "\t", raw)
+    raw = re.sub(r"\\[a-zA-Z]+-?\d* ?", "", raw)
+    raw = raw.replace("{", "").replace("}", "")
+    return html.unescape(raw)
+
+
+def extract_rtf(rtf_path: str) -> tuple[str, str]:
+    raw = read_text_file(rtf_path)
+    if raw is None:
+        print("ERROR: Could not read RTF file", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from striprtf.striprtf import rtf_to_text
+        text = rtf_to_text(raw)
+        if text.strip():
+            return text, "striprtf"
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    return strip_rtf_fallback(raw), "rtf-regex"
+
+
+def extract_with_ebook_convert(input_path: str) -> str | None:
+    if not shutil.which("ebook-convert"):
+        return None
+    output_path = OUTPUT_DIR / "ebook-convert-output.txt"
+    try:
+        result = subprocess.run(
+            ["ebook-convert", input_path, str(output_path)],
+            capture_output=True, text=True, timeout=300
+        )
+        if result.returncode == 0 and output_path.exists():
+            text = output_path.read_text(encoding="utf-8", errors="replace")
+            if text.strip():
+                return text
+    except Exception:
+        pass
+    return None
 
 
 def extract_with_pdftotext(pdf_path: str) -> str | None:
@@ -277,7 +434,8 @@ def extract_with_docling(pdf_path: str) -> str | None:
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: extract.py <path-to-pdf-or-epub> [--mode technical|text]", file=sys.stderr)
+        print("Usage: extract.py <path-to-document> [--mode technical|text]", file=sys.stderr)
+        print(f"Supported formats: {supported_formats_message()}", file=sys.stderr)
         sys.exit(1)
 
     input_path = sys.argv[1]
@@ -295,33 +453,47 @@ def main():
         print(f"ERROR: File not found: {input_path}", file=sys.stderr)
         sys.exit(1)
 
-    ext = Path(input_path).suffix.lower()
-    is_epub = ext == ".epub"
-    is_pdf = ext == ".pdf"
+    input_file = Path(input_path)
+    ext = input_file.suffix.lower()
+    document_format = ext.lstrip(".")
 
-    if not is_epub and not is_pdf:
-        # Sniff magic bytes as fallback
+    # Sniff magic bytes as a fallback for files without useful extensions.
+    if ext not in SUPPORTED_EXTENSIONS:
         with open(input_path, "rb") as f:
             header = f.read(8)
         if header[:4] == b"%PDF":
-            is_pdf = True
-        elif header[:2] == b"PK":  # ZIP magic → likely EPUB
-            is_epub = True
+            ext = ".pdf"
+            document_format = "pdf"
+        elif header[:2] == b"PK":
+            with zipfile.ZipFile(input_path) as zf:
+                names = set(zf.namelist())
+                if "mimetype" in names and zf.read("mimetype").startswith(b"application/epub"):
+                    ext = ".epub"
+                    document_format = "epub"
+                elif "word/document.xml" in names:
+                    ext = ".docx"
+                    document_format = "docx"
+                else:
+                    print(
+                        f"ERROR: Unsupported ZIP-based format '{input_file.name}'. Supported: {supported_formats_message()}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
         else:
             print(
-                f"ERROR: Unsupported format '{ext}'. Supported: .pdf, .epub",
+                f"ERROR: Unsupported format '{ext or '<none>'}'. Supported: {supported_formats_message()}",
                 file=sys.stderr,
             )
             sys.exit(1)
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    if is_epub:
+    if ext == ".epub":
         print(f"Extracting EPUB: {input_path}")
         text, method = extract_epub(input_path)
         pages = count_epub_chapters(input_path)
         pages_label = "spine_items"
-    else:
+    elif ext == ".pdf":
         print(f"Extracting PDF: {input_path}")
         if extraction_mode == "technical":
             print("Mode: technical — using Docling (layout-aware)...", end=" ", flush=True)
@@ -369,6 +541,52 @@ def main():
 
         pages = count_pages(input_path)
         pages_label = "pages"
+    elif ext in TEXT_EXTENSIONS:
+        print(f"Extracting text document: {input_path}")
+        text = read_text_file(input_path)
+        if text is None or not text.strip():
+            print("ERROR: Could not read text document", file=sys.stderr)
+            sys.exit(1)
+        method = "plain-text"
+        pages = 0
+        pages_label = "sections"
+    elif ext in HTML_EXTENSIONS:
+        print(f"Extracting HTML: {input_path}")
+        text = extract_html_file(input_path)
+        if text is None or not text.strip():
+            print("ERROR: Could not extract text from HTML", file=sys.stderr)
+            sys.exit(1)
+        method = "html-parser"
+        pages = 0
+        pages_label = "sections"
+    elif ext == ".docx":
+        print(f"Extracting DOCX: {input_path}")
+        text, method = extract_docx(input_path)
+        pages = 0
+        pages_label = "sections"
+    elif ext == ".rtf":
+        print(f"Extracting RTF: {input_path}")
+        text, method = extract_rtf(input_path)
+        pages = 0
+        pages_label = "sections"
+    elif ext in CALIBRE_EBOOK_EXTENSIONS:
+        print(f"Extracting ebook with Calibre: {input_path}")
+        text = extract_with_ebook_convert(input_path)
+        if text is None or not text.strip():
+            print(
+                f"ERROR: Could not extract text from {ext}. Install Calibre and ensure ebook-convert is on PATH.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        method = "ebook-convert"
+        pages = 0
+        pages_label = "sections"
+    else:
+        print(
+            f"ERROR: Unsupported format '{ext}'. Supported: {supported_formats_message()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Write full text
     OUTPUT_TEXT.write_text(text, encoding="utf-8")
@@ -380,7 +598,7 @@ def main():
     metadata = {
         "source_file": str(Path(input_path).resolve()),
         "filename": Path(input_path).name,
-        "format": "epub" if is_epub else "pdf",
+        "format": document_format,
         "extraction_method": method,
         "extraction_mode": extraction_mode,
         "file_size_mb": round(file_size_mb, 2),
@@ -395,17 +613,22 @@ def main():
 
     OUTPUT_META.write_text(json.dumps(metadata, indent=2, ensure_ascii=False))
 
-    page_line = f"   {'Spine items' if is_epub else 'Pages'}: {pages}"
-    print(f"\n📖 Extraction complete:")
-    print(f"   Format  : {'EPUB' if is_epub else 'PDF'}")
+    page_label = {
+        "spine_items": "Spine items",
+        "pages": "Pages",
+        "sections": "Sections",
+    }.get(pages_label, pages_label.replace("_", " ").title())
+    page_line = f"   {page_label}: {pages}"
+    print("\nExtraction complete:")
+    print(f"   Format  : {document_format.upper()}")
     print(f"   Method  : {method}")
     print(page_line)
     print(f"   Words   : {len(text.split()):,}")
     print(f"   Tokens  : ~{tokens // 1000}K")
     print(f"   Chapters: {structure['chapters_detected']} detected")
     print(f"   ToC     : {'yes' if structure['has_toc'] else 'not detected'}")
-    print(f"\n   Text → {OUTPUT_TEXT}")
-    print(f"   Meta → {OUTPUT_META}")
+    print(f"\n   Text -> {OUTPUT_TEXT}")
+    print(f"   Meta -> {OUTPUT_META}")
 
 
 if __name__ == "__main__":

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -622,20 +622,27 @@ def main():
             ext = ".pdf"
             document_format = "pdf"
         elif header[:2] == b"PK":
-            with zipfile.ZipFile(input_path) as zf:
-                names = set(zf.namelist())
-                if "mimetype" in names and zf.read("mimetype").startswith(b"application/epub"):
-                    ext = ".epub"
-                    document_format = "epub"
-                elif "word/document.xml" in names:
-                    ext = ".docx"
-                    document_format = "docx"
-                else:
-                    print(
-                        f"ERROR: Unsupported ZIP-based format '{input_file.name}'. Supported: {supported_formats_message()}",
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
+            try:
+                with zipfile.ZipFile(input_path) as zf:
+                    names = set(zf.namelist())
+                    if "mimetype" in names and zf.read("mimetype").startswith(b"application/epub"):
+                        ext = ".epub"
+                        document_format = "epub"
+                    elif "word/document.xml" in names:
+                        ext = ".docx"
+                        document_format = "docx"
+                    else:
+                        print(
+                            f"ERROR: Unsupported ZIP-based format '{input_file.name}'. Supported: {supported_formats_message()}",
+                            file=sys.stderr,
+                        )
+                        sys.exit(1)
+            except (zipfile.BadZipFile, KeyError, OSError):
+                print(
+                    f"ERROR: Unsupported ZIP-based format '{input_file.name}'. Supported: {supported_formats_message()}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
         else:
             print(
                 f"ERROR: Unsupported format '{ext or '<none>'}'. Supported: {supported_formats_message()}",

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -27,6 +27,7 @@ Set BOOK_SKILL_WORKDIR to override the output directory.
 
 import html
 import html.parser
+import importlib.util
 import json
 import os
 import re
@@ -58,6 +59,16 @@ SUPPORTED_EXTENSIONS = {
     *CALIBRE_EBOOK_EXTENSIONS,
 }
 
+PYTHON_DEPENDENCIES = {
+    "docling": "docling",
+    "PyPDF2": "PyPDF2",
+    "pdfminer": "pdfminer.six",
+    "ebooklib": "ebooklib",
+    "bs4": "beautifulsoup4",
+    "docx": "python-docx",
+    "striprtf": "striprtf",
+}
+
 
 def estimate_tokens(text: str) -> int:
     return int(len(text.split()) / WORDS_PER_TOKEN)
@@ -65,6 +76,151 @@ def estimate_tokens(text: str) -> int:
 
 def supported_formats_message() -> str:
     return ", ".join(sorted(SUPPORTED_EXTENSIONS))
+
+
+def python_module_available(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def missing_python_packages(module_names: list[str]) -> list[str]:
+    missing = []
+    for module_name in module_names:
+        if not python_module_available(module_name):
+            missing.append(PYTHON_DEPENDENCIES[module_name])
+    return missing
+
+
+def install_python_packages(packages: list[str]) -> bool:
+    if not packages:
+        return True
+
+    print(f"Installing missing Python package(s): {', '.join(packages)}")
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", *packages],
+            text=True,
+            timeout=600,
+        )
+    except Exception as exc:
+        print(f"Package installation failed: {exc}", file=sys.stderr)
+        return False
+
+    importlib.invalidate_caches()
+    return result.returncode == 0
+
+
+def normalize_install_mode(argv: list[str]) -> str:
+    mode = os.environ.get("BOOK_SKILL_INSTALL_MISSING", "ask").lower()
+    if "--no-install-missing" in argv:
+        return "no"
+    if "--install-missing" in argv:
+        idx = argv.index("--install-missing")
+        if idx + 1 < len(argv) and not argv[idx + 1].startswith("--"):
+            mode = argv[idx + 1].lower()
+        else:
+            mode = "yes"
+    if mode in {"1", "true", "y", "yes", "install"}:
+        return "yes"
+    if mode in {"0", "false", "n", "no", "fallback", "skip"}:
+        return "no"
+    return "ask"
+
+
+def offer_dependency_install(
+    *,
+    feature: str,
+    module_names: list[str],
+    fallback: str | None,
+    install_mode: str,
+) -> None:
+    packages = missing_python_packages(module_names)
+    if not packages:
+        return
+
+    message = f"{feature} uses {', '.join(packages)} if installed"
+    if fallback:
+        message += f", otherwise {fallback}"
+    message += "."
+    print(message)
+
+    should_install = False
+    if install_mode == "yes":
+        should_install = True
+    elif install_mode == "ask" and sys.stdin.isatty():
+        answer = input("Missing package(s) detected. Do you want to install? y=install, n=fallback: ").strip().lower()
+        should_install = answer in {"y", "yes", "install"}
+    else:
+        if fallback:
+            print("Non-interactive mode or install disabled; using fallback.")
+        else:
+            print("Non-interactive mode or install disabled; installation skipped.")
+
+    if not should_install:
+        if fallback:
+            print(f"Using fallback: {fallback}.")
+        return
+
+    if install_python_packages(packages):
+        still_missing = missing_python_packages(module_names)
+        if not still_missing:
+            print("Package installation complete.")
+            return
+        print(f"Package installation incomplete; still missing: {', '.join(still_missing)}", file=sys.stderr)
+    else:
+        print("Package installation failed.", file=sys.stderr)
+
+    if fallback:
+        print(f"Using fallback: {fallback}.")
+
+
+def prepare_dependencies(ext: str, extraction_mode: str, install_mode: str) -> None:
+    if ext == ".pdf" and extraction_mode == "technical":
+        offer_dependency_install(
+            feature="Technical PDF extraction",
+            module_names=["docling"],
+            fallback="the PDF text fallback chain",
+            install_mode=install_mode,
+        )
+
+    if ext == ".pdf" and not shutil.which("pdftotext"):
+        offer_dependency_install(
+            feature="PDF text extraction",
+            module_names=["PyPDF2", "pdfminer"],
+            fallback="any installed Python PDF parser; extraction fails if none are available",
+            install_mode=install_mode,
+        )
+
+    if ext == ".epub":
+        offer_dependency_install(
+            feature="EPUB extraction",
+            module_names=["ebooklib", "bs4"],
+            fallback="a stdlib ZIP/HTML parser",
+            install_mode=install_mode,
+        )
+
+    if ext in HTML_EXTENSIONS:
+        offer_dependency_install(
+            feature="HTML extraction",
+            module_names=["bs4"],
+            fallback="a stdlib HTML parser",
+            install_mode=install_mode,
+        )
+
+    if ext == ".docx":
+        offer_dependency_install(
+            feature="DOCX extraction",
+            module_names=["docx"],
+            fallback="a stdlib ZIP/XML parser",
+            install_mode=install_mode,
+        )
+
+    if ext == ".rtf":
+        offer_dependency_install(
+            feature="RTF extraction",
+            module_names=["striprtf"],
+            fallback="a basic regex cleanup fallback",
+            install_mode=install_mode,
+        )
 
 
 def read_text_file(path: str) -> str | None:
@@ -434,11 +590,12 @@ def extract_with_docling(pdf_path: str) -> str | None:
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: extract.py <path-to-document> [--mode technical|text]", file=sys.stderr)
+        print("Usage: extract.py <path-to-document> [--mode technical|text] [--install-missing ask|yes|no]", file=sys.stderr)
         print(f"Supported formats: {supported_formats_message()}", file=sys.stderr)
         sys.exit(1)
 
     input_path = sys.argv[1]
+    install_mode = normalize_install_mode(sys.argv)
 
     # Parse --mode flag
     extraction_mode = "text"
@@ -487,6 +644,15 @@ def main():
             sys.exit(1)
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    prepare_dependencies(ext, extraction_mode, install_mode)
+
+    if ext in CALIBRE_EBOOK_EXTENSIONS and not shutil.which("ebook-convert"):
+        print(
+            "MOBI/AZW/AZW3 extraction requires Calibre's ebook-convert command. "
+            "Install Calibre and ensure ebook-convert is on PATH, then rerun this command.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if ext == ".epub":
         print(f"Extracting EPUB: {input_path}")

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -12,8 +12,10 @@ EPUB extraction tries methods in order:
   2. zipfile + html.parser — stdlib fallback (no extra deps)
 
 Outputs:
-  /tmp/book_skill_work/full_text.txt  — full extracted text
-  /tmp/book_skill_work/metadata.json  — stats and metadata
+  <tempdir>/book_skill_work/full_text.txt  — full extracted text
+  <tempdir>/book_skill_work/metadata.json  — stats and metadata
+
+Set BOOK_SKILL_WORKDIR to override the output directory.
 """
 
 import html
@@ -24,10 +26,16 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
-OUTPUT_DIR = Path("/tmp/book_skill_work")
+OUTPUT_DIR = Path(
+    os.environ.get(
+        "BOOK_SKILL_WORKDIR",
+        str(Path(tempfile.gettempdir()) / "book_skill_work"),
+    )
+)
 OUTPUT_TEXT = OUTPUT_DIR / "full_text.txt"
 OUTPUT_META = OUTPUT_DIR / "metadata.json"
 


### PR DESCRIPTION
## Summary
- update the converter skill instructions to support Amp skill locations in addition to Claude Code
- generate Amp-compatible skill frontmatter and usage guidance by default
- make extraction workdir use the platform temp directory with BOOK_SKILL_WORKDIR override

## Verification
- python -m py_compile scripts/extract.py
- git diff --check
- parsed SKILL.md frontmatter with PyYAML