### PR TITLE
feat: detect `Chapter <Roman>` and Thai chapter headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Thai chapter headings** — `บทที่ N`, `ตอนที่ N` and `ภาคที่ N` are now detected as
+  chapter boundaries, with Thai numerals (๐–๙) as well as Arabic digits. Thai-language
+  books previously had no heading detection at all and fell back to length-based
+  splitting. Ordinary words that begin with a chapter word (`บทความ`, `ตอนนี้`) are not
+  treated as headings.
+
 ### Documentation
 - Clarified the two install paths so they are not confused: **`git clone` into a
   skills folder** registers the `/book-to-skill` agent skill (Claude Code / Copilot
@@ -35,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PyPDF2` is end-of-life and no longer receives security fixes (#54).
 
 ### Fixed
+- **`Chapter I.` — a chapter word followed by a Roman numeral — is now detected.** It
+  matched neither existing pattern (`_EXPLICIT_CHAPTER` required Arabic digits after the
+  chapter word; `_ROMAN_HEAD` required the numeral to start the line), so books using
+  this common form segmented on footnote cross-references instead of chapters. Measured
+  on Project Gutenberg #132 (*The Art of War*, Giles translation): 2 detected "chapters",
+  both footnote citations, become the 13 real headings.
 - PDF text extracted via `pdftotext` is now decoded as UTF-8 rather than the
   process locale encoding, so accented characters and punctuation are no longer
   mojibake on non-UTF-8 locales (e.g. Windows).

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -56,7 +56,7 @@ def estimate_tokens(text: str) -> int:
 # the longer words match in full. Captures the number (bounded to 1..99 — drops
 # years like "2025.") and whatever follows it on the line, so we can reject prose.
 _EXPLICIT_CHAPTER = re.compile(
-    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(\d{1,2})\b(?P<rest>.*)$",
+    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(?:(\d{1,2})|(?P<roman>[IVXLCDM]{1,7}))\b(?P<rest>.*)$",
     re.IGNORECASE,
 )
 # A heading's number is followed by end-of-line, punctuation (“. : - —“), or a
@@ -92,6 +92,16 @@ _CN_NUM_CLASS = "〇零一二两三四五六七八九十百千"
 _FW_DIGITS = "０-９"
 _CN_CHAPTER = re.compile(rf"^\s*第\s*([0-9{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[章回卷节篇讲]")
 _MD_CN_HEADING = re.compile(rf"^#{{1,6}}\s+第?\s*([{_FW_DIGITS}{_CN_NUM_CLASS}]+)\s*[·、.:：章回卷节篇讲]")
+
+# Thai chapter headings: "บทที่ 3", "บทที่ ๑๒", "ตอนที่ ๘๗", "ภาคที่ 2".
+# Thai digits (U+0E50-U+0E59) are positional like Arabic — unlike the Chinese
+# numerals above they need no unit composition, only a digit remap. Optional
+# Markdown "#" prefix so "## บทที่ ๑" is recognized in converted ebooks.
+_TH_DIGITS = "๐-๙"
+_TH_DIGIT_MAP = str.maketrans("๐๑๒๓๔๕๖๗๘๙", "0123456789")
+_TH_CHAPTER = re.compile(
+    rf"^\s*(?:#{{1,6}}\s+)?(?:บทที่|ตอนที่|ภาคที่|บท|ตอน|ภาค)\s*([0-9{_TH_DIGITS}]+)\b"
+)
 
 # Table-of-contents header lines across common languages. Anchored to a whole
 # line (^\s*X\s*$) so an inline "the contents of this chapter" never matches.
@@ -239,13 +249,18 @@ def _chapter_number(line: str) -> int | None:
         return None
     m = _EXPLICIT_CHAPTER.match(s)
     if m and _HEADING_TAIL.match(m.group("rest")):
-        return int(m.group(1))
+        if m.group(1):
+            return int(m.group(1))
+        return _roman_to_int(m.group("roman").upper())
     rm = _ROMAN_HEAD.match(s)
     if rm:
         return _roman_to_int(rm.group(1))
     cm = _CN_CHAPTER.match(s) or _MD_CN_HEADING.match(s)
     if cm:
         return _cn_numeral_to_int(cm.group(1))
+    tm = _TH_CHAPTER.match(s)
+    if tm:
+        return int(tm.group(1).translate(_TH_DIGIT_MAP))
     return None
 
 

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -548,6 +548,50 @@ class TestDetectStructure:
         result = detect_structure(text)
         assert result["chapters_detected"] == 2
 
+    def test_detects_chapter_word_with_roman_numeral(self):
+        """`Chapter I.` — the combination of the word plus a Roman numeral.
+
+        Regression: each half worked alone (`Chapter 1` via _EXPLICIT_CHAPTER,
+        `I. Loomings` via _ROMAN_HEAD) but the combination matched neither, so
+        books using it fell back to no segmentation. Project Gutenberg's
+        `The Art of War` (#132) is one: 13 such headings, 0 detected, while two
+        footnote cross-references (`ch. 71.]`) were picked up instead.
+        """
+        text = "\n".join(
+            "Chapter %s. Section\nBody text here." % r
+            for r in ("I", "II", "III", "IV", "V")
+        )
+        assert detect_structure(text)["chapters_detected"] == 5
+
+    def test_detects_thai_chapters(self):
+        """Thai headings: `บทที่ N` / `ตอนที่ N`, with Thai or Arabic digits."""
+        text = (
+            "บทที่ ๑ ว่าด้วยการวางแผน\nเนื้อหา\n"
+            "บทที่ ๒ ว่าด้วยการรบ\nเนื้อหา\n"
+            "บทที่ 3 ว่าด้วยกลยุทธ์\nเนื้อหา"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_thai_episode_headings_and_markdown_prefix(self):
+        text = "## ตอนที่ ๘๖ เรื่องหนึ่ง\nเนื้อหา\n## ตอนที่ ๘๗ เรื่องสอง\nเนื้อหา"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_thai_prose_is_not_a_chapter_heading(self):
+        """`บทความ` (article) and `ตอนนี้` (now) start with the chapter words
+        but are ordinary prose — they must not be treated as headings."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("บทความนี้ยาวมากและมีรายละเอียดเยอะ") is None
+        assert _chapter_number("ตอนนี้เรามาดูกันว่าเกิดอะไรขึ้น") is None
+
+    def test_roman_footnote_reference_is_not_a_chapter(self):
+        """Scholarly cross-references must stay rejected after the Roman change."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("V. § 19, note.") is None
+        assert _chapter_number("VI. § 21:\u2014") is None
+        assert _chapter_number("Chapter 6 explores the topic in depth") is None
+
     def test_detects_toc(self):
         text = "Table of Contents\n1. Intro\n2. Body"
         result = detect_structure(text)


### PR DESCRIPTION
## Summary (Required)

Two chapter-heading forms were silently skipped by the segmenter: `Chapter I.` (chapter
word followed by a Roman numeral) and Thai headings (`บทที่ N` / `ตอนที่ N` / `ภาคที่ N`).
Books using either form were segmented on the wrong lines — on Project Gutenberg #132
(*The Art of War*) the segmenter found 2 "chapters", both of which were footnote
cross-references rather than real headings.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `Chapter I. LAYING PLANS` was detected as a heading by neither regex.
  `_EXPLICIT_CHAPTER` requires Arabic digits after the chapter word, and `_ROMAN_HEAD`
  requires the line to *start* with the numeral — a chapter word followed by a Roman
  numeral falls between the two. Books in this very common Gutenberg form segmented on
  footnote citations instead of chapters.
- **Adds:** Thai chapter-heading detection — `บทที่`, `ตอนที่`, `ภาคที่`, with Thai
  numerals (๐–๙, U+0E50–U+0E59) as well as Arabic digits. For Thai-language books,
  which previously had no heading detection at all.

## Motivation & context (Required)

Both forms surfaced while converting public-domain books. The failure is silent: no
error, no warning — the skill is simply built from the wrong segments, and the only way
to notice is to read the output and count. Thai support matters because Thai books
currently fall back to length-based splitting.

Closes #n/a — found while converting books, no issue was filed first.

## How it works (Required for anything non-trivial)

Roman numerals: `_EXPLICIT_CHAPTER` now accepts a Roman numeral where it previously
required Arabic digits, so the chapter-word branch covers `Chapter I.` without touching
`_ROMAN_HEAD` (bare `I.` at line start keeps working as before).

Thai numerals are positional like Arabic — unlike the CJK numerals already supported,
they need only a digit remap, not unit composition — so they are added alongside the
existing Chinese support, following the same shape.

`บทความ` (article) and `ตอนนี้` (now) are ordinary words that begin with the chapter
words; the pattern requires the number to follow, so neither is treated as a heading.
Tests cover both.

**Rejected alternative — widening `_HEADING_TAIL` with `\w`:** `\w` also admits
lowercase Latin, which would make `Chapter 6 explores the topic` parse as a heading.
The character class instead lists the Thai and CJK ranges explicitly, so uppercase-only
behaviour for Latin is preserved.

## Evidence (Required)

- **Tests:** 5 tests added in `tests/test_book_to_skill.py` — `Chapter I.` detection,
  Thai headings with Thai numerals, Thai headings with Arabic digits, and the two
  negative cases (`บทความ`, `ตอนนี้`). Full suite: 148 passed.
- **Before / after:** measured on Project Gutenberg #132 (*The Art of War*, Giles
  translation), which uses `Chapter I.` for all 13 chapters:

| | before | after |
|---|---|---|
| chapters detected | 2 | 13 |
| what was detected | `ch. 71.]`, `ch. 69. "I dare not...` | the 13 real headings |

Both pre-existing detections were footnote cross-references, so the book segmented on
citations rather than chapters.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (`SKILL.md` unchanged)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Related: #70 mentions fidelity checking; this is a different failure mode — segmentation
silently producing the wrong chapters, rather than bad summaries from correct chapters.
