### PR TITLE
fix(pdf): decode pdftotext output as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PyPDF2` is end-of-life and no longer receives security fixes (#54).
 
 ### Fixed
+- PDF text extracted via `pdftotext` is now decoded as UTF-8 rather than the
+  process locale encoding, so accented characters and punctuation are no longer
+  mojibake on non-UTF-8 locales (e.g. Windows).
 - Text files (`.txt`, `.md`, `.rst`, `.adoc`, `.html`, `.rtf`) saved as UTF-16 or
   UTF-32 (e.g. Windows Notepad "Unicode" or PowerShell output) are now decoded by
   their byte-order mark instead of being read as `cp1252`/`latin-1` mojibake.

--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -13,7 +13,8 @@ def extract_with_pdftotext(pdf_path: str) -> str | None:
         pdf_path = os.path.abspath(pdf_path)
         result = subprocess.run(
             ["pdftotext", "-layout", pdf_path, "-"],
-            capture_output=True, text=True, timeout=120
+            capture_output=True, text=True, timeout=120,
+            encoding="utf-8", errors="replace",
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -34,6 +34,7 @@ from book_to_skill.utils import (
     main,
 )
 from book_to_skill.config import SUPPORTED_EXTENSIONS
+from book_to_skill.parsers import pdf as pdf_parser
 from book_to_skill.parsers.text import read_text_file
 from book_to_skill.parsers.docx import extract_docx_with_zipfile
 from book_to_skill.parsers.rtf import strip_rtf_fallback
@@ -1284,3 +1285,26 @@ class TestTextEncodingDetection:
     def test_empty_file_returns_empty_string(self, tmp_path):
         # An empty file decodes to "" (not None, which is reserved for read errors).
         assert read_text_file(self._write(tmp_path, b"")) == ""
+
+
+class TestPdftotextEncoding:
+    """pdftotext output (UTF-8) is decoded as UTF-8, not the locale encoding."""
+
+    def test_pdftotext_decodes_as_utf8(self, monkeypatch):
+        captured = {}
+
+        class _Result:
+            returncode = 0
+            stdout = "Café — naïve"
+
+        monkeypatch.setattr(pdf_parser.shutil, "which", lambda name: "/usr/bin/pdftotext")
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return _Result()
+
+        monkeypatch.setattr(pdf_parser.subprocess, "run", fake_run)
+
+        assert pdf_parser.extract_with_pdftotext("x.pdf") == "Café — naïve"
+        assert captured.get("encoding") == "utf-8"
+        assert captured.get("errors") == "replace"


### PR DESCRIPTION
## Summary (Required)

`extract_with_pdftotext` ran `subprocess.run(..., text=True)` with no `encoding=`,
so `pdftotext`'s UTF-8 output was decoded using the process **locale** encoding.
On a non-UTF-8 locale (Windows `cp1252`, a minimal `C`-locale container) that
produces mojibake. This pins the decode to UTF-8.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `book_to_skill/parsers/pdf.py` decoded `pdftotext` output with the
  locale encoding instead of UTF-8. Added `encoding="utf-8", errors="replace"` to
  the `subprocess.run` call so extracted PDF text is correct regardless of locale.

## Motivation & context (Required)
`pdftotext` emits UTF-8; Python's `text=True` decodes with
`locale.getpreferredencoding()`, which is not UTF-8 on Windows or a bare `C`
locale — silently corrupting accented characters, smart quotes, and dashes. Same
encoding-hardening as the recent RTF/HTML/text fixes.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
One-line change: pass `encoding="utf-8", errors="replace"` to the existing
`subprocess.run`. `errors="replace"` keeps a stray non-UTF-8 byte from aborting
extraction. Only `extract_with_pdftotext` is touched; `count_pages`' `pdfinfo`
call parses an integer only, so its decoding is irrelevant and left untouched.

## Evidence (Required)
- **Tests:** `TestPdftotextEncoding.test_pdftotext_decodes_as_utf8` mocks
  `subprocess.run` and asserts the call passes `encoding="utf-8"` /
  `errors="replace"` and that stdout is returned intact. (No live `pdftotext`
  binary needed.)

```
$ pytest -q
143 passed
$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
