### PR TITLE
feat(extractor): detect French/German/Italian/Dutch chapter words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blocks are ignored.
 - Table-of-contents detection extended to Chinese, Japanese, French, German,
   Italian, and Dutch.
+- Chapter detection now recognizes French, German, Italian, and Dutch chapter
+  words (`Chapitre`, `Kapitel`, `Capitolo`, `Hoofdstuk`), matching the
+  table-of-contents languages added previously.
+- Heading-title detection now accepts titles starting with `Ü`/`Û`/`Ý`/`Þ`
+  (e.g. German "Überblick"), which the previous `À–Ú` range excluded.
 
 ### Security
 - **CI security scanning** — added CodeQL (Python, security-and-quality + weekly

--- a/scripts/extractor/utils.py
+++ b/scripts/extractor/utils.py
@@ -51,20 +51,24 @@ def estimate_tokens(text: str) -> int:
 
 
 # Explicit chapter heading: "Chapter 5", "Capítulo 5: ...", "Chapter 1. Intro".
-# Captures the number (bounded to 1..99 — drops years like "2025.") and whatever
-# follows it on the line, so we can reject prose.
+# Also French/German/Italian/Dutch chapter words (chapitre/kapitel/capitolo/
+# hoofdstuk), matching the ToC languages added alongside. "ch.?" stays last so
+# the longer words match in full. Captures the number (bounded to 1..99 — drops
+# years like "2025.") and whatever follows it on the line, so we can reject prose.
 _EXPLICIT_CHAPTER = re.compile(
-    r"^\s*(?:chapter|cap[ií]tulo|ch\.?)\s*(\d{1,2})\b(?P<rest>.*)$", re.IGNORECASE
+    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(\d{1,2})\b(?P<rest>.*)$",
+    re.IGNORECASE,
 )
-# A heading's number is followed by end-of-line, punctuation (". : - —"), or a
-# Capitalized title word. A lowercase continuation ("Chapter 6 explores...",
-# "Chapter 8 are relevant...") is prose / a cross-reference, not a heading.
-_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+[A-ZÀ-Ú0-9\"“(]")
+# A heading's number is followed by end-of-line, punctuation (“. : - —“), or a
+# Capitalized title word. A lowercase continuation (“Chapter 6 explores...”,
+# “Chapter 8 are relevant...”) is prose / a cross-reference, not a heading.
+# The uppercase class is À-Þ so titles starting with Ü/Û (common in German, e.g. “Überblick”) are recognized.
+_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+[A-ZÀ-Þ0-9\"“(]")
 
 # Roman-numeral chapter heading: "I: Loomings", "II. The Carpet-Bag".
 # Requires a separator (":" or ".") and a Capitalized title after it, so a bare
 # "I" or "V." (a page divider / list marker) is not mistaken for a chapter.
-_ROMAN_HEAD = re.compile(r"^\s*([IVXLCDM]+)\s*[:.]\s+[A-ZÀ-Ú\"“(]")
+_ROMAN_HEAD = re.compile(r"^\s*([IVXLCDM]+)\s*[:.]\s+[A-ZÀ-Þ\"“(]")
 _ROMAN_VALUES = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
 
 # Chinese chapter headings. Two common styles:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -725,6 +725,38 @@ class TestDetectStructure:
         assert _cn_numeral_to_int("不是数字") is None
         assert _cn_numeral_to_int("9999") is None  # out of 1..999 chapter range
 
+    def test_french_chapitre(self):
+        assert detect_structure("Chapitre 1\nx\nChapitre 2\nx")["chapters_detected"] == 2
+
+    def test_german_kapitel(self):
+        assert detect_structure("Kapitel 1\nx\nKapitel 2\nx")["chapters_detected"] == 2
+
+    def test_italian_capitolo(self):
+        assert detect_structure("Capitolo 1\nx\nCapitolo 2\nx")["chapters_detected"] == 2
+
+    def test_dutch_hoofdstuk(self):
+        assert detect_structure("Hoofdstuk 1\nx\nHoofdstuk 2\nx")["chapters_detected"] == 2
+
+    def test_german_kapitel_with_title(self):
+        text = "Kapitel 1: Einführung\nx\nKapitel 2: Methoden\nx"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_european_lowercase_cross_reference_not_chapter(self):
+        # A lowercase continuation is prose / a cross-reference, not a heading —
+        # the existing _HEADING_TAIL guard must reject it for the new words too.
+        text = "Kapitel 3 behandelt das Thema ausführlich.\nChapitre 6 explique le contexte ici.\n"
+        assert detect_structure(text)["chapters_detected"] == 0
+
+    def test_german_kapitel_umlaut_title(self):
+        # "Überblick" starts with Ü (U+00DC) — the widened À-Þ range accepts it.
+        text = "Kapitel 1 Anfang\nx\nKapitel 2 Überblick\nx"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_roman_heading_umlaut_title(self):
+        # _ROMAN_HEAD range widened too: a Roman heading with an Ü-title counts.
+        text = "I: Überblick\nbody\nII: Anfang\nbody\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
 
 class TestTextExtraction:
     """Tests for plain-text file extraction."""


### PR DESCRIPTION
## What & why

PR #44 added **table-of-contents** detection for French, German, Italian, and
Dutch, but the **chapter-number** detector (`_EXPLICIT_CHAPTER`) was not extended
to match. So a FR/DE/IT/NL book whose chapters are headed `Chapitre 1` /
`Kapitel 1` / `Capitolo 1` / `Hoofdstuk 1` reported **0 chapters**. This closes
that asymmetry, scoped to exactly the four languages #44 already covers on the
ToC side.

Measured before this PR:

| Heading | `chapters_detected` (before) |
|---|---|
| `Chapter 1` (EN) | works |
| `Capítulo 1` (ES/PT) | works |
| `Chapitre 1` (FR) | **0** |
| `Kapitel 1` (DE) | **0** |
| `Capitolo 1` (IT) | **0** |
| `Hoofdstuk 1` (NL) | **0** |

### Two parts
1. **Chapter words** — added `chapitre`/`kapitel`/`capitolo`/`hoofdstuk` to the
   `_EXPLICIT_CHAPTER` alternation (`ch.?` kept last so the longer words match in
   full; `capitolo` is distinct from `cap[ií]tulo`).
2. **Heading-title guard fix (German robustness)** — the shared title guard used
   the uppercase range `À–Ú` (U+00C0–U+00DA), which stops at `Ú` and so **excluded
   `Ü`**. German chapter titles frequently start with `Ü` ("Überblick",
   "Übersicht"), so `Kapitel 2 Überblick` was silently dropped. Widened the range
   to `À–Þ` (adds `Û Ü Ý Þ`) in both heading-title regexes (`_HEADING_TAIL` and
   `_ROMAN_HEAD`) for consistency. The widening adds uppercase letters only.

## Evidence

8 new tests (all green), plus full-suite regression:

- Chapter words: `Chapitre`/`Kapitel`/`Capitolo`/`Hoofdstuk` → 2 each; German
  title-with-colon → 2.
- Guard: German space-separated Ü-title (`Kapitel 2 Überblick`) → 2; Roman
  Ü-title (`I: Überblick`) → 2.
- Regression guard: lowercase cross-references (`Kapitel 3 behandelt…`,
  `Chapitre 6 explique…`) → 0 — the new words inherit the existing prose
  rejection, so this is no more false-positive-prone than the current English
  behavior.

```
$ pytest -q
95 passed
$ ruff check --select E9,F --target-version py310 scripts/ tests/
All checks passed!
```

Before/after:

```
detect_structure("Kapitel 1 Anfang\nKapitel 2 Überblick")["chapters_detected"]
before: 1   (Ü-title dropped)
after:  2
```

## Checklist
- [x] One focused change (European chapter detection; chapter words + the guard fix that makes the German half actually work)
- [x] Tests added/updated for behavior changes (8 new)
- [x] `ruff check --select E9,F --target-version py310 scripts/ tests/` clean (the CI lint command)
- [x] `pytest -q` green (95 passed)
- [ ] `python3 tools/validate_skill.py SKILL.md` — N/A (SKILL.md unchanged)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no SKILL.md changes; no new dependencies
