### PR TITLE
feat: Chinese (CJK) chapter detection + UTF-8 output fix on Windows

### DIFF
--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -7,6 +7,15 @@ Modular entrypoint wrapper.
 import os
 import sys
 
+# Force UTF-8 stdout/stderr so the attribution banner (braille art) and the
+# dependency-check glyphs (✓ / ✗) don't raise UnicodeEncodeError on Windows
+# consoles that default to a legacy code page (e.g. GBK / cp936).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 # Ensure the scripts/ directory (where the 'extractor' package lives) is in sys.path
 # so the modular package can be imported reliably regardless of the working directory.
 sys.path.insert(0, str(os.path.dirname(os.path.abspath(__file__))))

--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -65,6 +65,42 @@ _HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+[A-ZÀ-Ú0-9\"“(]")
 _ROMAN_HEAD = re.compile(r"^\s*([IVXLCDM]+)\s*[:.]\s+[A-ZÀ-Ú\"“(]")
 _ROMAN_VALUES = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
 
+# Chinese chapter headings. Two common styles:
+#   1. explicit "第N章" / "第 3 回" / "第十二节" / "第一讲" — 第 + numeral + a
+#      chapter classifier (章回卷节篇讲);
+#   2. a Markdown heading led by a CJK ordinal and a separator, e.g.
+#      "## 一 · 缘起" or "## 第一讲" — common in CJK ebooks and lecture notes.
+# Scoped to CJK numerals, so Latin/Roman detection above is completely unaffected
+# (e.g. "## 5 Setup" is still not treated as a heading here). detect_structure()
+# dedupes by number, so a "##" heading and a repeated "###" sub-ordinal collapse
+# to a single chapter.
+_CN_NUM_VALUES = {
+    "〇": 0, "零": 0, "一": 1, "二": 2, "两": 2, "三": 3, "四": 4, "五": 5,
+    "六": 6, "七": 7, "八": 8, "九": 9,
+}
+_CN_NUM_UNITS = {"十": 10, "百": 100, "千": 1000}
+_CN_NUM_CLASS = "〇零一二两三四五六七八九十百千"
+_CN_CHAPTER = re.compile(rf"^\s*第\s*([0-9{_CN_NUM_CLASS}]+)\s*[章回卷节篇讲]")
+_MD_CN_HEADING = re.compile(rf"^#{{1,6}}\s+第?\s*([{_CN_NUM_CLASS}]+)\s*[·、.:：章回卷节篇讲]")
+
+
+def _cn_numeral_to_int(s: str) -> int | None:
+    """Parse a Chinese (or ASCII-digit) chapter numeral into an int (1..999)."""
+    if s.isdigit():
+        n = int(s)
+        return n if 1 <= n <= 999 else None
+    section = current = 0
+    for ch in s:
+        if ch in _CN_NUM_VALUES:
+            current = _CN_NUM_VALUES[ch]
+        elif ch in _CN_NUM_UNITS:
+            section += (current or 1) * _CN_NUM_UNITS[ch]
+            current = 0
+        else:
+            return None
+    total = section + current
+    return total if 1 <= total <= 999 else None
+
 
 def _int_to_roman(n: int) -> str:
     table = [(1000, "M"), (900, "CM"), (500, "D"), (400, "CD"), (100, "C"),
@@ -97,8 +133,9 @@ def _roman_to_int(s: str) -> int | None:
 def _chapter_number(line: str) -> int | None:
     """Return the chapter number if the line is a genuine chapter heading.
 
-    Handles both Arabic ("Chapter 5", "Capítulo 5: ...") and Roman-numeral
-    ("I: Loomings", "II. The Carpet-Bag") heading styles.
+    Handles Arabic ("Chapter 5", "Capítulo 5: ..."), Roman-numeral
+    ("I: Loomings", "II. The Carpet-Bag") and Chinese ("第三章 …", "## 一 · …",
+    "## 第一讲") heading styles.
     """
     s = line.strip()
     if len(s) > 80:
@@ -109,6 +146,9 @@ def _chapter_number(line: str) -> int | None:
     rm = _ROMAN_HEAD.match(s)
     if rm:
         return _roman_to_int(rm.group(1))
+    cm = _CN_CHAPTER.match(s) or _MD_CN_HEADING.match(s)
+    if cm:
+        return _cn_numeral_to_int(cm.group(1))
     return None
 
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -30,6 +30,7 @@ from extractor.utils import (
     parse_arguments,
     estimate_tokens,
     detect_structure,
+    _cn_numeral_to_int,
     main,
 )
 from extractor.config import SUPPORTED_EXTENSIONS
@@ -601,6 +602,46 @@ class TestDetectStructure:
         # A chapter heading far past the old 50k-char window must still be found.
         text = "Capítulo 1\n" + ("filler word " * 6000) + "\nCapítulo 2\n"
         assert detect_structure(text)["chapters_detected"] == 2
+
+    # ── Chinese (CJK) chapter headings ──────────────────────────────────────
+
+    def test_chinese_di_n_zhang(self):
+        text = "第一章 绪论\n正文。\n第二章 方法\n更多正文。\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_chinese_di_n_jiang_lecture(self):
+        # lecture transcripts numbered 第N讲
+        text = "第一讲\n正文\n第二讲\n正文\n第三讲\n正文\n"
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_markdown_cjk_ordinal_heading(self):
+        # "## 一 · 缘起" style, common in CJK ebooks
+        text = "## 一 · 缘起\n正文\n## 二 · 主体\n正文\n## 三 · 结语\n正文\n"
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_markdown_di_n_jiang_heading(self):
+        text = "## 第一讲\n正文\n## 第二讲\n正文\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_chinese_dedups_toc_and_body(self):
+        # ToC entry "第一讲..... 2" and body heading "## 第一讲" count once.
+        text = "第一讲..... 2\n第二讲..... 12\n## 第一讲\n正文\n## 第二讲\n正文\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_cjk_detection_does_not_affect_latin(self):
+        # A bare Arabic-numeral Markdown heading is NOT a chapter (unchanged).
+        assert detect_structure("## 5 Setup\n## 6 Teardown\n")["chapters_detected"] == 0
+
+    def test_chinese_numeral_parsing(self):
+        assert _cn_numeral_to_int("一") == 1
+        assert _cn_numeral_to_int("十") == 10
+        assert _cn_numeral_to_int("十一") == 11
+        assert _cn_numeral_to_int("二十") == 20
+        assert _cn_numeral_to_int("二十一") == 21
+        assert _cn_numeral_to_int("一百零八") == 108
+        assert _cn_numeral_to_int("15") == 15
+        assert _cn_numeral_to_int("不是数字") is None
+        assert _cn_numeral_to_int("9999") is None  # out of 1..999 chapter range
 
 
 class TestTextExtraction:

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -30,6 +30,15 @@ import re
 import sys
 from pathlib import Path
 
+# Force UTF-8 stdout/stderr so the ✓ / ✗ result glyphs don't raise
+# UnicodeEncodeError on Windows consoles that default to a legacy code page
+# (e.g. GBK / cp936).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 # Claude Code built-in tools. Bash grants may be scoped, e.g. "Bash(python3 *)".
 CLAUDE_CODE_TOOLS = {
     "Bash", "Read", "Write", "Edit", "Glob", "Grep",


### PR DESCRIPTION
Two small, self-contained improvements found while converting Chinese-language books with this tool.

## 1. Chinese chapter-heading detection

`detect_structure()` recognized only Latin (`Chapter N`, `Capítulo N`) and Roman-numeral headings, so Chinese sources were reported as **0 chapters**. For example a 15-lecture book whose sections are `第一讲 … 第十五讲`, or Markdown docs with `## 一 · …` headings, got no structure at all.

This adds detection for:
- explicit `第N章 / 第N回 / 第N节 / 第N卷 / 第N篇 / 第N讲` (Arabic or Chinese numerals)
- Markdown headings led by a CJK ordinal: `## 一 · 缘起`, `## 第一讲`

A small Chinese-numeral parser (`一二三` / `十百千` / `〇零` → int) lets these dedupe by number exactly like the existing Arabic/Roman logic (a ToC entry and its body heading still count once).

It is **scoped to CJK numerals**, so Latin/Roman detection is completely unchanged — `## 5 Setup` is still not treated as a chapter (test included).

## 2. UTF-8 output on Windows

`extract.py --check` and `tools/validate_skill.py` raise `UnicodeEncodeError` on Windows consoles that default to a legacy code page (cp936/GBK), because they print the braille attribution banner and the `✓`/`✗` glyphs. Forcing `sys.stdout`/`sys.stderr` to UTF-8 at startup fixes it; no logic changes.

## Tests

6 new CJK chapter-detection tests + a Chinese-numeral-parser test. Full suite: **67 passed**, no regressions.

## Notes

Chapter count is only a hint for the downstream analysis step, so this widens coverage without altering existing behavior on non-CJK input.