### PR TITLE
feat(skill): emit machine-readable index.json for one-hop topic lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) cre
 | File | Purpose | Size |
 |------|---------|------|
 | `SKILL.md` | Core mental models + chapter index | ~4,000 tokens |
+| `index.json` | Machine-readable topic→chapter map for one-hop lookup | tiny |
 | `chapters/ch01-*.md` … | One file per chapter, loaded on-demand | ~1,000 tokens each |
 | `glossary.md` | Every key term, alphabetically sorted with chapter refs | ~1,500 tokens |
 | `patterns.md` | All techniques, algorithms, and design patterns | ~2,000 tokens |

--- a/SKILL.md
+++ b/SKILL.md
@@ -452,12 +452,13 @@ argument-hint: [topic, framework name, or chapter number]
 ## How to Use This Skill
 
 - **Without arguments** — load core frameworks for reference
-- **With a topic** — ask about `replication`, `pricing`, or another indexed topic; I find and read the relevant chapter
+- **With a topic** — ask about `replication`, `pricing`, or another indexed topic; I resolve it through `index.json` (one small read) to the exact chapter file, then read only that file
 - **With chapter** — ask for `ch05`; I load that specific chapter
 - **Browse** — ask "what chapters do you have?" to see the full index
 
-When you ask about a topic not covered in Core Frameworks below, I will read
-the relevant chapter file before answering.
+When you ask about a topic not covered in Core Frameworks below, I consult
+`index.json` to map the topic to its chapter file in a single hop — no scanning
+of the prose indexes — and read only that file before answering.
 
 ---
 
@@ -486,6 +487,7 @@ the relevant chapter file before answering.
 
 ## Supporting Files
 
+- [index.json](index.json) — machine-readable topic→chapter map for one-hop lookup
 - [glossary.md](glossary.md) — all key terms with definitions
 - [patterns.md](patterns.md) — all techniques and design patterns
 - [cheatsheet.md](cheatsheet.md) — quick reference tables and decision guides
@@ -498,6 +500,43 @@ This skill covers the book content only. For hands-on implementation in your cod
 combine with project-specific tools. For topics beyond this book, check related skills
 or ask the agent directly.
 ```
+
+---
+
+## Step 9.5 — Generate the machine-readable index (`index.json`)
+
+The Markdown Chapter/Topic indexes in `SKILL.md` are for humans. Also write a
+machine-readable `index.json` so the agent resolves a topic to its chapter file
+in **one small read** instead of scanning prose — this is what kills the
+table-of-contents "discovery" cost at query time.
+
+Create `$SKILLS_HOME/<skill_name>/index.json`:
+
+```json
+{
+  "skill": "<skill_name>",
+  "title": "<Full Title>",
+  "author": "<Author(s)>",
+  "generated": "<YYYY-MM-DD>",
+  "chapters": [
+    { "n": 1, "file": "chapters/ch01-<slug>.md", "title": "<Title>", "frameworks": ["<f1>", "<f2>"] }
+  ],
+  "topics": {
+    "<topic-or-framework, lowercased>": ["ch05"],
+    "<another-topic>": ["ch02", "ch11"]
+  }
+}
+```
+
+Rules:
+- `topics` keys are lowercase; values are chapter ids (`"ch05"`), matching the
+  Topic Index in `SKILL.md` exactly — the two must never drift.
+- Every `file` path must point to a chapter file that exists on disk.
+- Keep it small and flat — it is read in full on most queries.
+
+When resolving a user topic at runtime: read `index.json`, look up the topic (exact
+or closest key), open only the referenced chapter file(s). Fall back to the
+Markdown Topic Index only if `index.json` is absent (older skills).
 
 ---
 
@@ -592,6 +631,12 @@ Update the master skill file `$SKILLS_HOME/<skill_name>/SKILL.md`:
 - **Chapter Index**: Append the new chapters to the index table, linking to the newly created files.
 - **Topic Index**: Merge the new topics alphabetically. If an existing topic is also covered in the new chapters, append the new chapter links to its line (e.g. `- **Topic** → ch05, ch13`).
 
+### 5b. Re-generate `index.json`
+Regenerate `$SKILLS_HOME/<skill_name>/index.json` (Step 9.5) so it stays in sync:
+append the new chapters to `chapters`, merge the new topic keys into `topics`, and
+bump `generated`. The `topics` map must match the updated Markdown Topic Index
+exactly. If the existing skill has no `index.json` (older skill), create one now.
+
 ### 6. Cleanup and Proceed to Step 10
 Once the files are successfully written and merged, skip to **Step 10** to perform cleanup and print a custom update report summarizing the newly added chapters, merged glossary terms, and updated indices.
 
@@ -606,4 +651,4 @@ Once the files are successfully written and merged, skip to **Step 10** to perfo
 5. **Front-load SKILL.md** — compaction keeps the first 5,000 tokens; most important content comes first
 6. **Chapter files are on-demand** — they don't count against skill budget until loaded
 7. **Never copy raw book text** — always synthesize, summarize, extract signal
-8. **Topic index is critical** — it's how the agent navigates to the right chapter file
+8. **Topic index is critical** — it's how the agent navigates to the right chapter file; keep `index.json` and the Markdown Topic Index in sync, every `file` pointing to a real chapter

--- a/tests/test_validate_index.py
+++ b/tests/test_validate_index.py
@@ -1,0 +1,74 @@
+"""Tests for tools/validate_index.py — index.json integrity checks."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+spec = importlib.util.spec_from_file_location("validate_index", TOOLS_DIR / "validate_index.py")
+vi = importlib.util.module_from_spec(spec)
+sys.modules["validate_index"] = vi
+spec.loader.exec_module(vi)
+
+
+def _make_skill(tmp_path, index, with_files=("chapters/ch01-intro.md", "chapters/ch05-prfaq.md")):
+    (tmp_path / "chapters").mkdir(exist_ok=True)
+    for f in with_files:
+        (tmp_path / f).write_text("# chapter", encoding="utf-8")
+    (tmp_path / "index.json").write_text(json.dumps(index), encoding="utf-8")
+    return tmp_path
+
+
+VALID_INDEX = {
+    "skill": "working-backwards",
+    "title": "Working Backwards",
+    "chapters": [
+        {"n": 1, "file": "chapters/ch01-intro.md", "title": "Intro", "frameworks": []},
+        {"n": 5, "file": "chapters/ch05-prfaq.md", "title": "PR/FAQ", "frameworks": ["PR/FAQ"]},
+    ],
+    "topics": {"pr/faq": ["ch05"], "intro": ["ch01"]},
+}
+
+
+class TestValidateIndex:
+    def test_valid_index_passes(self, tmp_path):
+        sd = _make_skill(tmp_path, VALID_INDEX)
+        errors, warnings = vi.validate(sd)
+        assert errors == []
+
+    def test_missing_index_errors(self, tmp_path):
+        errors, _ = vi.validate(tmp_path)
+        assert any("not found" in e for e in errors)
+
+    def test_chapter_file_missing_on_disk(self, tmp_path):
+        sd = _make_skill(tmp_path, VALID_INDEX, with_files=("chapters/ch01-intro.md",))
+        errors, _ = vi.validate(sd)
+        assert any("does not exist on disk" in e for e in errors)
+
+    def test_topic_points_to_unknown_chapter(self, tmp_path):
+        idx = json.loads(json.dumps(VALID_INDEX))
+        idx["topics"]["ghost"] = ["ch99"]
+        sd = _make_skill(tmp_path, idx)
+        errors, _ = vi.validate(sd)
+        assert any("unknown chapter 'ch99'" in e for e in errors)
+
+    def test_uppercase_topic_key_errors(self, tmp_path):
+        idx = json.loads(json.dumps(VALID_INDEX))
+        idx["topics"]["PR_FAQ"] = ["ch05"]
+        sd = _make_skill(tmp_path, idx)
+        errors, _ = vi.validate(sd)
+        assert any("not lowercase" in e for e in errors)
+
+    def test_unreachable_chapter_warns(self, tmp_path):
+        idx = json.loads(json.dumps(VALID_INDEX))
+        del idx["topics"]["intro"]  # ch01 now unreachable
+        sd = _make_skill(tmp_path, idx)
+        errors, warnings = vi.validate(sd)
+        assert errors == []
+        assert any("not reachable" in w for w in warnings)
+
+    def test_invalid_json_errors(self, tmp_path):
+        (tmp_path / "index.json").write_text("{not json", encoding="utf-8")
+        errors, _ = vi.validate(tmp_path)
+        assert any("not valid JSON" in e for e in errors)

--- a/tools/validate_index.py
+++ b/tools/validate_index.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+validate_index.py — check a generated skill's index.json for integrity.
+
+A skill's index.json (Step 9.5) is what lets the agent resolve a topic to its
+chapter file in one hop. If it drifts from the files on disk, that lookup breaks
+silently. This validator catches the drift.
+
+Checks:
+  1. index.json is valid JSON with the required keys
+  2. every chapter `file` exists on disk
+  3. every chapter id referenced in `topics` exists in `chapters`
+  4. topic keys are lowercase
+  5. (warning) every chapter is reachable from at least one topic
+
+Usage:
+  python3 tools/validate_index.py <skill_dir>
+Exit code 0 = valid, 1 = errors found.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_KEYS = {"skill", "title", "chapters", "topics"}
+
+
+def validate(skill_dir: Path) -> tuple[list[str], list[str]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    idx_path = skill_dir / "index.json"
+    if not idx_path.is_file():
+        return ([f"index.json not found in {skill_dir}"], [])
+
+    try:
+        idx = json.loads(idx_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return ([f"index.json is not valid JSON: {exc}"], [])
+
+    missing_keys = REQUIRED_KEYS - idx.keys()
+    if missing_keys:
+        errors.append(f"missing required keys: {', '.join(sorted(missing_keys))}")
+        return (errors, warnings)
+
+    chapters = idx.get("chapters", [])
+    chapter_ids: set[str] = set()
+    for ch in chapters:
+        n = ch.get("n")
+        cid = f"ch{int(n):02d}" if isinstance(n, int) else None
+        if cid:
+            chapter_ids.add(cid)
+        file_rel = ch.get("file")
+        if not file_rel:
+            errors.append(f"chapter {n} has no 'file'")
+            continue
+        if not (skill_dir / file_rel).is_file():
+            errors.append(f"chapter {n}: file does not exist on disk: {file_rel}")
+
+    topics = idx.get("topics", {})
+    referenced: set[str] = set()
+    for topic, refs in topics.items():
+        if topic != topic.lower():
+            errors.append(f"topic key not lowercase: '{topic}'")
+        if not isinstance(refs, list):
+            errors.append(f"topic '{topic}' must map to a list of chapter ids")
+            continue
+        for ref in refs:
+            referenced.add(ref)
+            if ref not in chapter_ids:
+                errors.append(f"topic '{topic}' references unknown chapter '{ref}'")
+
+    unreachable = chapter_ids - referenced
+    if unreachable:
+        warnings.append(f"chapters not reachable from any topic: {', '.join(sorted(unreachable))}")
+
+    return (errors, warnings)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: validate_index.py <skill_dir>", file=sys.stderr)
+        return 2
+
+    skill_dir = Path(sys.argv[1])
+    errors, warnings = validate(skill_dir)
+
+    for w in warnings:
+        print(f"  WARN  {w}")
+    if errors:
+        for e in errors:
+            print(f"  ERROR {e}")
+        print(f"\n✗ index.json invalid: {len(errors)} error(s)")
+        return 1
+
+    print(f"✓ index.json valid ({len(warnings)} warning(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Step 9.5 generates index.json (topic->chapter file) so the agent resolves a topic in one small read instead of scanning prose — attacks the ~9.8K-token ToC discovery cost measured by discovery_tax.py. How-to-Use/fold-in updated to consult+sync it. tools/validate_index.py + tests catch drift.