### PR TITLE
add support to github copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <h1 align="center">📚 book-to-skill</h1>
 
 <p align="center">
-  <strong>Turn any technical book, document folder, or collection of sources into a unified Claude Code skill — ready to study, reference, and use while you work.</strong>
+  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in GitHub Copilot CLI, Amp, or Claude Code.</strong>
 </p>
 
 <p align="center">
   <a href="https://github.com/virgiliojr94/book-to-skill/releases"><img src="https://img.shields.io/github/v/release/virgiliojr94/book-to-skill?style=for-the-badge&color=blueviolet" alt="Latest release"></a>
-  <img src="https://img.shields.io/badge/Claude_Code-Skill-blueviolet?style=for-the-badge" alt="Claude Code Skill">
+  <img src="https://img.shields.io/badge/Agent_Skills-Open_Standard-blueviolet?style=for-the-badge" alt="Agent Skills standard">
   <img src="https://img.shields.io/badge/PDF%20%E2%80%A2%20EPUB%20%E2%80%A2%20DOCX%20%E2%80%A2%20MD%20%E2%80%A2%20HTML%20%E2%80%A2%20RTF%20%E2%80%A2%20MOBI-supported-green?style=for-the-badge" alt="Formats supported">
   <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="MIT License">
 </p>
@@ -36,18 +36,20 @@ You buy a great technical book. You read it once. Three months later you can't r
 
 The usual workarounds don't help:
 - 📄 "Let me just search the PDF" → you get a list of pages, not answers
-- 🧠 "I'll ask Claude about this book" → it either hallucinates or says it doesn't have the content
+- 🧠 "I'll ask the agent about this book" → it either hallucinates or says it doesn't have the content
 - 📝 "I'll take notes as I read" → you end up with a 200-line doc you never open again
 
-**book-to-skill solves this by turning the book into a structured skill Claude loads on demand.**
+**book-to-skill solves this by turning the book into a structured skill your agent loads on demand.**
 
-Once installed, you just type `/your-book-slug replication` and Claude reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
+Once installed, you just type `/your-book-slug replication` and the agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
+
+Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
 
 ---
 
 ## 📦 What it generates
 
-Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill at `~/.claude/skills/<slug>/`:
+Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Amp or cross-agent, `~/.claude/skills/<slug>/` for Claude Code):
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -98,7 +100,7 @@ Supported document formats: PDF, EPUB, DOCX, TXT, Markdown, reStructuredText, As
 /book-to-skill ~/articles/new-paper.pdf ~/.claude/skills/project-knowledge
 ```
 
-After the skill is created, use it like any other Claude Code skill:
+After the skill is created, use it like any other agent skill:
 
 ```bash
 /designing-data-intensive-apps                  # load core mental models
@@ -106,6 +108,8 @@ After the skill is created, use it like any other Claude Code skill:
 /designing-data-intensive-apps ch05             # dive into chapter 5
 /designing-data-intensive-apps "what chapters do you have?"
 ```
+
+In GitHub Copilot CLI you may need to run `/skills reload` after the file is written so the new skill appears in `/skills list`. Claude Code and Amp pick it up on the next session.
 
 ---
 
@@ -176,8 +180,11 @@ scripts/extract.py <paths…> --mode <technical|text>
           Generates master SKILL.md with core mental models
                │
                ▼
-          ~/.claude/skills/<slug>/  ✅ written
-          /tmp/book_skill_work/     🗑️  cleaned up
+          Skill written to one of:
+            ~/.copilot/skills/<slug>/   (GitHub Copilot CLI)
+            ~/.agents/skills/<slug>/    (Copilot CLI or Amp, cross-agent)
+            ~/.claude/skills/<slug>/    (Claude Code)
+          /tmp/book_skill_work/         🗑️  cleaned up
 ```
 
 **Extraction benchmark** (103-page technical book, CPU only):
@@ -321,6 +328,25 @@ book-to-skill is built for a different job: you want to go deep on a specific to
 
 ## 📥 Install
 
+The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
+
+**GitHub Copilot CLI** (personal skill):
+
+```bash
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.copilot/skills/book-to-skill
+# then, in a `copilot` session:
+/skills reload
+/skills info book-to-skill
+```
+
+Or the cross-agent path that Copilot CLI and Amp both discover:
+
+```bash
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
+```
+
+**Claude Code**:
+
 Copy this into your Claude Code session:
 
 ```
@@ -333,7 +359,7 @@ Or manually using standard `git clone` (ensures modular engine files are fetched
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 ```
 
-Then in any Claude Code session:
+Then in any agent session:
 
 ```bash
 /book-to-skill ~/path/to/your-book.pdf
@@ -358,7 +384,7 @@ book-to-skill/
 │       └── parsers/      # Format-specific parsers (pdf, epub, docx, html, rtf, calibre, text)
 ├── tools/
 │   ├── discovery_tax.py  # measures token cost vs context-dump / discovery loop
-│   └── validate_skill.py # checks a generated SKILL.md against Claude Code rules
+│   └── validate_skill.py # checks a generated SKILL.md against host rules (--lens claude|copilot|amp)
 ├── tests/                # pytest suite (extraction, detection, discovery tax)
 ├── docs/
 │   ├── PERFORMANCE.md    # measured benchmarks, discovery tax, cost

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Amp or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
-compatibility: "Amp skill directories (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills) and Claude Code skill directories (~/.claude/skills)."
-allowed-tools:
-  - Bash
-  - shell_command
-  - Read
-  - Write
-  - Glob
-  - Grep
-argument-hint: <path-to-document-folder-or-glob>... [skill-name-slug]
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 ---
+
+<!--
+Cross-agent notes (informational; ignored by host agents):
+  - Compatible skill roots: GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills,
+    .github/skills, .claude/skills, .agents/skills), Amp (.agents/skills,
+    ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills).
+  - `allowed-tools` is intentionally omitted to stay agent-neutral: Copilot CLI uses
+    `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`, Amp
+    adds `shell_command`. The skill needs shell (to run extract.py) and file
+    read/write — each host will prompt for those on first use.
+  - Argument hint: <path-to-document-folder-or-glob>... [skill-name-slug]
+-->
 
 # Book-to-Skill Converter
 
@@ -18,7 +21,7 @@ Transform written knowledge into actionable agent skills by extracting structure
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Amp, Claude Code, or another compatible agent can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -63,12 +66,16 @@ Four paths available. Route based on what the user asks:
 
 This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
 
-1. Claude Code skills: `~/.claude/skills/`
-2. Amp project-local skills: `.agents/skills/`
-3. Amp global skills: `~/.config/agents/skills/`
-4. Amp legacy global skills: `~/.config/amp/skills/`
+1. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
+2. Cross-agent personal skills (Copilot + Amp): `~/.agents/skills/`
+3. Claude Code personal skills: `~/.claude/skills/`
+4. Project-local Copilot skills: `.github/skills/`
+5. Project-local Claude skills: `.claude/skills/`
+6. Project-local Amp / Copilot skills: `.agents/skills/`
+7. Amp global skills: `~/.config/agents/skills/`
+8. Amp legacy global skills: `~/.config/amp/skills/`
 
-Generated skills should default to `~/.claude/skills/` for Claude Code unless the user asks for Amp project-local or Amp global output.
+For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
 
 ---
 
@@ -124,7 +131,11 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 for candidate in \
+  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
+  ".github/skills/book-to-skill/scripts/extract.py" \
+  ".claude/skills/book-to-skill/scripts/extract.py" \
   ".agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
@@ -289,11 +300,19 @@ Otherwise, propose two options and let the user choose:
 
 Default to author-concept format if the book has a strong methodological identity.
 
-Choose the destination skill root:
-- **Claude Code default**: `~/.claude/skills`
-- **Amp global**: `~/.config/agents/skills` if that is the user's existing global skill location
-- **Amp project-local**: `.agents/skills` when the user explicitly wants the generated book skill scoped to the current workspace
-- **Amp legacy**: `~/.config/amp/skills` if that is the user's existing global skill location
+Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem for existing skill homes and pick by **the host the user is running in**:
+
+| Host agent | Personal skill root (probe in order) | Project-local root |
+|---|---|---|
+| **GitHub Copilot CLI** | `~/.copilot/skills` → `~/.agents/skills` | `.github/skills` → `.claude/skills` → `.agents/skills` |
+| **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
+| **Claude Code** | `~/.claude/skills` | `.claude/skills` |
+
+Selection rules:
+1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
+2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
+3. If the user explicitly asked for project-local output, prefer the project-local row.
+4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:
@@ -440,11 +459,9 @@ Create `$SKILLS_HOME/<skill_name>/SKILL.md`:
 ---
 name: <skill_name>
 description: "Knowledge base from \"<Full Title>\" by <Author(s)>. Use when applying <author>'s frameworks for <key topics, 3–6 terms>, studying the book, or referencing its concepts."
-allowed-tools:
-  - Read
-  - Grep
-argument-hint: [topic, framework name, or chapter number]
 ---
+
+<!-- argument-hint: [topic, framework name, or chapter number] -->
 
 # <Full Title>
 **Author**: <Author(s)> | **Pages**: ~<N> | **Chapters**: <N> | **Generated**: <YYYY-MM-DD>
@@ -544,6 +561,14 @@ Usage:
   Ask for <skill_name>                  → load core frameworks
   Ask <skill_name> about <topic>        → find and explain a topic
   Ask <skill_name> for ch<N>            → dive into a specific chapter
+
+Reload (if your agent doesn't auto-detect new skills):
+  GitHub Copilot CLI:  /skills reload
+  Claude Code:         restart the session
+  Amp:                 restart the session
+
+Share this skill (Copilot ecosystem, optional):
+  gh skill publish $SKILLS_HOME/<skill_name>
 ```
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,11 @@ document into clean text + metadata; the agent turns that into a structured skil
             └────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
-                ~/.claude/skills/<slug>/
+                <SKILLS_HOME>/<slug>/  ← chosen per host:
+                  ~/.copilot/skills/   GitHub Copilot CLI
+                  ~/.agents/skills/    Copilot CLI or Amp (cross-agent)
+                  ~/.claude/skills/    Claude Code
+                  .github|.claude|.agents/skills/  project-local
                   SKILL.md         core frameworks + chapter & topic index (~4K)
                   chapters/*.md    on-demand, loaded only when asked
                   glossary.md      terms
@@ -61,7 +65,7 @@ document into clean text + metadata; the agent turns that into a structured skil
 | `scripts/extractor/parsers/` | one module per format |
 | `scripts/extractor/dependencies.py` | optional-dependency probing + `--check` |
 | `tools/discovery_tax.py` | measures token cost vs context-dump / discovery loop |
-| `tools/validate_skill.py` | checks a generated SKILL.md against Claude Code rules |
+| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude|copilot|amp`) |
 | `SKILL.md` | the generator spec (Steps 0–10 + fold-in workflow) |
 
 ## Extending

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
-"""Audit a SKILL.md against Claude Code Agent Skills rules (Claude-only lens).
+"""Audit a SKILL.md against Agent Skills rules for a chosen host (lens).
 
 Severity:
-  ERROR  -> breaks/degrades the skill ON CLAUDE CODE (fails CI)
-  WARN   -> Claude ignores it, or it's a soft guideline (does not fail CI)
+  ERROR  -> breaks/degrades the skill on the chosen host (fails CI)
+  WARN   -> the host ignores it, or it's a soft guideline (does not fail CI)
 
-The repo is positioned as a Claude Code skill, so this checks Claude rules
-only. Frontmatter keys aimed at other agents (e.g. Amp's `shell_command`,
-`compatibility`, `argument-hint`) are reported as WARN because Claude Code
-silently ignores them — they are intentional cross-agent metadata, not errors.
+Lenses:
+  claude   — Claude Code rules (default; back-compat)
+  copilot  — GitHub Copilot CLI rules
+  amp      — Sourcegraph Amp rules
+
+The SKILL.md format itself is an open standard
+(https://github.com/agentskills/agentskills) — `name` + `description` are the
+only universally-required fields. Lenses differ on which `allowed-tools` names
+are recognized and which extra frontmatter keys are accepted vs. silently
+ignored.
 
 Refs:
-  https://code.claude.com/docs/en/skills
-  https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+  Claude     https://code.claude.com/docs/en/skills
+             https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+  Copilot    https://docs.github.com/en/copilot/concepts/agents/about-agent-skills
+             https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills
+  Amp        https://ampcode.com/manual#skills
 
-Usage: python3 tools/validate_skill.py [path/to/SKILL.md]
+Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp] [path/to/SKILL.md]
 """
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -25,8 +35,45 @@ CLAUDE_CODE_TOOLS = {
     "Bash", "Read", "Write", "Edit", "Glob", "Grep",
     "WebFetch", "WebSearch", "NotebookEdit", "Task", "TodoWrite",
 }
-RECOGNIZED_KEYS = {"name", "description", "allowed-tools", "license"}
-RESERVED_NAME_WORDS = {"anthropic", "claude"}
+
+# Copilot CLI recognized literal tool tokens. Anything else is assumed to be an
+# MCP-server name (free-form), which Copilot accepts — so unknown tokens get a
+# soft note, not an error.
+COPILOT_CLI_TOOLS = {"shell", "bash", "write"}
+
+# Amp accepts Claude's tool names plus its own `shell_command` shorthand.
+AMP_TOOLS = CLAUDE_CODE_TOOLS | {"shell_command"}
+
+LENSES = {
+    "claude": {
+        "label": "Claude Code",
+        "tools": CLAUDE_CODE_TOOLS,
+        "recognized_keys": {"name", "description", "allowed-tools", "license"},
+        "reserved_name_words": {"anthropic", "claude"},
+        "bash_tool_names": {"Bash"},
+        "unknown_tool_severity": "error",
+    },
+    "copilot": {
+        "label": "GitHub Copilot CLI",
+        "tools": COPILOT_CLI_TOOLS,
+        "recognized_keys": {"name", "description", "allowed-tools", "license"},
+        "reserved_name_words": set(),
+        "bash_tool_names": {"shell", "bash"},
+        # Unknown tokens are likely MCP server names — Copilot accepts them.
+        "unknown_tool_severity": "warn",
+    },
+    "amp": {
+        "label": "Amp",
+        "tools": AMP_TOOLS,
+        "recognized_keys": {
+            "name", "description", "allowed-tools", "license",
+            "compatibility", "argument-hint",
+        },
+        "reserved_name_words": set(),
+        "bash_tool_names": {"shell_command", "Bash"},
+        "unknown_tool_severity": "warn",
+    },
+}
 
 
 def parse_frontmatter(text):
@@ -64,11 +111,13 @@ def top_level_keys(fm):
 
 
 def tool_base(entry):
-    """Bash(python3 *) -> Bash ; Read -> Read."""
+    """Bash(python3 *) -> Bash ; Read -> Read ; My-MCP(do_thing) -> My-MCP."""
     return entry.split("(", 1)[0].strip()
 
 
-def audit(path):
+def audit(path, lens="claude"):
+    rules = LENSES[lens]
+    label = rules["label"]
     text = Path(path).read_text(encoding="utf-8")
     fm, body = parse_frontmatter(text)
     errors, warns = [], []
@@ -83,8 +132,10 @@ def audit(path):
             errors.append(f"name: {len(name)} > 64 chars")
         if not re.fullmatch(r"[a-z0-9-]+", name):
             errors.append(f"name: '{name}' must be lowercase letters/digits/hyphens")
-        if any(w in name.lower() for w in RESERVED_NAME_WORDS):
-            errors.append(f"name: '{name}' contains a reserved word")
+        for w in rules["reserved_name_words"]:
+            if w in name.lower():
+                errors.append(f"name: '{name}' contains a reserved word")
+                break
 
     desc = get_scalar(fm, "description")
     if not desc:
@@ -92,29 +143,41 @@ def audit(path):
     elif len(desc) > 1024:
         errors.append(f"description: {len(desc)} > 1024 chars")
 
-    # Tool grant analysis (Claude lens)
+    # Tool grant analysis (lens-specific)
     tools = get_list_items(fm, "allowed-tools")
     if not tools:
         inline = get_scalar(fm, "allowed-tools")
         if inline:
             tools = inline.split()
-    if tools:  # a restriction is declared -> Claude Code enforces it
+    if tools:  # a restriction is declared -> the host enforces it
         bases = {tool_base(t) for t in tools}
-        claude_valid = bases & CLAUDE_CODE_TOOLS
-        unknown = [t for t in tools if tool_base(t) not in CLAUDE_CODE_TOOLS]
+        known = {b for b in bases if b in rules["tools"]}
+        unknown = [t for t in tools if tool_base(t) not in rules["tools"]]
         uses_bash = bool(re.search(r"```bash", body)) or "python3 " in body
-        if uses_bash and "Bash" not in bases:
-            errors.append("allowed-tools declares a restriction but omits 'Bash', yet the "
-                          "skill runs bash/python3 — under Claude Code those steps would be blocked")
-        if not claude_valid:
-            errors.append("allowed-tools: no recognized Claude Code tool in the list")
+        if uses_bash and not (bases & rules["bash_tool_names"]):
+            bash_names = " or ".join(f"'{n}'" for n in sorted(rules["bash_tool_names"]))
+            errors.append(
+                f"allowed-tools declares a restriction but omits {bash_names}, yet the "
+                f"skill runs bash/python3 — under {label} those steps would be blocked"
+            )
+        if not known and rules["tools"]:
+            # Claude: hard error (none of the listed tools are recognized).
+            # Copilot/Amp: tokens are likely MCP names — handled by the warn path.
+            if rules["unknown_tool_severity"] == "error":
+                errors.append(f"allowed-tools: no recognized {label} tool in the list")
         if unknown:
-            warns.append(f"allowed-tools: {unknown} are not Claude Code tool names "
-                         "(ignored by Claude)")
+            msg = (f"allowed-tools: {unknown} are not {label} built-in tool names "
+                   f"(treated as MCP-server names by Copilot, ignored by Claude)")
+            if rules["unknown_tool_severity"] == "error":
+                # Already covered by the 'no recognized tool' error if list is all-unknown;
+                # otherwise it's a soft note.
+                warns.append(msg)
+            else:
+                warns.append(msg)
 
     for k in top_level_keys(fm):
-        if k not in RECOGNIZED_KEYS:
-            warns.append(f"frontmatter '{k}': not a recognized Claude Code key (ignored by Claude)")
+        if k not in rules["recognized_keys"]:
+            warns.append(f"frontmatter '{k}': not a recognized {label} key (ignored by {label})")
 
     n = len(text.splitlines())
     if n > 500:
@@ -124,17 +187,25 @@ def audit(path):
 
 
 def main():
-    target = sys.argv[1] if len(sys.argv) > 1 else "SKILL.md"
-    errors, warns = audit(target)
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("path", nargs="?", default="SKILL.md",
+                        help="Path to SKILL.md (default: SKILL.md)")
+    parser.add_argument("--lens", choices=sorted(LENSES.keys()), default="claude",
+                        help="Which host's rules to validate against (default: claude)")
+    args = parser.parse_args()
+
+    errors, warns = audit(args.path, lens=args.lens)
+    label = LENSES[args.lens]["label"]
     for w in warns:
         print(f"  WARN  {w}")
     for e in errors:
         print(f"  ERROR {e}")
     if errors:
-        print(f"✗ {target}: {len(errors)} error(s), {len(warns)} warning(s)")
+        print(f"✗ {args.path} [{label}]: {len(errors)} error(s), {len(warns)} warning(s)")
         sys.exit(1)
-    print(f"✓ {target}: no Claude-breaking issues ({len(warns)} warning(s))")
+    print(f"✓ {args.path} [{label}]: no {label}-breaking issues ({len(warns)} warning(s))")
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
<!-- Conventional Commit title, e.g. fix(extractor): scan full text -->

## What & why
Makes `book-to-skill` a tri-agent project. Previously the converter targeted Claude Code (primary) with Amp also supported (see CHANGELOG #13/#14). This PR adds **GitHub Copilot CLI** as a first-class target so the same `SKILL.md` discovers, installs, and runs identically across all three hosts via the open [Agent Skills](https://github.com/agentskills/agentskills) standard.

No Python source under `scripts/` was touched — the extractor is host-agnostic. All changes are in the SKILL.md generator spec, the validator, the README, and the architecture doc.


## What changed

### `SKILL.md`
- **Frontmatter** trimmed to the open-standard minimum (`name` + `description`). The previous `compatibility`, `allowed-tools`, and `argument-hint` keys were a mix of Claude- and Amp-flavored tokens that Copilot silently ignored; moved to an HTML comment for human readers. Both Claude and Copilot interpret missing `allowed-tools` as "no restriction" and prompt on first use of shell/Read/Write.
- **Description** updated to mention all three hosts so each agent's auto-loader picks it up.
- **Skill Locations** section now lists 8 discovery paths in Copilot-first order: `~/.copilot/skills/`, `~/.agents/skills/`, `~/.claude/skills/`, then the four project-local roots, then the two Amp-specific roots.
- **Step 2** (`SCRIPT_PATH` resolution): extended the bash probe ladder to walk all 8 candidates.
- **Step 5** (where to write the generated skill): replaced the Claude-only default with a per-host selection table. Rules: single existing root → use it; none → ask once per session; project-local present → use it; unknown host → ask which agent.
- **Step 9** (generated child-skill template): dropped `allowed-tools: [Read, Grep]` and `argument-hint` from its frontmatter (same rationale as parent).
- **Step 10** (cleanup report): added a per-host reload hint + an opt-in `gh skill publish` line.

### `tools/validate_skill.py`
- Added a `--lens claude|copilot|amp` flag. Each lens is a table of: recognized tool tokens, recognized frontmatter keys, bash-equivalent tool names, reserved name words, and unknown-tool severity.
- Behavior:
  - `claude` — same rules as before (back-compat: this is the default, so existing CI keeps passing without changes).
  - `copilot` — recognizes `shell`/`bash`/`write`; unknown tokens are warned, not errored (Copilot treats them as MCP server names).
  - `amp` — Claude's tool set plus `shell_command`; also accepts `compatibility`/`argument-hint` keys that other hosts ignore.
- Each lens exits non-zero only on rules that would actually break the skill on that host.

### `README.md`
- Headline updated to call out GitHub Copilot CLI, Amp, and Claude Code.
- Badge changed from "Claude_Code-Skill" to "Agent_Skills-Open_Standard".
- "What it generates" and "How it works" diagram now show all three install destinations.
- Install section: new Copilot CLI block first, then the cross-agent `~/.agents/skills/` path, then the existing Claude Code block (preserved unchanged for current users).
- Usage section: agent-neutral wording + `/skills reload` note for Copilot.

### `docs/ARCHITECTURE.md`
- Output diagram shows the per-host destination paths.
- Key-components table notes the new `--lens` flag on the validator.

## Checklist
- [ ] One focused change
- [ ] Tests added/updated for behavior changes
- [ ] `ruff check .` clean
- [ ] `pytest -q` green
- [ ] `python3 tools/validate_skill.py SKILL.md` passes (if SKILL.md changed)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] No raw book text shipped; no net SKILL.md bloat without justification
