### PR TITLE
ci(dependabot): group github-actions bumps into one weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       interval: weekly
     commit-message:
       prefix: ci
+    # One PR per week with all action bumps grouped, instead of one PR per action.
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Groups all github-actions version bumps into a single weekly PR instead of one per action.