### PR TITLE
Add Codex skill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <h1 align="center">📚 book-to-skill</h1>
 
 <p align="center">
-  <strong>Turn any technical book or document into a Claude Code skill — ready to study, reference, and use while you work.</strong>
+  <strong>Turn any technical book or document into a Codex, Amp, or Claude Code skill — ready to study, reference, and use while you work.</strong>
 </p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/Claude_Code-Skill-blueviolet?style=for-the-badge" alt="Claude Code Skill">
+  <img src="https://img.shields.io/badge/Codex-Skill-black?style=for-the-badge" alt="Codex Skill">
   <img src="https://img.shields.io/badge/PDF%20%E2%80%A2%20EPUB%20%E2%80%A2%20DOCX%20%E2%80%A2%20MD%20%E2%80%A2%20HTML%20%E2%80%A2%20RTF%20%E2%80%A2%20MOBI-supported-green?style=for-the-badge" alt="Formats supported">
   <img src="https://img.shields.io/badge/effort-high-orange?style=for-the-badge" alt="Effort: high">
   <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="MIT License">
@@ -32,15 +33,15 @@ The usual workarounds don't help:
 - 🧠 "I'll ask Claude about this book" → it either hallucinates or says it doesn't have the content
 - 📝 "I'll take notes as I read" → you end up with a 200-line doc you never open again
 
-**book-to-skill solves this by turning the book into a structured skill Claude loads on demand.**
+**book-to-skill solves this by turning the book into a structured skill your coding agent loads on demand.**
 
-Once installed, you just type `/your-book-slug replication` and Claude reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
+Once installed, you ask about the generated skill by slug or topic and your agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
 
 ---
 
 ## 📦 What it generates
 
-Running `/book-to-skill your-book.pdf` (or `.epub`) creates a full skill at `~/.claude/skills/<slug>/`:
+Running `/book-to-skill your-book.pdf` (or `.epub`) creates a full skill in the active agent's skill directory, such as `~/.codex/skills/<slug>/` for Codex or `~/.claude/skills/<slug>/` for Claude Code:
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -75,7 +76,7 @@ Supported document formats: PDF, EPUB, DOCX, TXT, Markdown, reStructuredText, As
 /book-to-skill /tmp/ddd-evans.pdf domain-driven-design
 ```
 
-After the skill is created, use it like any other Claude Code skill:
+After the skill is created, use it like any other agent skill. In slash-command environments:
 
 ```bash
 /designing-data-intensive-apps                  # load core mental models
@@ -83,6 +84,8 @@ After the skill is created, use it like any other Claude Code skill:
 /designing-data-intensive-apps ch05             # dive into chapter 5
 /designing-data-intensive-apps "what chapters do you have?"
 ```
+
+In Codex, ask naturally, for example: `Use the designing-data-intensive-apps skill to explain replication tradeoffs`.
 
 ---
 
@@ -139,7 +142,7 @@ scripts/extract.py --mode <technical|text>
      └── /tmp/book_skill_work/metadata.json
                │
                ▼
-          Claude analyzes structure
+          Your agent analyzes structure
           (title, author, chapters, ToC)
                │
                ▼
@@ -149,7 +152,7 @@ scripts/extract.py --mode <technical|text>
           Generates master SKILL.md with core mental models
                │
                ▼
-          ~/.claude/skills/<slug>/  ✅ written
+          ~/.codex/skills/<slug>/ or ~/.claude/skills/<slug>/  ✅ written
           /tmp/book_skill_work/     🗑️  cleaned up
 ```
 
@@ -215,6 +218,26 @@ book-to-skill is built for a different job: you want to go deep on one book and 
 ---
 
 ## 📥 Install
+
+### Codex
+
+Install into `${CODEX_HOME:-~/.codex}/skills`:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/book-to-skill/scripts"
+
+curl -o "${CODEX_HOME:-$HOME/.codex}/skills/book-to-skill/SKILL.md" \
+  https://raw.githubusercontent.com/virgiliojr94/book-to-skill/master/SKILL.md
+
+curl -o "${CODEX_HOME:-$HOME/.codex}/skills/book-to-skill/scripts/extract.py" \
+  https://raw.githubusercontent.com/virgiliojr94/book-to-skill/master/scripts/extract.py
+
+chmod +x "${CODEX_HOME:-$HOME/.codex}/skills/book-to-skill/scripts/extract.py"
+```
+
+Restart Codex after installing new skills.
+
+### Claude Code
 
 Copy this into your Claude Code session:
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Amp or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
-compatibility: "Amp skill directories (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills) and Claude Code skill directories (~/.claude/skills)."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Codex, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
+compatibility: "Codex skill directories ($CODEX_HOME/skills or ~/.codex/skills), Amp skill directories (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills), and Claude Code skill directories (~/.claude/skills)."
 allowed-tools:
   - shell_command
   - Read
@@ -17,7 +17,7 @@ Transform written knowledge into actionable agent skills by extracting structure
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Amp, Claude Code, or another compatible agent can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Codex, Amp, Claude Code, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -57,12 +57,13 @@ Three paths available. Route based on what the user asks:
 
 This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
 
-1. Amp project-local skills: `.agents/skills/`
-2. Amp global skills: `~/.config/agents/skills/`
-3. Amp legacy global skills: `~/.config/amp/skills/`
-4. Claude Code skills: `~/.claude/skills/`
+1. Codex global skills: `$CODEX_HOME/skills/` or `~/.codex/skills/`
+2. Amp project-local skills: `.agents/skills/`
+3. Amp global skills: `~/.config/agents/skills/`
+4. Amp legacy global skills: `~/.config/amp/skills/`
+5. Claude Code skills: `~/.claude/skills/`
 
-Generated skills should default to `~/.config/agents/skills/` for Amp unless the user asks for project-local or Claude Code output.
+Generated skills should default to the current agent's global skill directory. In Codex, use `${CODEX_HOME:-$HOME/.codex}/skills` unless the user asks for project-local, Amp, or Claude Code output.
 
 ---
 
@@ -121,6 +122,7 @@ Run the extraction script, passing the book type:
 ```bash
 SCRIPT_PATH=""
 for candidate in \
+  "${CODEX_HOME:-$HOME/.codex}/skills/book-to-skill/scripts/extract.py" \
   ".agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py" \
@@ -290,6 +292,7 @@ Otherwise, propose two options and let the user choose:
 Default to author-concept format if the book has a strong methodological identity.
 
 Choose the destination skill root:
+- **Codex default**: `${CODEX_HOME:-$HOME/.codex}/skills`
 - **Amp default**: `~/.config/agents/skills`
 - **Amp project-local**: `.agents/skills` when the user explicitly wants the generated book skill scoped to the current workspace
 - **Amp legacy**: `~/.config/amp/skills` if that is the user's existing global skill location


### PR DESCRIPTION
## Summary
- Add Codex as a supported skill runtime in `SKILL.md` metadata and workflow guidance.
- Include `${CODEX_HOME:-$HOME/.codex}/skills` when locating the bundled extractor and choosing the default generated skill location.
- Document Codex installation and usage in the README while keeping existing Amp and Claude Code paths intact.

## Why
Codex uses `~/.codex/skills` by default, so the current instructions cannot locate `scripts/extract.py` or write generated book skills to the expected Codex skill directory without manual edits.

## Validation
- `python3 -m py_compile scripts/extract.py`
- `python3 scripts/extract.py` usage smoke check
- `BOOK_SKILL_WORKDIR=$(mktemp -d /tmp/book-to-skill-work.XXXXXX) python3 scripts/extract.py "$tmpfile" --mode text --install-missing no`
- `git diff --check`
