### PR TITLE
ci(security): add CodeQL, Bandit, Zizmor scanning + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Keep GitHub Actions fresh (and enables pinning actions to SHAs later).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,29 @@ jobs:
           test -f "$BOOK_SKILL_WORKDIR/metadata.json"
           grep -q "Backpressure" "$BOOK_SKILL_WORKDIR/full_text.txt"
 
+  security:
+    name: security (bandit + zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install scanners
+        run: pip install bandit zizmor
+      - name: Bandit — gate on HIGH severity
+        # Hard gate: only HIGH-severity / MEDIUM-confidence findings fail CI, to
+        # avoid blocking on the known-acceptable subprocess (pip install) calls.
+        # Ratchet down to medium once the open B314 docx-XML finding is hardened.
+        run: bandit -q -r scripts tools --severity-level high --confidence-level medium
+      - name: Bandit — report MEDIUM+ (informational)
+        run: bandit -q -r scripts tools -ll || true
+      - name: Zizmor — workflow audit (informational)
+        # Surfaces GitHub Actions risks (injection, pull_request_target misuse).
+        # Currently only flags unpinned-uses (tags vs SHA) — non-blocking until
+        # the actions are pinned to SHAs (Dependabot follow-up).
+        run: zizmor .github/workflows/ || true
+
   validate-skill:
     name: validate SKILL.md (Claude Code rules)
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly scan so newly-disclosed query packs catch latent issues.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze (python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **CI security scanning** — added CodeQL (Python, security-and-quality + weekly
+  schedule), Bandit (gates on HIGH severity; reports MEDIUM+ informationally), and
+  Zizmor (GitHub Actions workflow audit, informational). Added a Dependabot config
+  for the `github-actions` ecosystem. Known open finding to harden in a follow-up:
+  Bandit B314 (`xml.etree.ElementTree.fromstring` in the DOCX parser — untrusted
+  XML).
+
 ### Fixed
 - **Package now imports on interpreters that evaluate annotations eagerly.**
   Added `from __future__ import annotations` to every module using PEP 604


### PR DESCRIPTION
Safer intake for external contributions. CodeQL (Python, security-and-quality + weekly), Bandit (gates HIGH; B314 docx-XML medium tracked as follow-up), Zizmor (workflow audit, informational — only unpinned-uses today), Dependabot (github-actions). All gates green-able now; ratchet-later philosophy like the ruff E9,F gate.