### PR TITLE
fix: print attribution banner from extract.py (reliable across invocations)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -151,9 +151,6 @@ if [ -z "$SCRIPT_PATH" ]; then
   exit 1
 fi
 
-# Attribution banner (best-effort; never fails the run)
-cat "$(dirname "$SCRIPT_PATH")/banner.txt" 2>/dev/null || true
-
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"

--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -406,7 +406,19 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
     }
 
 
+def print_banner() -> None:
+    """Print the attribution banner. Done here (not only in SKILL.md) so it
+    shows on every run regardless of how the agent invokes extraction."""
+    banner = Path(__file__).resolve().parent.parent / "banner.txt"
+    try:
+        sys.stderr.write(banner.read_text(encoding="utf-8") + "\n")
+    except Exception:
+        pass  # best-effort: never block extraction on the banner
+
+
 def main():
+    print_banner()
+
     if "--check" in sys.argv[1:]:
         sys.exit(run_dependency_check())
 


### PR DESCRIPTION
The banner only lived as a cat in SKILL.md Step 2, so when the agent improvised extraction (venv for docling) it skipped it — banner never showed on a real run. Moved to extract.py main() (stderr, best-effort); dropped the redundant SKILL.md cat. Prints on every invocation now.