### PR TITLE
fix(epub): read content in spine order in the stdlib extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dependency-free DOCX fallback (used when `python-docx` is not installed)
   now reconstructs tables as tab-joined rows in document order, instead of
   flattening each cell onto its own line.
+- The dependency-free EPUB extractor (used when `ebooklib` is not installed) now
+  reads content in true spine (reading) order instead of manifest order, so
+  chapters are no longer scrambled. Content documents not listed in the spine are
+  still included (appended after the spine content).
 
 ## [1.2.0] — 2026-06-17
 

--- a/book_to_skill/parsers/epub.py
+++ b/book_to_skill/parsers/epub.py
@@ -56,15 +56,39 @@ def extract_with_zipfile(epub_path: str) -> str | None:
             opf_path = _find_opf_path(zf)
             opf_dir = posixpath.dirname(opf_path) if opf_path else ""
 
-            # Read OPF spine to get reading order, fall back to sorted xhtml files
+            # Build reading order from the OPF spine (not the manifest's href
+            # order), then append any remaining content docs as a safety net.
             spine_order: list[str] = []
+            seen: set[str] = set()
             if opf_path:
                 opf_text = zf.read(opf_path).decode("utf-8", errors="replace")
-                raw_hrefs = re.findall(r'href=["\']([^"\']+\.(?:xhtml|html))["\']', opf_text)
-                # Resolve hrefs relative to the OPF directory
-                for href in raw_hrefs:
-                    resolved = posixpath.normpath(posixpath.join(opf_dir, href)) if opf_dir else href
-                    spine_order.append(resolved)
+
+                # Manifest: item id -> resolved href. Parse each <item> opening
+                # tag so attribute order (id before/after href) does not matter;
+                # both self-closing <item .../> and <item ...></item> forms work
+                # because all attributes live in the opening tag.
+                manifest: dict[str, str] = {}
+                for item_tag in re.findall(r"<item\b[^>]*?/?>", opf_text):
+                    id_m = re.search(r'\bid=["\']([^"\']+)["\']', item_tag)
+                    href_m = re.search(r'\bhref=["\']([^"\']+)["\']', item_tag)
+                    if id_m and href_m:
+                        href = href_m.group(1)
+                        resolved = posixpath.normpath(posixpath.join(opf_dir, href)) if opf_dir else href
+                        manifest[id_m.group(1)] = resolved
+
+                # Spine: ordered idrefs -> hrefs (true reading order).
+                for idref in re.findall(r'<itemref\b[^>]*?\bidref=["\']([^"\']+)["\']', opf_text):
+                    href = manifest.get(idref)
+                    if href and href not in seen:
+                        spine_order.append(href)
+                        seen.add(href)
+
+                # Safety net: append remaining manifest content documents (e.g. a
+                # nav doc not in the spine) in manifest order, so nothing is lost.
+                for href in manifest.values():
+                    if href.endswith((".html", ".xhtml")) and href not in seen:
+                        spine_order.append(href)
+                        seen.add(href)
 
             html_files = spine_order or sorted(
                 n for n in names if n.endswith((".html", ".xhtml"))

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1141,7 +1141,6 @@ class TestEpubSpineOrder:
     """The stdlib EPUB extractor reads content in spine order, with a safety net."""
 
     def _make_epub(self, tmp_path, opf_xml, files, opf_name="content.opf"):
-        import zipfile
         p = tmp_path / "book.epub"
         with zipfile.ZipFile(p, "w") as zf:
             zf.writestr("mimetype", "application/epub+zip")
@@ -1230,7 +1229,6 @@ class TestEpubSpineOrder:
     def test_no_opf_falls_back_to_sorted_files(self, tmp_path):
         # No container.xml / no OPF at all: the final fallback reads sorted
         # content files from the zip.
-        import zipfile
         p = tmp_path / "noopf.epub"
         with zipfile.ZipFile(p, "w") as zf:
             zf.writestr("mimetype", "application/epub+zip")

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -36,6 +36,7 @@ from book_to_skill.utils import (
 from book_to_skill.config import SUPPORTED_EXTENSIONS
 from book_to_skill.parsers.docx import extract_docx_with_zipfile
 from book_to_skill.parsers.rtf import strip_rtf_fallback
+from book_to_skill.parsers.epub import extract_with_zipfile
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1134,3 +1135,106 @@ class TestDocxTableReconstruction:
         )
         out = extract_docx_with_zipfile(self._make_docx(tmp_path, body))
         assert out == "Before\nInside SDT\nAfter"
+
+
+class TestEpubSpineOrder:
+    """The stdlib EPUB extractor reads content in spine order, with a safety net."""
+
+    def _make_epub(self, tmp_path, opf_xml, files, opf_name="content.opf"):
+        import zipfile
+        p = tmp_path / "book.epub"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr(
+                "META-INF/container.xml",
+                '<?xml version="1.0"?>'
+                '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">'
+                f'<rootfiles><rootfile full-path="{opf_name}" media-type="application/oebps-package+xml"/></rootfiles>'
+                '</container>',
+            )
+            zf.writestr(opf_name, opf_xml)
+            for name, html in files.items():
+                zf.writestr(name, html)
+        return str(p)
+
+    def _doc(self, text):
+        return f"<html><body><p>{text}</p></body></html>"
+
+    def test_spine_order_overrides_manifest_order(self, tmp_path):
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item id="c2" href="ch2.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/>'
+            '</manifest><spine><itemref idref="c1"/><itemref idref="c2"/></spine></package>'
+        )
+        files = {"ch1.xhtml": self._doc("FIRST"), "ch2.xhtml": self._doc("SECOND")}
+        out = extract_with_zipfile(self._make_epub(tmp_path, opf, files))
+        assert out.index("FIRST") < out.index("SECOND")
+
+    def test_non_spine_doc_kept_as_safety_net_after_spine(self, tmp_path):
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/>'
+            '<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>'
+            '</manifest><spine><itemref idref="c1"/></spine></package>'
+        )
+        files = {"ch1.xhtml": self._doc("CONTENT"), "nav.xhtml": self._doc("NAVTOC")}
+        out = extract_with_zipfile(self._make_epub(tmp_path, opf, files))
+        assert "NAVTOC" in out
+        assert out.index("CONTENT") < out.index("NAVTOC")
+
+    def test_item_attribute_order_robust(self, tmp_path):
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item href="only.xhtml" id="c1" media-type="application/xhtml+xml"/>'
+            '</manifest><spine><itemref idref="c1"/></spine></package>'
+        )
+        files = {"only.xhtml": self._doc("ONLY")}
+        out = extract_with_zipfile(self._make_epub(tmp_path, opf, files))
+        assert "ONLY" in out
+
+    def test_spine_absent_uses_safety_net(self, tmp_path):
+        # No <spine>: the manifest content doc is still included via the safety net.
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item id="a" href="a.xhtml" media-type="application/xhtml+xml"/>'
+            '</manifest></package>'
+        )
+        files = {"a.xhtml": self._doc("ALPHA")}
+        out = extract_with_zipfile(self._make_epub(tmp_path, opf, files))
+        assert "ALPHA" in out
+
+    def test_opf_in_subdir_resolves_hrefs(self, tmp_path):
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"/>'
+            '</manifest><spine><itemref idref="c1"/></spine></package>'
+        )
+        files = {"OEBPS/ch1.xhtml": self._doc("SUBDIR")}
+        out = extract_with_zipfile(
+            self._make_epub(tmp_path, opf, files, opf_name="OEBPS/content.opf")
+        )
+        assert "SUBDIR" in out
+
+    def test_non_self_closing_item_tag(self, tmp_path):
+        # <item ...></item> (non-self-closing) is parsed via its opening tag.
+        opf = (
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"><manifest>'
+            '<item id="c1" href="ch1.xhtml" media-type="application/xhtml+xml"></item>'
+            '</manifest><spine><itemref idref="c1"></itemref></spine></package>'
+        )
+        files = {"ch1.xhtml": self._doc("NONSELFCLOSE")}
+        out = extract_with_zipfile(self._make_epub(tmp_path, opf, files))
+        assert "NONSELFCLOSE" in out
+
+    def test_no_opf_falls_back_to_sorted_files(self, tmp_path):
+        # No container.xml / no OPF at all: the final fallback reads sorted
+        # content files from the zip.
+        import zipfile
+        p = tmp_path / "noopf.epub"
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("a.xhtml", self._doc("AAA"))
+            zf.writestr("b.xhtml", self._doc("BBB"))
+        out = extract_with_zipfile(str(p))
+        assert "AAA" in out and "BBB" in out


### PR DESCRIPTION
## Summary (Required)

The stdlib EPUB extractor (used when `ebooklib` is not installed) read content in
`<manifest>` document order instead of `<spine>` reading order, so chapters came
out scrambled and the nav document was interleaved. This PR makes it read in true
spine order, keeping a safety net that still includes non-spine content docs.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `extract_with_zipfile` in `book_to_skill/parsers/epub.py` scraped every
  `href` in the OPF (the `<manifest>`, in document order) rather than resolving the
  `<spine>` reading order. Root cause: it never read `<itemref>` / mapped ids to
  hrefs. Chapters were emitted in manifest order, and manifest-only docs (nav) were
  interleaved into the content.
- **Improves:** content is now emitted in true spine order; non-spine content
  documents are appended after the spine content (safety net) so nothing is dropped.

## Motivation & context (Required)
The dependency-free EPUB path is what runs on a base install. Wrong chapter order
degrades every downstream step (chapter mapping, summaries). `count_epub_chapters`
already reads `<itemref>`, so the spine data was right there but unused.
Closes #n/a (no tracking issue; found while auditing the stdlib parser fallbacks).

## How it works (Required for anything non-trivial)

Build a manifest `id → href` map by parsing each `<item>` tag (extracting `id` and
`href` independently, so attribute order doesn't matter), then emit:
1. spine items in `<itemref>` order (deduped via a `seen` set);
2. **safety net** — remaining manifest `.html`/`.xhtml` docs not in the spine,
   appended after;
3. the existing `spine_order or sorted(content files)` fallback when no OPF/spine
   parses.

OPF-relative href resolution is unchanged. Regex-based like the rest of the file
(no XML parser → no XXE). `count_epub_chapters`, `_find_opf_path`, and the
`ebooklib` path are untouched.

## Evidence (Required)
- **Tests:** 7 new tests in `TestEpubSpineOrder` — spine-overrides-manifest order,
  safety-net (non-spine doc kept, after spine content), `<item>` attribute-order
  robustness, non-self-closing `<item>`, spine-absent → safety net, no-OPF → sorted
  fallback, and OPF-in-subdir href resolution.
- **Before / after:** minimal EPUB whose manifest lists `ch2` before `ch1` while the
  spine reads `ch1, ch2`:

```
before: 'SECOND chapter text ... FIRST chapter text ... NAV ...'   # manifest order
after:  'FIRST chapter text ... SECOND chapter text ... NAV ...'   # spine order

$ pytest -q
133 passed
$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Orthogonal to the open PR queue (none touch `epub.py`). The safety net is a
deliberate choice: non-spine content docs (e.g. an EPUB2 nav) are kept rather than
dropped, just moved after the spine content.
