### PR TITLE
docs: align README/SKILL.md with merged multi-source + Claude Code de…

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The extractor tries tools in order per format and uses the first available. If n
 ## ⚙️ How it works
 
 ```
-PDF or EPUB
+One file · a folder · a glob · a list of paths
      │
      ▼
 Step 1.5 — "Technical or text-heavy book?"
@@ -135,15 +135,17 @@ Step 1.5 — "Technical or text-heavy book?"
      └── text      → pdftotext → PyPDF2 → pdfminer  (instant)
      │
      ▼
-scripts/extract.py --mode <technical|text>
-  EPUB → ebooklib → stdlib zipfile
+scripts/extract.py <paths…> --mode <technical|text>
+  per source: PDF → pdftotext/Docling · EPUB → ebooklib → stdlib zipfile · DOCX/HTML/RTF/…
+  (one bad source is skipped with a warning; the rest still process)
      │
-     ├── /tmp/book_skill_work/full_text.txt
-     └── /tmp/book_skill_work/metadata.json
+     ├── /tmp/book_skill_work/full_text.txt   (all sources merged, with source markers)
+     └── /tmp/book_skill_work/metadata.json   (aggregated stats + per-source array)
                │
                ▼
           Claude analyzes structure
-          (title, author, chapters, ToC)
+          (title, author, chapters, ToC — spanning all sources)
+          ── or, if targeting an existing skill: folds new content in (Mode 4)
                │
                ▼
           Generates per-chapter summaries  (800–1,200 tokens each)
@@ -250,10 +252,13 @@ book-to-skill/
 │   ├── extract.py        # Thin entrypoint wrapper
 │   └── extractor/        # Modular extraction package
 │       ├── __init__.py
-│       ├── config.py
+│       ├── config.py     # Extensions, paths, dependency constants
 │       ├── dependencies.py
-│       ├── utils.py
-│       └── parsers/      # Format-specific parser components (pdf, epub, docx, etc.)
+│       ├── exceptions.py # ExtractionError (per-source failures, batch-safe)
+│       ├── utils.py      # CLI parsing, multi-source resolution, runner
+│       └── parsers/      # Format-specific parsers (pdf, epub, docx, html, rtf, calibre, text)
+├── tests/
+│   └── test_extractor.py # Test suite (multi-source, batch resilience, EPUB, parsers)
 └── README.md             # This file
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,12 +62,12 @@ Four paths available. Route based on what the user asks:
 
 This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
 
-1. Amp project-local skills: `.agents/skills/`
-2. Amp global skills: `~/.config/agents/skills/`
-3. Amp legacy global skills: `~/.config/amp/skills/`
-4. Claude Code skills: `~/.claude/skills/`
+1. Claude Code skills: `~/.claude/skills/`
+2. Amp project-local skills: `.agents/skills/`
+3. Amp global skills: `~/.config/agents/skills/`
+4. Amp legacy global skills: `~/.config/amp/skills/`
 
-Generated skills should default to `~/.config/agents/skills/` for Amp unless the user asks for project-local or Claude Code output.
+Generated skills should default to `~/.claude/skills/` for Claude Code unless the user asks for Amp project-local or Amp global output.
 
 ---
 
@@ -123,10 +123,10 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 for candidate in \
+  "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
   ".agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.claude/skills/book-to-skill/scripts/extract.py"
+  "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
 do
   if [ -f "$candidate" ]; then
     SCRIPT_PATH="$candidate"
@@ -280,10 +280,10 @@ Otherwise, propose two options and let the user choose:
 Default to author-concept format if the book has a strong methodological identity.
 
 Choose the destination skill root:
-- **Amp default**: `~/.config/agents/skills`
+- **Claude Code default**: `~/.claude/skills`
+- **Amp global**: `~/.config/agents/skills` if that is the user's existing global skill location
 - **Amp project-local**: `.agents/skills` when the user explicitly wants the generated book skill scoped to the current workspace
 - **Amp legacy**: `~/.config/amp/skills` if that is the user's existing global skill location
-- **Claude Code**: `~/.claude/skills` if the user explicitly asks for Claude Code output
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:


### PR DESCRIPTION
…fault

- Default generated-skill destination is now Claude Code (~/.claude/skills), matching the README and the 'Claude Code Skill' positioning; Amp targets become opt-in. Reordered the Skill Locations list, Step 5 destination, and the extract.py script-path search to put ~/.claude/skills first.
- README repository-structure block: add exceptions.py and the tests/ dir (38-test suite) that #8/#12 introduced.
- README 'How it works' diagram: reflect multi-source input (file/folder/glob/ list), per-source batch resilience, merged output, and Mode 4 fold-in.