### PR TITLE
feat: detect Korean chapter headings and standalone numeric dividers

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -93,6 +93,30 @@ _FW_DIGITS = "０-９"
 _CN_CHAPTER = re.compile(rf"^\s*第\s*([0-9{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[章回卷节篇讲]")
 _MD_CN_HEADING = re.compile(rf"^#{{1,6}}\s+第?\s*([{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[·、.:：章回卷节篇讲]")
 
+# Korean chapter headings. Two safe styles:
+#   1. "제N장" / "제 12 화" / "제1부" — the 제 prefix (Hangul "je-") is an
+#      unambiguous chapter marker, so any classifier (장/화/부/편/강/과) is safe.
+#   2. bare "N강" / "N화" / "N부" — common lecture/episode/part units. "N장" is
+#      DELIBERATELY excluded here: 장 is also the everyday counter for flat sheets
+#      ("사진 10장"), so a bare number + 장 would false-match prose. The 강/화/부
+#      units are not everyday counters, and _HEADING_TAIL still gates the tail so
+#      "3화보다" (prose cross-reference) is rejected. Arabic + full-width digits
+#      only (Sino-Korean numerals like 제삼장 are rare and skipped).
+_KO_CHAPTER = re.compile(rf"^\s*제\s*([0-9{_FW_DIGITS}]{{1,2}})\s*[장화부편강과]")
+_KO_UNIT = re.compile(rf"^\s*([0-9{_FW_DIGITS}]{{1,2}})\s*[강화부](?P<rest>.*)$")
+# Korean-aware heading tail for the bare "N강" unit. Unlike _HEADING_TAIL (which
+# expects a Latin capital title word), a Korean title starts with Hangul, so we
+# accept: end-of-line, a separator, or whitespace-then-any-title-char. A unit
+# followed DIRECTLY by a Hangul particle ("4강은", "3화보다" — no space) is prose
+# cross-reference and is rejected.
+_KO_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–·、]|^\s+\S")
+# Standalone numeric section divider whose whole line is just "N." (1..99 + a
+# period), e.g. "01.", "2.", "12.". Common in Korean (and other) publishing where
+# the chapter number is a divider and the title sits on the following line(s).
+# Requiring the line to be ONLY "N." — nothing after the period — keeps numbered
+# list items ("1. Buy milk"), step labels ("1단계"), and years ("2025.") out.
+_NUM_DIVIDER = re.compile(rf"^\s*([0-9{_FW_DIGITS}]{{1,2}})\.\s*$")
+
 # Table-of-contents header lines across common languages. Anchored to a whole
 # line (^\s*X\s*$) so an inline "the contents of this chapter" never matches.
 _TOC_HEADERS = (
@@ -246,6 +270,18 @@ def _chapter_number(line: str) -> int | None:
     cm = _CN_CHAPTER.match(s) or _MD_CN_HEADING.match(s)
     if cm:
         return _cn_numeral_to_int(cm.group(1))
+    km = _KO_CHAPTER.match(s)
+    if km:
+        n = int(km.group(1))
+        return n if 1 <= n <= 99 else None
+    ku = _KO_UNIT.match(s)
+    if ku and _KO_HEADING_TAIL.match(ku.group("rest")):
+        n = int(ku.group(1))
+        return n if 1 <= n <= 99 else None
+    nd = _NUM_DIVIDER.match(s)
+    if nd:
+        n = int(nd.group(1))
+        return n if 1 <= n <= 99 else None
     return None
 
 

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -547,6 +547,32 @@ class TestDetectStructure:
         result = detect_structure(text)
         assert result["chapters_detected"] == 2
 
+    def test_detects_chapters_korean_je_marker(self):
+        # "제N장/화/부/편/강/과" — the 제 prefix is an unambiguous chapter marker.
+        text = "제1장 시작하며\n본문입니다.\n제 2 화 전개\n제5부 부록"
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_detects_chapters_korean_lecture_unit(self):
+        # bare "N강/N화/N부" lecture/episode units (장 excluded — it's the everyday
+        # counter for flat sheets, e.g. "사진 10장").
+        text = "4강 마무리 강의\n내용\n5강 정리"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_korean_counter_is_not_a_chapter(self):
+        # 장 as a sheet counter and units glued to a particle must not match.
+        text = "사진 10장을 준비했다. 4강은 어렵고 3화보다 쉽다. 표 2개."
+        assert detect_structure(text)["chapters_detected"] == 0
+
+    def test_detects_numeric_divider_lines(self):
+        # A line that is only "N." (common in Korean publishing; the title sits on
+        # the next line). List items / step labels / years must not match.
+        text = "01.\n첫 번째 장 제목\n02.\n두 번째 장 제목"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_numeric_list_item_is_not_a_divider(self):
+        text = "1. Buy milk\n2. Buy eggs\n1단계 준비\n2025."
+        assert detect_structure(text)["chapters_detected"] == 0
+
     def test_detects_toc(self):
         text = "Table of Contents\n1. Intro\n2. Body"
         result = detect_structure(text)


### PR DESCRIPTION
## Problem

Korean books and lecture notes are reported as **0 chapters** by `detect_structure()`, because chapter detection only recognizes Latin (`Chapter N`), Roman (`I: Title`), and CJK (`第N章`, `## 一`) heading styles. Real-world Korean sources use `제N장` markers and standalone `01.` dividers, so their chapter mapping in Step 3 falls back to a heading scan that misses everything.

Tested on a real 102-page Korean ebook: **0 → 8 chapters detected** after this change.

## What this adds

Three Korean-common heading styles in `_chapter_number()`:

1. **`제N장 / 제N화 / 제N부 / 제N편 / 제N강 / 제N과`** — the `제` prefix (Hangul *je-*) is an unambiguous chapter marker, mirroring the existing `第N章` handling.
2. **bare `N강 / N화 / N부`** lecture / episode / part units, gated by a Korean-aware heading tail (`_KO_HEADING_TAIL`) so a unit glued to a particle (`4강은`, `3화보다` — no space) is treated as prose and rejected. **`N장` is deliberately excluded** — `장` is also the everyday counter for flat sheets (`사진 10장` = "10 photos"), which would false-match prose.
3. **standalone `N.` divider lines** (e.g. `01.` on its own line with the title on the following line — very common in Korean publishing). Requiring the *whole line* to be only `N.` keeps numbered list items (`1. Buy milk`), step labels (`1단계`), and years (`2025.`) out.

Arabic + full-width digits only (Sino-Korean numerals like `제삼장` are rare and skipped). **Existing Latin / Roman / CJK detection is unchanged.**

## Tests

Adds 5 tests to `TestStructureDetection` covering positives (제N장, N강, `01.` dividers) and the excluded false-positives (sheet counters, particle-glued units, list items, step labels, years). Existing English/Chinese detection tests still pass.

## Notes

- No new dependencies; pure regex additions.
- Motivated by real usage converting a Korean ebook into a skill; happy to adjust naming or scope (e.g. gate the bare `N.` divider more tightly) if you prefer.
