### PR TITLE
chore: add pyproject.toml (requires-python + ruff/pytest config)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`pyproject.toml`** declaring `requires-python = ">=3.9"` and centralizing the
+  ruff/pytest config so `ruff check .` and `pytest` locally match CI without
+  passing flags by hand. Metadata only — no build backend or console scripts; the
+  tool stays CLI-first via `python3 scripts/extract.py`.
 - Structure detection now recognizes Markdown/AsciiDoc ATX headings (`#`, `==`)
   as chapters when no numeric "Chapter N" headings are present, fixing a
   zero-chapter result for `.md`/`.adoc` sources. Headings inside fenced code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "book-to-skill"
+version = "1.1.0"
+description = "Convert books and documents into structured, on-demand agent skills."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+
+# Tooling config so `ruff check .` and `pytest` locally match CI without flags.
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+# High-value gate only: syntax errors (E9) + pyflakes (F). Style stays ungated.
+select = ["E9", "F"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]


### PR DESCRIPTION
PR 2 of 2 — explicit runtime contract.

## What
Adds a minimal `pyproject.toml`: project metadata, `requires-python = ">=3.9"`, and the `ruff`/`pytest` config in one place.

## Why (the learning)
Today versions and rules live scattered (flags in `ci.yml`, support only implicit). Centralizing buys two things:

1. **Runtime contract**: `requires-python` makes `pip` refuse an incompatible interpreter with a clear message, instead of the cryptic import-time `TypeError`. (`>=3.9` because the package runs on 3.9 — see PR 1.)
2. **Dev == CI**: with `[tool.ruff]` and `[tool.pytest.ini_options]`, running `ruff check .` and `pytest` locally uses exactly what CI uses, no flags to memorize.

## Tradeoff
**Metadata only** — no build backend, no `console_scripts`. The tool stays CLI-first (`python3 scripts/extract.py`); packaging to PyPI is not worth the complexity now. Keeps the surface minimal.

## Evidence
`ruff check .` reads the config and passes with no flags. `pytest` discovers tests via `testpaths`. (The suite going green on 3.9 lands with PR 1.)