### PR TITLE
ci: add GitHub Actions pipeline (test matrix, lint, smoke, skill vali…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run test suite
+        run: pytest tests/ -q
+
+  lint:
+    name: lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff check
+        # High-value gate: syntax errors (E9, e.g. IndentationError) + pyflakes
+        # (F: undefined names, unused imports). Style rules are intentionally
+        # not gated yet to avoid blocking on cosmetic churn.
+        run: ruff check --select E9,F --target-version py310 scripts/ tests/
+
+  smoke:
+    name: smoke (dependency-free extraction)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Extract a sample with no optional deps installed
+        run: |
+          set -euo pipefail
+          mkdir -p sample
+          printf '# Backpressure\n\nChapter 1\nBounded queues prevent overload.\n' > sample/note.md
+          export BOOK_SKILL_WORKDIR="$RUNNER_TEMP/work"
+          python3 scripts/extract.py sample/note.md --mode text --install-missing no
+          test -f "$BOOK_SKILL_WORKDIR/full_text.txt"
+          test -f "$BOOK_SKILL_WORKDIR/metadata.json"
+          grep -q "Backpressure" "$BOOK_SKILL_WORKDIR/full_text.txt"
+
+  validate-skill:
+    name: validate SKILL.md frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check SKILL.md frontmatter has required keys
+        run: |
+          python3 - <<'PY'
+          import sys, pathlib
+          text = pathlib.Path("SKILL.md").read_text(encoding="utf-8")
+          if not text.startswith("---"):
+              sys.exit("SKILL.md: missing YAML frontmatter (--- block)")
+          end = text.find("\n---", 3)
+          if end == -1:
+              sys.exit("SKILL.md: unterminated frontmatter block")
+          fm = text[3:end]
+          required = ["name:", "description:"]
+          missing = [k for k in required
+                     if not any(ln.strip().startswith(k) for ln in fm.splitlines())]
+          if missing:
+              sys.exit("SKILL.md frontmatter missing required keys: " + ", ".join(missing))
+          print("SKILL.md frontmatter OK")
+          PY

--- a/scripts/extractor/__init__.py
+++ b/scripts/extractor/__init__.py
@@ -1,2 +1,4 @@
 from extractor.utils import resolve_input_files, extract_single_file, main
 from extractor.exceptions import ExtractionError
+
+__all__ = ["resolve_input_files", "extract_single_file", "main", "ExtractionError"]

--- a/scripts/extractor/parsers/docx.py
+++ b/scripts/extractor/parsers/docx.py
@@ -1,6 +1,4 @@
-import sys
 import zipfile
-from extractor.config import supported_formats_message
 from extractor.exceptions import ExtractionError
 
 

--- a/scripts/extractor/parsers/pdf.py
+++ b/scripts/extractor/parsers/pdf.py
@@ -1,7 +1,5 @@
 import shutil
 import subprocess
-import sys
-from extractor.parsers.calibre import extract_with_ebook_convert
 
 
 def extract_with_pdftotext(pdf_path: str) -> str | None:

--- a/scripts/extractor/parsers/rtf.py
+++ b/scripts/extractor/parsers/rtf.py
@@ -1,6 +1,5 @@
 import html
 import re
-import sys
 from extractor.parsers.text import read_text_file
 from extractor.exceptions import ExtractionError
 

--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -56,7 +56,7 @@ def detect_structure(text: str) -> dict:
         r"^\s*(chapter\s+\d+|CHAPTER\s+\d+|ch\.\s*\d+|\d+\.\s+[A-Z])",
         re.IGNORECASE
     )
-    chapters_found = [l.strip() for l in lines if chapter_pattern.match(l)]
+    chapters_found = [line.strip() for line in lines if chapter_pattern.match(line)]
 
     # Look for ToC indicators in the first ~30k chars
     toc_pattern = re.compile(

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -9,7 +9,6 @@ Covers:
 """
 
 import json
-import os
 import sys
 import textwrap
 import zipfile


### PR DESCRIPTION
…dation)

Adds .github/workflows/ci.yml running on push to master and on every PR:

- test: pytest across Python 3.10/3.11/3.12/3.13 (the 38-test suite)
- lint: ruff check, gated on E9 (syntax errors, e.g. IndentationError)
  + F (pyflakes: undefined names, unused imports). Style rules are left ungated for now to avoid blocking on cosmetic churn.
- smoke: runs extract.py on a sample with --install-missing no, asserting the dependency-free fallback produces full_text.txt + metadata.json (guards the 'git clone and it just works' install promise)
- validate-skill: checks SKILL.md frontmatter has the required keys

Includes the minimal cleanup needed to make the lint gate green: removed dead imports (docx/pdf/rtf parsers, tests), added __all__ to the package __init__, and renamed an ambiguous loop var. No behavior change; the 38 tests still pass.