### PR TITLE
test: tripwire — reintroduce global sort to verify CI catches it

### DIFF
--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -152,6 +152,7 @@ def resolve_input_files(paths: list[str]) -> list[Path]:
             seen.add(resolved_path)
             unique_paths.append(resolved_path)
 
+    unique_paths.sort(key=lambda x: str(x).lower())
     return unique_paths
 
 


### PR DESCRIPTION
Deliberate regression to validate the CI test gate. Re-adds the global alphabetical sort in resolve_input_files that #8 removed, breaking explicit input-order preservation. Expect the test job to fail on TestInputOrderPreservation. To be reverted / closed without merge.