### PR TITLE
fix(text): decode UTF-16/UTF-32 files by BOM in read_text_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PyPDF2` is end-of-life and no longer receives security fixes (#54).
 
 ### Fixed
+- Text files (`.txt`, `.md`, `.rst`, `.adoc`, `.html`, `.rtf`) saved as UTF-16 or
+  UTF-32 (e.g. Windows Notepad "Unicode" or PowerShell output) are now decoded by
+  their byte-order mark instead of being read as `cp1252`/`latin-1` mojibake.
 - The dependency-free RTF fallback (used when `striprtf` is not installed) now
   decodes `\uN` unicode escapes — smart quotes, dashes, accented letters — instead
   of dropping them and leaving only the ASCII fallback character.

--- a/book_to_skill/parsers/text.py
+++ b/book_to_skill/parsers/text.py
@@ -2,14 +2,37 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+# Byte-order marks, longest first: the UTF-32 LE BOM ("ff fe 00 00") starts with
+# the UTF-16 LE BOM ("ff fe"), so UTF-32 must be checked before UTF-16.
+_BOMS = (
+    (b"\xef\xbb\xbf", "utf-8-sig"),
+    (b"\xff\xfe\x00\x00", "utf-32"),
+    (b"\x00\x00\xfe\xff", "utf-32"),
+    (b"\xff\xfe", "utf-16"),
+    (b"\xfe\xff", "utf-16"),
+)
+
 
 def read_text_file(path: str) -> str | None:
-    for encoding in ("utf-8-sig", "utf-8", "cp1252", "latin-1"):
+    try:
+        data = Path(path).read_bytes()
+    except Exception as e:
+        print(f"  [warn] read_text_file failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return None
+
+    # Decode by BOM when present (the utf-16/utf-32 codecs strip the BOM and
+    # auto-select byte order).
+    for bom, encoding in _BOMS:
+        if data.startswith(bom):
+            try:
+                return data.decode(encoding)
+            except (UnicodeDecodeError, LookupError):
+                break
+
+    # No (usable) BOM: fall back to the prior chain for BOM-less files.
+    for encoding in ("utf-8", "cp1252", "latin-1"):
         try:
-            return Path(path).read_text(encoding=encoding)
+            return data.decode(encoding)
         except UnicodeDecodeError:
             continue
-        except Exception as e:
-            print(f"  [warn] read_text_file failed: {type(e).__name__}: {e}", file=sys.stderr)
-            return None
     return None

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -34,6 +34,7 @@ from book_to_skill.utils import (
     main,
 )
 from book_to_skill.config import SUPPORTED_EXTENSIONS
+from book_to_skill.parsers.text import read_text_file
 from book_to_skill.parsers.docx import extract_docx_with_zipfile
 from book_to_skill.parsers.rtf import strip_rtf_fallback
 from book_to_skill.parsers.epub import extract_with_zipfile
@@ -1236,3 +1237,50 @@ class TestEpubSpineOrder:
             zf.writestr("b.xhtml", self._doc("BBB"))
         out = extract_with_zipfile(str(p))
         assert "AAA" in out and "BBB" in out
+
+
+class TestTextEncodingDetection:
+    """read_text_file decodes UTF-16/UTF-32 by BOM, with a BOM-less fallback."""
+
+    SAMPLE = "Café — naïve résumé\nSecond line"
+
+    def _write(self, tmp_path, raw_bytes):
+        p = tmp_path / "sample.txt"
+        p.write_bytes(raw_bytes)
+        return str(p)
+
+    def test_utf16_le_bom(self, tmp_path):
+        raw = b"\xff\xfe" + self.SAMPLE.encode("utf-16-le")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_utf16_be_bom(self, tmp_path):
+        raw = b"\xfe\xff" + self.SAMPLE.encode("utf-16-be")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_utf32_le_bom(self, tmp_path):
+        raw = b"\xff\xfe\x00\x00" + self.SAMPLE.encode("utf-32-le")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_utf8_bom(self, tmp_path):
+        raw = b"\xef\xbb\xbf" + self.SAMPLE.encode("utf-8")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_utf8_no_bom(self, tmp_path):
+        raw = self.SAMPLE.encode("utf-8")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_cp1252_no_bom(self, tmp_path):
+        # 0xE9 (é) is valid cp1252 but not a valid standalone utf-8 byte.
+        raw = "café".encode("cp1252")
+        assert read_text_file(self._write(tmp_path, raw)) == "café"
+
+    def test_ascii_no_bom(self, tmp_path):
+        assert read_text_file(self._write(tmp_path, b"hello world")) == "hello world"
+
+    def test_utf32_be_bom(self, tmp_path):
+        raw = b"\x00\x00\xfe\xff" + self.SAMPLE.encode("utf-32-be")
+        assert read_text_file(self._write(tmp_path, raw)) == self.SAMPLE
+
+    def test_empty_file_returns_empty_string(self, tmp_path):
+        # An empty file decodes to "" (not None, which is reserved for read errors).
+        assert read_text_file(self._write(tmp_path, b"")) == ""


### PR DESCRIPTION
## Summary (Required)

`read_text_file` (the dependency-free text reader used by the text/Markdown/HTML/RTF
parsers) tried encodings `utf-8-sig → utf-8 → cp1252 → latin-1`. Because cp1252/latin-1
accept almost any bytes, UTF-16/UTF-32 files were never decoded correctly — they came
back as mojibake with NUL bytes. This PR decodes by byte-order mark first, then falls
back to the same chain for BOM-less files.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `book_to_skill/parsers/text.py` returned mojibake for UTF-16/UTF-32 files.
  Root cause: cp1252/latin-1 accept any bytes, so a UTF-16 file never reached a correct
  decode. Now the file's bytes are read once and decoded by BOM (`utf-8-sig`, `utf-16`,
  `utf-32`), with UTF-32 BOMs checked before UTF-16 (the UTF-32 LE BOM `ff fe 00 00`
  starts with the UTF-16 LE BOM `ff fe`).
- **Improves:** correct text for Windows-origin files (Notepad "Unicode"/"Unicode big
  endian", PowerShell `>` output) across `.txt`, `.md`, `.rst`, `.adoc`, `.html`, `.rtf`.

## Motivation & context (Required)
UTF-16 is a common Windows text encoding; silently extracting it as mojibake corrupts
the source text and the consolidated UTF-8 output. Found while auditing the
dependency-free parser fallbacks.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
Read bytes once; match a longest-first BOM table (`utf-8-sig` / `utf-32` / `utf-16`);
on a BOM match decode with that codec (the utf-16/utf-32 codecs strip the BOM and pick
byte order); if the BOM decode fails (truncated), fall through. BOM-less files use the
unchanged `utf-8 → cp1252 → latin-1` chain (dropping `utf-8-sig`, which is identical to
`utf-8` for BOM-less input). The read-failure path (`except → warn → None`) is preserved.

## Evidence (Required)
- **Tests:** 9 new tests in `TestTextEncodingDetection` — UTF-16 LE/BE, UTF-32 LE/BE,
  UTF-8 BOM, UTF-8 no-BOM, cp1252 no-BOM, ASCII, and empty-file → "".
- **Before / after:** a UTF-16 LE file of `"Café — naïve résumé\nSecond line"`:

```
before: 'ÿþC\x00a\x00f\x00é\x00 \x00\x14 …'   # cp1252/latin-1 mojibake
after:  'Café — naïve résumé\nSecond line'

$ pytest -q
142 passed
$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Orthogonal to the open PR queue (none touch `text.py`). BOM-less UTF-16 (no detector) is
intentionally left to the fallback chain, as before — out of scope without adding a
charset-detection dependency.
