### PR TITLE
fix(extractor): defer annotation evaluation so import works on Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to **book-to-skill** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Package now imports on interpreters that evaluate annotations eagerly.**
+  Added `from __future__ import annotations` to every module using PEP 604
+  unions (`str | None`) — `scripts/extractor/{utils,dependencies}.py`, all
+  `scripts/extractor/parsers/*.py`, and `tools/discovery_tax.py`. Before this,
+  importing the package under Python 3.9 raised `TypeError: unsupported operand
+  type(s) for |: 'type' and 'NoneType'` at import time, so the whole test suite
+  failed during collection. The annotations are now lazy (free at runtime), so
+  the package imports and runs cleanly on Python 3.9 as well.
+
 ## [1.1.0] — 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed during collection. The annotations are now lazy (free at runtime), so
   the package imports and runs cleanly on Python 3.9 as well.
 
+### Changed
+- CI test matrix now includes Python 3.9 so the import path above is guarded and
+  cannot silently re-break.
+
 ## [1.1.0] — 2026-06-12
 
 ### Added

--- a/scripts/extractor/dependencies.py
+++ b/scripts/extractor/dependencies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 import os
 import shutil

--- a/scripts/extractor/parsers/calibre.py
+++ b/scripts/extractor/parsers/calibre.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 import subprocess
 from extractor.config import OUTPUT_DIR

--- a/scripts/extractor/parsers/docx.py
+++ b/scripts/extractor/parsers/docx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zipfile
 from extractor.exceptions import ExtractionError
 

--- a/scripts/extractor/parsers/epub.py
+++ b/scripts/extractor/parsers/epub.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import posixpath
 import re
 import zipfile

--- a/scripts/extractor/parsers/html.py
+++ b/scripts/extractor/parsers/html.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import html.parser
 from extractor.parsers.text import read_text_file

--- a/scripts/extractor/parsers/pdf.py
+++ b/scripts/extractor/parsers/pdf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 import subprocess
 

--- a/scripts/extractor/parsers/text.py
+++ b/scripts/extractor/parsers/text.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 

--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import json
 import os

--- a/tools/discovery_tax.py
+++ b/tools/discovery_tax.py
@@ -28,6 +28,8 @@ Usage:
       [--skill-dir <skill_folder>] [--target-chapter N] [--core-tokens 4000]
 """
 
+from __future__ import annotations
+
 import argparse
 import re
 import sys


### PR DESCRIPTION
PR 1 of 2 — runtime robustness.

## What
Adds `from __future__ import annotations` to every module that uses PEP 604 unions (`str | None`) in signatures: `scripts/extractor/{utils,dependencies}.py`, `scripts/extractor/parsers/*.py`, and `tools/discovery_tax.py`. Also adds `"3.9"` to the CI test matrix (per review) so the fix is guarded, not just promised.

## Why (the learning)
Function-signature annotations are evaluated **at import time**, not lazily. `str | None` is only a valid expression from Python 3.10 on. On 3.9 it raises `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` **at import** — and since the package fails to import, the whole suite fails during pytest collection.

The current CI matrix (3.10–3.13) never exercised 3.9, so nothing caught it. `from __future__ import annotations` makes all annotations lazy strings (PEP 563): zero runtime cost and the `|` is never evaluated.

## Tradeoff
Minimal diff (one line per file), no behavior change on 3.10+. Positive side effect: the package now imports and runs on 3.9 too — which is why PR 2 declares `requires-python = ">=3.9"`.

## Evidence
`pytest` on **Python 3.9.6**: before, collection failed with the `TypeError`; after, **60 passed**. `ruff --select E9,F` clean. The new 3.9 matrix entry locks this in CI.