### PR TITLE
fix(html): decode entities once in the stdlib parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dependency-free RTF fallback (used when `striprtf` is not installed) now
   decodes `\uN` unicode escapes — smart quotes, dashes, accented letters — instead
   of dropping them and leaving only the ASCII fallback character.
+- The stdlib HTML parser (the fallback for HTML files and EPUB extraction when
+  BeautifulSoup is not installed) no longer decodes HTML entities twice, so
+  double-encoded entities such as `&amp;amp;` survive intact.
 
 ## [1.2.0] — 2026-06-17
 

--- a/book_to_skill/parsers/html.py
+++ b/book_to_skill/parsers/html.py
@@ -31,7 +31,10 @@ class _HTMLTextExtractor(html.parser.HTMLParser):
             self._parts.append(data)
 
     def get_text(self) -> str:
-        return html.unescape("".join(self._parts))
+        # HTMLParser(convert_charrefs=True) already decoded entities in
+        # handle_data; do NOT unescape again or double-encoded entities
+        # (e.g. "&amp;amp;") collapse incorrectly.
+        return "".join(self._parts)
 
 
 def extract_html_content(raw_html: str) -> str:

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1033,3 +1033,35 @@ class TestRtfUnicodeFallback:
         # Two adjacent \uN escapes, each with a \'XX hex fallback, decode cleanly.
         text = self._BS + "u8220" + self._BS + "'93Hi" + self._BS + "u8221" + self._BS + "'94"
         assert strip_rtf_fallback(text) == "“Hi”"
+
+
+class TestHtmlEntityDecoding:
+    """The stdlib HTML parser decodes entities exactly once (not twice)."""
+
+    def _text(self, fragment):
+        # Feed a raw fragment (no block tags) through a fresh stdlib parser.
+        from book_to_skill.parsers.html import _HTMLTextExtractor
+        p = _HTMLTextExtractor()
+        p.feed(fragment)
+        return p.get_text()
+
+    def test_double_encoded_ampersand(self):
+        # The bug: this used to collapse to "&" (decoded twice).
+        assert self._text("&amp;amp;") == "&amp;"
+
+    def test_double_encoded_tag(self):
+        assert self._text("&amp;lt;tag&amp;gt;") == "&lt;tag&gt;"
+
+    def test_single_entities_still_decode(self):
+        assert self._text("&lt;b&gt;") == "<b>"
+        assert self._text("&amp;") == "&"
+
+    def test_numeric_and_named_entities(self):
+        assert self._text("&#233;") == "é"      # decimal numeric
+        assert self._text("&#xE9;") == "é"      # hex numeric
+        assert self._text("&copy;") == "©"      # non-ASCII named entity
+        assert self._text("hello") == "hello"   # plain text
+
+    def test_skip_tag_content_excluded(self):
+        # Confirms the change didn't disturb skip-tag handling.
+        assert self._text("<style>x{}</style>keep") == "keep"


### PR DESCRIPTION
## What & why

`_HTMLTextExtractor` in `book_to_skill/parsers/html.py` is the stdlib HTML→text
converter — the fallback for HTML files when BeautifulSoup isn't installed, and
also reused by the **EPUB** stdlib zipfile fallback (`epub.py` imports it).

It subclasses `html.parser.HTMLParser`, whose default `convert_charrefs=True`
**already decodes** entities in `handle_data`. But `get_text()` then called
`html.unescape(...)` — a **second** decode. Entities were unescaped twice.

Single-encoded entities survive (after the first decode they're no longer
entities), but double-encoded ones collapse incorrectly:

| Input | before | after |
|---|---|---|
| `&amp;amp;` | `&` | `&amp;` |
| `&amp;lt;tag&amp;gt;` | `<tag>` | `&lt;tag&gt;` |
| `&lt;b&gt;` (single) | `<b>` | `<b>` (unchanged) |

Double-encoded entities appear whenever an author writes a literal `&amp;` or
shows example markup, so the fallback silently corrupted them.

## How

Remove the redundant second decode — one line in `get_text()`:

```python
def get_text(self) -> str:
    # HTMLParser(convert_charrefs=True) already decoded entities in
    # handle_data; do NOT unescape again or double-encoded entities
    # (e.g. "&amp;amp;") collapse incorrectly.
    return "".join(self._parts)
```

`convert_charrefs=True` performs a complete, correct single decode using the same
entity table `html.unescape` uses — verified across named (`&copy;`), decimal
(`&#233;`), and hex (`&#xE9;`) entities. So removing the extra call fixes
double-encoded entities **and** keeps single entities correct. `import html`
stays (still referenced via `html.parser`).

## Evidence

5 new tests for `_HTMLTextExtractor`: the two double-encoded cases (the bug),
single-entity regression, decimal/hex/named entity decoding, and a skip-tag
guard.

```
$ pytest -q
121 passed
$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Checklist
- [x] One focused change (stdlib HTML entity decoding)
- [x] Tests added (5 new — first targeted coverage for `_HTMLTextExtractor` entities)
- [x] `ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/` clean
- [x] `pytest -q` green (121 passed)
- [ ] `python3 tools/validate_skill.py SKILL.md` — N/A (SKILL.md unchanged)
- [x] `CHANGELOG.md` updated under `## [Unreleased]` → `### Fixed`
- [x] No new dependencies; BeautifulSoup path and `epub.py` untouched
