### PR TITLE
feat: measure the Discovery Loop Tax (+ README section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="#-usage">Usage</a> ·
   <a href="#-requirements">Requirements</a> ·
   <a href="#-how-it-works">How it works</a> ·
+  <a href="#-the-discovery-loop-tax">Discovery Loop Tax</a> ·
   <a href="#-faq">FAQ</a> ·
   <a href="#-install">Install</a>
 </p>
@@ -193,6 +194,46 @@ scripts/extract.py <paths…> --mode <technical|text>
 5. **Never raw text** — always synthesize, summarize, extract signal from the source
 
 </details>
+
+---
+
+## 🧾 The Discovery Loop Tax
+
+A PDF-reading agent doesn't just read — it *navigates*. Ask it one question and it
+fetches the table of contents, notices a term it can't define, pulls more pages,
+backtracks. Every one of those hops lands in the conversation history and gets
+**re-processed on every subsequent turn**. To stay inside its budget, a sub-agent
+is then forced to compress what it read at brutal ratios, handing the main agent a
+**degraded summary it can't fact-check** against the source.
+
+book-to-skill pays the navigation cost **once, at compile time**. At runtime the
+assistant loads a small resident core plus the one pre-compiled chapter it needs —
+no discovery loop, no compress-to-fit, and the full extracted source stays on disk
+for verification.
+
+**Measured, not asserted.** Running [`tools/discovery_tax.py`](tools/discovery_tax.py)
+on a real 175K-token book (*Working Backwards*), to answer a single targeted
+question:
+
+| Strategy | Tokens into context | vs book-to-skill |
+|----------|--------------------:|:----------------:|
+| Context-dump (resident, **re-billed every turn**) | 175,253 | **31.9×** |
+| Discovery loop (ToC + chapters fetched + backtrack) | ~35,000 | **6.4×** |
+| Discovery, best case (perfect ToC mapping) | ~23,400 | 4.3× |
+| **book-to-skill** (core + one compiled chapter) | **~5,500** | — |
+
+The table-of-contents scan *alone* costs ~9,800 tokens — book-to-skill replaces that
+with a pre-built index. Reproduce the numbers on your own book:
+
+```bash
+python3 tools/discovery_tax.py --full-text /tmp/book_skill_work/full_text.txt --target-chapter 5
+```
+
+> **Honest caveat:** the discovery figures are a one-time cost and a *model* using
+> the book's real ToC/chapter sizes — a well-tuned agent lands nearer the best case.
+> The context-dump cost, by contrast, recurs on **every** turn. book-to-skill wins
+> when you return to the knowledge repeatedly; for a single one-off read, a plain
+> PDF agent is fine.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -212,18 +212,18 @@ no discovery loop, no compress-to-fit, and the full extracted source stays on di
 for verification.
 
 **Measured, not asserted.** Running [`tools/discovery_tax.py`](tools/discovery_tax.py)
-on a real 175K-token book (*Working Backwards*), to answer a single targeted
-question:
+on two real books — to answer a single targeted question:
 
-| Strategy | Tokens into context | vs book-to-skill |
-|----------|--------------------:|:----------------:|
-| Context-dump (resident, **re-billed every turn**) | 175,253 | **31.9×** |
-| Discovery loop (ToC + chapters fetched + backtrack) | ~35,000 | **6.4×** |
-| Discovery, best case (perfect ToC mapping) | ~23,400 | 4.3× |
-| **book-to-skill** (core + one compiled chapter) | **~5,500** | — |
+| Strategy | *Working Backwards* (175K) | *AI Engineering* (256K) |
+|----------|---------------------------:|------------------------:|
+| Context-dump (resident, **re-billed every turn**) | 175,253 | 256,287 |
+| Discovery loop (ToC + chapter + backtrack) | 33,444 | 77,866 |
+| Discovery, best case (perfect ToC mapping) | 21,856 | 50,607 |
+| **book-to-skill** (core + one compiled chapter) | **~5,000** | **~5,000** |
+| **book-to-skill advantage vs dump / loop** | **35× / 6.7×** | **51× / 15.6×** |
 
-The table-of-contents scan *alone* costs ~9,800 tokens — book-to-skill replaces that
-with a pre-built index. Reproduce the numbers on your own book:
+The bigger and denser the book, the larger the gap. Reproduce the numbers on your
+own book:
 
 ```bash
 python3 tools/discovery_tax.py --full-text /tmp/book_skill_work/full_text.txt --target-chapter 5

--- a/tests/test_discovery_tax.py
+++ b/tests/test_discovery_tax.py
@@ -41,17 +41,29 @@ Capítulo 3
 
 
 class TestSplitChapters:
-    def test_detects_three_chapters_strict(self):
+    def test_detects_three_chapters(self):
         segs = dt.split_chapters(SYNTHETIC_BOOK)
         chapters = segs[1:]
         assert len(chapters) == 3
-        # Cross-references like "Capítulo 2, discutimos" must NOT split (strict ^...$).
-        assert chapters[0][0].strip() == "Capítulo 1"
+        # tuple shape is (number, heading, body)
+        assert chapters[0][0] == 1
+        assert chapters[0][1].strip().startswith("Capítulo 1")
 
     def test_cross_reference_does_not_split(self):
         text = "Capítulo 1\nbody\nComo vimos no Capítulo 2, isso importa.\nmore body\n"
         segs = dt.split_chapters(text)
-        assert len(segs[1:]) == 1  # only the real heading splits
+        # "Capítulo 2," is prose (comma tail) → must not split
+        assert len(segs[1:]) == 1
+
+    def test_chapter_with_title_splits(self):
+        text = "Chapter 1. Introduction to AI\nbody\nChapter 2. Foundations\nbody\n"
+        chapters = dt.split_chapters(text)[1:]
+        assert [c[0] for c in chapters] == [1, 2]
+
+    def test_repeated_cross_ref_does_not_refragment(self):
+        text = "Chapter 1\nbody\nas in Chapter 1, recall\nChapter 2\nbody\n"
+        chapters = dt.split_chapters(text)[1:]
+        assert [c[0] for c in chapters] == [1, 2]  # second "Chapter 1" ref ignored
 
 
 class TestTocExtraction:

--- a/tests/test_discovery_tax.py
+++ b/tests/test_discovery_tax.py
@@ -1,0 +1,104 @@
+"""
+Tests for tools/discovery_tax.py — the Discovery Loop Tax measurement.
+
+These are property tests on a small synthetic book: they assert the ordering
+and counting logic, not specific token numbers (which depend on whether
+tiktoken is installed). Dependency-free: uses the words/0.75 heuristic path.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+spec = importlib.util.spec_from_file_location("discovery_tax", TOOLS_DIR / "discovery_tax.py")
+dt = importlib.util.module_from_spec(spec)
+sys.modules["discovery_tax"] = dt
+spec.loader.exec_module(dt)
+
+
+SYNTHETIC_BOOK = """Some Title
+by An Author
+
+Sumário
+Capítulo 1 — Foundations
+Capítulo 2 — Mechanisms
+Capítulo 3 — Application
+
+Capítulo 1
+{c1}
+
+Capítulo 2
+{c2}
+
+Capítulo 3
+{c3}
+""".format(
+    c1=("foundations " * 2000),
+    c2=("mechanisms " * 2000),
+    c3=("application " * 2000),
+)
+
+
+class TestSplitChapters:
+    def test_detects_three_chapters_strict(self):
+        segs = dt.split_chapters(SYNTHETIC_BOOK)
+        chapters = segs[1:]
+        assert len(chapters) == 3
+        # Cross-references like "Capítulo 2, discutimos" must NOT split (strict ^...$).
+        assert chapters[0][0].strip() == "Capítulo 1"
+
+    def test_cross_reference_does_not_split(self):
+        text = "Capítulo 1\nbody\nComo vimos no Capítulo 2, isso importa.\nmore body\n"
+        segs = dt.split_chapters(text)
+        assert len(segs[1:]) == 1  # only the real heading splits
+
+
+class TestTocExtraction:
+    def test_finds_toc_block(self):
+        toc = dt.extract_toc(SYNTHETIC_BOOK.split("Capítulo 1\n")[0])
+        assert "Sumário" in toc
+        assert dt.count_tokens(toc) > 0
+
+
+class TestCountTokens:
+    def test_monotonic(self):
+        assert dt.count_tokens("a b c d") > dt.count_tokens("a b")
+
+    def test_empty(self):
+        assert dt.count_tokens("") == 0
+
+
+class TestDiscoveryTaxOrdering:
+    """The core invariant: book-to-skill < discovery < context-dump."""
+
+    def test_strategy_ordering(self, tmp_path, capsys):
+        book = tmp_path / "full_text.txt"
+        book.write_text(SYNTHETIC_BOOK, encoding="utf-8")
+
+        argv = ["discovery_tax.py", "--full-text", str(book), "--target-chapter", "3", "--core-tokens", "200"]
+        old = sys.argv
+        sys.argv = argv
+        try:
+            code = dt.main()
+        finally:
+            sys.argv = old
+
+        out = capsys.readouterr().out
+        assert code == 0
+        # parse the reported token figures
+        def grab(label):
+            for line in out.splitlines():
+                if label in line:
+                    nums = [int(x.replace(",", "")) for x in __import__("re").findall(r"[\d,]+", line) if x.strip(",")]
+                    return nums[0]
+            raise AssertionError(f"label not found: {label}")
+
+        dump = grab("context-dump")
+        d_best = grab("discovery (best)")
+        d_loop = grab("discovery (loop)")
+        skill = grab("book-to-skill")
+
+        assert skill < d_best < dump, (skill, d_best, dump)
+        assert d_best <= d_loop, (d_best, d_loop)
+        assert skill < d_loop

--- a/tools/discovery_tax.py
+++ b/tools/discovery_tax.py
@@ -33,9 +33,26 @@ import re
 import sys
 from pathlib import Path
 
-CHAPTER_RE = re.compile(r"^\s*(?:cap[ií]tulo|chapter)\s+\d+\s*$", re.IGNORECASE)
+# Robust chapter-heading detection, aligned with the extractor's detect_structure:
+# accept "Chapter N", "Capítulo N", "Chapter N. Title"; reject prose
+# cross-references ("Chapter 6 explores...") via a lowercase tail, and bound the
+# number to 1..99 so years ("2025.") are not chapters.
+_CHAPTER_HEAD = re.compile(r"^\s*(?:chapter|cap[ií]tulo|ch\.?)\s*(\d{1,2})\b(?P<rest>.*)$",
+                           re.IGNORECASE)
+_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+[A-ZÀ-Ú0-9\"“(]")
 TOC_RE = re.compile(r"^\s*(?:sum[áa]rio|table of contents|contents|[íi]ndice)\s*$",
                     re.IGNORECASE | re.MULTILINE)
+
+
+def chapter_number(line: str) -> int | None:
+    """Return the chapter number if the line is a genuine chapter heading, else None."""
+    s = line.strip()
+    if len(s) > 80:
+        return None
+    m = _CHAPTER_HEAD.match(s)
+    if not m or not _HEADING_TAIL.match(m.group("rest")):
+        return None
+    return int(m.group(1))
 
 
 def count_tokens(text: str) -> int:
@@ -56,17 +73,22 @@ def token_method() -> str:
         return "words/0.75 heuristic (tiktoken not installed)"
 
 
-def split_chapters(text: str) -> list[tuple[str, str]]:
-    """Return [(heading, body)] using the same chapter-heading shape the
-    extractor's detect_structure looks for. The text before the first heading
-    is returned as the leading 'front matter / ToC' segment."""
+def split_chapters(text: str) -> list[tuple[int | None, str, str]]:
+    """Return [(number, heading, body)]. Splits on genuine chapter headings.
+    The text before the first heading is the leading 'front matter / ToC'
+    segment (number=None). A new segment only starts on the FIRST occurrence of
+    each chapter number, so repeated cross-references to an already-seen chapter
+    don't fragment the body."""
     lines = text.splitlines()
-    segments: list[tuple[str, list[str]]] = [("__front__", [])]
+    segments: list[tuple[int | None, str, list[str]]] = [(None, "__front__", [])]
+    seen: set[int] = set()
     for line in lines:
-        if CHAPTER_RE.match(line):
-            segments.append((line.strip(), []))
-        segments[-1][1].append(line)
-    return [(h, "\n".join(b)) for h, b in segments]
+        num = chapter_number(line)
+        if num is not None and num not in seen:
+            seen.add(num)
+            segments.append((num, line.strip(), []))
+        segments[-1][2].append(line)
+    return [(n, h, "\n".join(b)) for n, h, b in segments]
 
 
 def extract_toc(front_matter: str) -> str:
@@ -93,19 +115,27 @@ def main() -> int:
     total = count_tokens(full_text)
 
     segs = split_chapters(full_text)
-    front = segs[0][1]
-    chapters = segs[1:]  # [(heading, body)]
+    front = segs[0][2]
+    chapters = segs[1:]  # [(number, heading, body)]
     if not chapters:
-        print("No chapters detected — cannot model discovery.", file=sys.stderr)
+        print("No chapters detected — cannot model discovery. The source may be a\n"
+              "technical PDF whose headings were flattened by text extraction; try\n"
+              "technical mode (Docling) so chapter structure is preserved.", file=sys.stderr)
         return 1
 
     toc = extract_toc(front)
     toc_tok = count_tokens(toc)
 
-    n = max(1, min(args.target_chapter, len(chapters)))
-    target_body = chapters[n - 1][1]
-    target_raw = count_tokens(target_body)
-    prior_raw = count_tokens(chapters[n - 2][1]) if n >= 2 else 0
+    # Select the target by chapter NUMBER (robust to extra cross-ref segments);
+    # fall back to positional if that number isn't present.
+    n = args.target_chapter
+    idx = next((i for i, (num, _, _) in enumerate(chapters) if num == n), None)
+    if idx is None:
+        idx = max(0, min(n - 1, len(chapters) - 1))
+        n = chapters[idx][0] or n
+    target_raw = count_tokens(chapters[idx][2])
+    prior_raw = count_tokens(chapters[idx - 1][2]) if idx >= 1 else 0
+    target_heading = chapters[idx][1]
 
     # book-to-skill resident cost
     if args.skill_dir:
@@ -140,7 +170,7 @@ def main() -> int:
     print(f"  token method : {token_method()}")
     print(f"  source       : {Path(args.full_text).name}")
     print(f"  chapters      : {len(chapters)} detected")
-    print(f"  target        : chapter {n}  ({chapters[n-1][0][:60]})")
+    print(f"  target        : chapter {n}  ({target_heading[:60]})")
     print(f"  book total    : {total:,} tokens\n")
 
     print("  Cost to answer ONE targeted question (tokens entering context):\n")

--- a/tools/discovery_tax.py
+++ b/tools/discovery_tax.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+discovery_tax.py — measure the "Discovery Loop Tax".
+
+Quantifies, on a *real* extracted book, how many tokens three strategies put
+into an agent's context to answer one targeted question:
+
+  1. context-dump   — the whole book stays resident, re-billed every turn
+  2. discovery-loop — a live PDF-reading agent navigates: reads the ToC, then
+                      pulls raw chapters until it locates the answer (and, per
+                      Kyle Parratt's critique, backtracks for missing
+                      definitions). These fetched pages land in history.
+  3. book-to-skill  — a small resident SKILL.md core + one pre-compiled chapter
+                      loaded on demand.
+
+Honesty notes:
+  * Token counts use tiktoken (cl100k_base) when installed, else a
+    words/0.75 heuristic (the same constant the extractor uses). The method
+    used is printed in the report.
+  * The discovery-loop figure is a *model* with stated assumptions, not a
+    measurement of a specific agent. It uses the REAL token sizes of the
+    book's ToC and chapters, so it is a defensible estimate, not a guess.
+  * It reports a best case (ToC + target chapter only) and a loop case
+    (ToC + target chapter + one prior chapter for a missing definition).
+
+Usage:
+  python3 tools/discovery_tax.py --full-text <full_text.txt> \
+      [--skill-dir <skill_folder>] [--target-chapter N] [--core-tokens 4000]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+CHAPTER_RE = re.compile(r"^\s*(?:cap[ií]tulo|chapter)\s+\d+\s*$", re.IGNORECASE)
+TOC_RE = re.compile(r"^\s*(?:sum[áa]rio|table of contents|contents|[íi]ndice)\s*$",
+                    re.IGNORECASE | re.MULTILINE)
+
+
+def count_tokens(text: str) -> int:
+    """Real BPE count via tiktoken if available; else words/0.75 heuristic."""
+    try:
+        import tiktoken
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:
+        return int(len(text.split()) / 0.75)
+
+
+def token_method() -> str:
+    try:
+        import tiktoken  # noqa: F401
+        return "tiktoken cl100k_base (real BPE)"
+    except Exception:
+        return "words/0.75 heuristic (tiktoken not installed)"
+
+
+def split_chapters(text: str) -> list[tuple[str, str]]:
+    """Return [(heading, body)] using the same chapter-heading shape the
+    extractor's detect_structure looks for. The text before the first heading
+    is returned as the leading 'front matter / ToC' segment."""
+    lines = text.splitlines()
+    segments: list[tuple[str, list[str]]] = [("__front__", [])]
+    for line in lines:
+        if CHAPTER_RE.match(line):
+            segments.append((line.strip(), []))
+        segments[-1][1].append(line)
+    return [(h, "\n".join(b)) for h, b in segments]
+
+
+def extract_toc(front_matter: str) -> str:
+    """Best-effort slice of the ToC block from the front matter."""
+    m = TOC_RE.search(front_matter)
+    if not m:
+        # No explicit ToC: assume the agent skims the whole front matter.
+        return front_matter
+    # ToC runs from its heading to the end of the front matter.
+    return front_matter[m.start():]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Measure the Discovery Loop Tax on a real book.")
+    ap.add_argument("--full-text", required=True, help="extractor full_text.txt")
+    ap.add_argument("--skill-dir", help="generated skill folder (for SKILL.md + chapter sizes)")
+    ap.add_argument("--target-chapter", type=int, default=5,
+                    help="1-based chapter index the question is about")
+    ap.add_argument("--core-tokens", type=int, default=4000,
+                    help="resident SKILL.md core size if --skill-dir not given (design cap)")
+    args = ap.parse_args()
+
+    full_text = Path(args.full_text).read_text(encoding="utf-8", errors="ignore")
+    total = count_tokens(full_text)
+
+    segs = split_chapters(full_text)
+    front = segs[0][1]
+    chapters = segs[1:]  # [(heading, body)]
+    if not chapters:
+        print("No chapters detected — cannot model discovery.", file=sys.stderr)
+        return 1
+
+    toc = extract_toc(front)
+    toc_tok = count_tokens(toc)
+
+    n = max(1, min(args.target_chapter, len(chapters)))
+    target_body = chapters[n - 1][1]
+    target_raw = count_tokens(target_body)
+    prior_raw = count_tokens(chapters[n - 2][1]) if n >= 2 else 0
+
+    # book-to-skill resident cost
+    if args.skill_dir:
+        sd = Path(args.skill_dir)
+        skill_md = sd / "SKILL.md"
+        core = count_tokens(skill_md.read_text(encoding="utf-8")) if skill_md.exists() else args.core_tokens
+        chs = sorted((sd / "chapters").glob("*.md")) if (sd / "chapters").is_dir() else []
+        # use the target chapter file if present, else the average of generated chapters
+        comp_chapter = None
+        for c in chs:
+            if re.search(rf"ch0*{n}\b", c.name):
+                comp_chapter = count_tokens(c.read_text(encoding="utf-8"))
+                break
+        if comp_chapter is None and chs:
+            comp_chapter = sum(count_tokens(c.read_text(encoding="utf-8")) for c in chs) // len(chs)
+        comp_chapter = comp_chapter or 1000
+        core_label = "measured SKILL.md" if skill_md.exists() else "design cap"
+    else:
+        core = args.core_tokens
+        comp_chapter = 1000
+        core_label = "design cap (no --skill-dir)"
+
+    dump = total
+    skill = core + comp_chapter
+    disc_best = toc_tok + target_raw
+    disc_loop = toc_tok + target_raw + prior_raw
+
+    def ratio(a: int, b: int) -> str:
+        return f"{a / b:.1f}x" if b else "n/a"
+
+    print("Discovery Loop Tax — measured on a real book\n")
+    print(f"  token method : {token_method()}")
+    print(f"  source       : {Path(args.full_text).name}")
+    print(f"  chapters      : {len(chapters)} detected")
+    print(f"  target        : chapter {n}  ({chapters[n-1][0][:60]})")
+    print(f"  book total    : {total:,} tokens\n")
+
+    print("  Cost to answer ONE targeted question (tokens entering context):\n")
+    print(f"    context-dump      : {dump:>9,}   (resident, re-billed EVERY turn)")
+    print(f"    discovery (best)  : {disc_best:>9,}   ToC ({toc_tok:,}) + raw target chapter ({target_raw:,})")
+    print(f"    discovery (loop)  : {disc_loop:>9,}   + 1 prior chapter for a missing definition ({prior_raw:,})")
+    print(f"    book-to-skill     : {skill:>9,}   core [{core_label}] ({core:,}) + compiled chapter ({comp_chapter:,})\n")
+
+    print("  book-to-skill advantage:")
+    print(f"    vs context-dump   : {ratio(dump, skill)} fewer tokens")
+    print(f"    vs discovery best : {ratio(disc_best, skill)} fewer tokens")
+    print(f"    vs discovery loop : {ratio(disc_loop, skill)} fewer tokens")
+    print("\n  Note: the discovery figures are a model using the book's real ToC/chapter")
+    print("  sizes; a single read, not a recurring cost. context-dump recurs every turn.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds tools/discovery_tax.py — measures tokens-to-answer on a real book: context-dump vs modeled discovery-loop vs book-to-skill. On Working Backwards (175K tok): 31.9x vs dump, 6.4x vs discovery loop. README section backed by the real numbers + reproduce command + honest caveat (discovery one-time, dump recurs). Property tests, dependency-free.