### PR TITLE
fix(extractor): detect full-width Arabic digits in CJK chapter headings

### DIFF
--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -82,8 +82,12 @@ _CN_NUM_VALUES = {
 }
 _CN_NUM_UNITS = {"十": 10, "百": 100, "千": 1000}
 _CN_NUM_CLASS = "〇零一二两三四五六七八九十百千"
-_CN_CHAPTER = re.compile(rf"^\s*第\s*([0-9{_CN_NUM_CLASS}]+)\s*[章回卷节篇讲]")
-_MD_CN_HEADING = re.compile(rf"^#{{1,6}}\s+第?\s*([{_CN_NUM_CLASS}]+)\s*[·、.:：章回卷节篇讲]")
+# Full-width Arabic digits (U+FF10–U+FF19) are common in Japanese typesetting,
+# e.g. "第１章". int() already parses them (str.isdigit() is True), so only the
+# regex character classes need to accept them.
+_FW_DIGITS = "０-９"
+_CN_CHAPTER = re.compile(rf"^\s*第\s*([0-9{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[章回卷节篇讲]")
+_MD_CN_HEADING = re.compile(rf"^#{{1,6}}\s+第?\s*([{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[·、.:：章回卷节篇讲]")
 
 # Table-of-contents header lines across common languages. Anchored to a whole
 # line (^\s*X\s*$) so an inline "the contents of this chapter" never matches.

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -641,6 +641,17 @@ class TestDetectStructure:
         text = "第一章 绪论\n正文。\n第二章 方法\n更多正文。\n"
         assert detect_structure(text)["chapters_detected"] == 2
 
+    def test_japanese_fullwidth_digit_chapters(self):
+        # Full-width Arabic digits (U+FF10–U+FF19) in "第N章" are common in
+        # Japanese typesetting and must be detected like half-width "第1章".
+        text = "第１章 はじめに\n本文。\n第２章 つぎ\n本文。\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_fullwidth_multi_digit_chapter(self):
+        # Multi-digit full-width numbers ("第１０章") resolve to the right int.
+        text = "第１章 序\n第１０章 終\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
     def test_chinese_di_n_jiang_lecture(self):
         # lecture transcripts numbered 第N讲
         text = "第一讲\n正文\n第二讲\n正文\n第三讲\n正文\n"
@@ -710,6 +721,7 @@ class TestDetectStructure:
         assert _cn_numeral_to_int("二十一") == 21
         assert _cn_numeral_to_int("一百零八") == 108
         assert _cn_numeral_to_int("15") == 15
+        assert _cn_numeral_to_int("１２") == 12  # full-width Arabic digits
         assert _cn_numeral_to_int("不是数字") is None
         assert _cn_numeral_to_int("9999") is None  # out of 1..999 chapter range
 


### PR DESCRIPTION
## Problem

CJK chapter detection (`_CN_CHAPTER` / `_MD_CN_HEADING`) accepts half-width Arabic digits (`第1章`) and CJK numerals (`第十二章`), but **not full-width Arabic digits** (U+FF10–U+FF19). Full-width numbering is common in Japanese typesetting (e.g. `第１章`), so a Japanese book using it was silently missed — `detect_structure` reported `0` chapters even with a clear ToC and chapter starts.

## Fix

Add the full-width digit range (`０-９`) to both CJK chapter-heading regex character classes. `_cn_numeral_to_int` already handles full-width digits (`str.isdigit()` is `True` and `int()` parses them), so the numeral converter needs no change. Latin/Roman detection is untouched.

```
第１章  → 1   （previously: not detected）
第１０章 → 10
第1章   → 1   （unchanged）
第十二章 → 12 （unchanged）
```

## Tests (measure, not assert)

- `test_japanese_fullwidth_digit_chapters` — `第１章 / 第２章` → 2 chapters
- `test_fullwidth_multi_digit_chapter` — `第１章 / 第１０章` → 2 chapters
- added a full-width assertion to `test_chinese_numeral_parsing` (`１２` → 12)

`pytest -q` → 87 passed · `ruff check .` clean. `SKILL.md` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)