### PR TITLE
Decode Cyrillic / non-Latin fonts that pdftotext silently drops

### DIFF
--- a/book_to_skill/config.py
+++ b/book_to_skill/config.py
@@ -25,6 +25,7 @@ SUPPORTED_EXTENSIONS = {
 
 PYTHON_DEPENDENCIES = {
     "docling": "docling",
+    "pdfplumber": "pdfplumber",
     "pypdf": "pypdf",
     "pdfminer": "pdfminer.six",
     "ebooklib": "ebooklib",

--- a/book_to_skill/dependencies.py
+++ b/book_to_skill/dependencies.py
@@ -14,11 +14,11 @@ from book_to_skill.config import PYTHON_DEPENDENCIES, HTML_EXTENSIONS
 DEPENDENCY_GROUPS = [
     {
         "label": "PDF (text-heavy)",
-        "modules": ["pypdf", "pdfminer"],
+        "modules": ["pdfplumber", "pypdf", "pdfminer"],
         "any_of_modules": True,
         "any_tool_suffices": True,
         "system": [("pdftotext", "poppler-utils", "sudo apt install poppler-utils")],
-        "note": "any one of pdftotext / pypdf / pdfminer is enough",
+        "note": "any one is enough; pdfplumber best for Cyrillic / non-Latin fonts that pdftotext drops",
     },
     {
         "label": "PDF (technical: tables, code, formulas)",
@@ -172,10 +172,21 @@ def prepare_dependencies(ext: str, extraction_mode: str, install_mode: str) -> N
             install_mode=install_mode,
         )
 
+    if ext == ".pdf":
+        # pdfplumber decodes subsetted / non-Latin (e.g. Cyrillic) fonts that
+        # pdftotext silently drops to punctuation — the corruption gate falls
+        # through to it, so it must be installable even when pdftotext is present.
+        offer_dependency_install(
+            feature="Reliable PDF text extraction (Cyrillic / non-Latin fonts)",
+            module_names=["pdfplumber"],
+            fallback="pdftotext/pypdf/pdfminer (may drop non-Latin glyphs)",
+            install_mode=install_mode,
+        )
+
     if ext == ".pdf" and not shutil.which("pdftotext"):
         offer_dependency_install(
             feature="PDF text extraction",
-            module_names=["pypdf", "pdfminer"],
+            module_names=["pdfplumber", "pypdf", "pdfminer"],
             fallback="any installed Python PDF parser; extraction fails if none are available",
             install_mode=install_mode,
         )

--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -79,6 +79,44 @@ def extract_with_docling(pdf_path: str) -> str | None:
         return None
 
 
+def extract_with_pdfplumber(pdf_path: str) -> str | None:
+    """pdfplumber decodes many subsetted / non-Latin (e.g. Cyrillic) fonts that
+    pdftotext and pypdf silently drop to punctuation. Slower, but correct."""
+    try:
+        import pdfplumber
+        parts = []
+        with pdfplumber.open(pdf_path) as pdf:
+            for page in pdf.pages:
+                try:
+                    parts.append(page.extract_text() or "")
+                except Exception:
+                    parts.append("")
+        return "\n".join(parts)
+    except ImportError:
+        return None
+    except Exception as e:
+        print(f"  [warn] extract_with_pdfplumber failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return None
+
+
+def alpha_ratio(text: str) -> float:
+    """Fraction of alphabetic chars among non-whitespace chars. Real prose is
+    letter-dominated (~0.5-0.95); a font-drop failure leaves mostly punctuation
+    (~0.0-0.15)."""
+    nonspace = [c for c in text if not c.isspace()]
+    if not nonspace:
+        return 0.0
+    return sum(c.isalpha() for c in nonspace) / len(nonspace)
+
+
+def looks_corrupt(text: str, threshold: float = 0.35) -> bool:
+    """True when an extractor returned non-empty text that is punctuation-
+    dominated — the classic pdftotext glyph-drop on subsetted fonts (a Cyrillic
+    PDF reads as ', . , ,'). Calibrated on real garbage (~0.02-0.11) vs clean
+    text (~0.51-0.96)."""
+    return bool(text) and len(text.strip()) > 200 and alpha_ratio(text) < threshold
+
+
 def count_pages(pdf_path: str) -> int:
     # Try pdfinfo first
     if shutil.which("pdfinfo"):

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -35,8 +35,11 @@ from book_to_skill.parsers.calibre import extract_with_ebook_convert
 from book_to_skill.parsers.pdf import (
     extract_with_docling,
     extract_with_pdftotext,
+    extract_with_pdfplumber,
     extract_with_pypdf,
     extract_with_pdfminer,
+    alpha_ratio,
+    looks_corrupt,
     count_pages,
 )
 from book_to_skill.parsers.epub import (
@@ -461,44 +464,65 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
         if extraction_mode == "technical":
             print("Mode: technical — using Docling (layout-aware)...", end=" ", flush=True)
             text = extract_with_docling(input_str)
-            if text:
+            if text and not looks_corrupt(text):
                 method = "docling"
                 print("OK")
             else:
-                print("not available, falling back to pdftotext")
-                extraction_mode = "text"
-                
-        if extraction_mode == "text" or not text:
-            print("Mode: text — using pdftotext...")
-            print("Trying pdftotext...", end=" ", flush=True)
-            text = extract_with_pdftotext(input_str)
-            
-            if text:
-                method = "pdftotext"
-                print("OK")
-            else:
-                print("not available")
-                print("Trying pypdf...", end=" ", flush=True)
-                text = extract_with_pypdf(input_str)
                 if text:
-                    method = "pypdf"
-                    print("OK")
+                    print("output looks corrupt (font/glyph drop) — falling back to text mode")
                 else:
+                    print("not available, falling back to text mode")
+                extraction_mode = "text"
+                text = None
+
+        if extraction_mode == "text" or not text:
+            # First extractor whose output is non-empty AND not corrupt wins.
+            # pdftotext is fast but silently drops subsetted / non-Latin glyphs
+            # (e.g. Cyrillic) to punctuation — the gate rejects that garbage and
+            # falls through to pdfplumber, which decodes those fonts correctly.
+            # See parsers.pdf.looks_corrupt.
+            print("Mode: text — trying extractors (pdftotext → pdfplumber → pypdf → pdfminer)...")
+            candidates = [
+                ("pdftotext", extract_with_pdftotext),
+                ("pdfplumber", extract_with_pdfplumber),
+                ("pypdf", extract_with_pypdf),
+                ("pdfminer", extract_with_pdfminer),
+            ]
+            text, method = None, None
+            best_text, best_method, best_ratio = None, None, -1.0
+            for name, fn in candidates:
+                print(f"Trying {name}...", end=" ", flush=True)
+                out = fn(input_str)
+                if not out or not out.strip():
                     print("not available")
-                    print("Trying pdfminer.six...", end=" ", flush=True)
-                    text = extract_with_pdfminer(input_str)
-                    if text:
-                        method = "pdfminer"
-                        print("OK")
-                    else:
-                        print("FAILED")
-                        raise ExtractionError(
-                            "Could not extract text from PDF.\n"
-                            "Install one of: poppler-utils (pdftotext), pypdf, or pdfminer.six\n"
-                            "  sudo apt install poppler-utils\n"
-                            "  pip3 install pypdf\n"
-                            "  pip3 install pdfminer.six"
-                        )
+                    continue
+                if looks_corrupt(out):
+                    print(f"corrupt (alpha_ratio={alpha_ratio(out):.2f}, glyph drop) — skipping")
+                    ratio = alpha_ratio(out)
+                    if ratio > best_ratio:
+                        best_text, best_method, best_ratio = out, name, ratio
+                    continue
+                print("OK")
+                text, method = out, name
+                break
+
+            if not text:
+                if best_text:
+                    # Every extractor looked corrupt (an unusual scan/font) — keep
+                    # the least-bad rather than hard-fail a partly-readable PDF.
+                    print(f"[warn] all extractors looked corrupt; using best-effort {best_method} "
+                          f"(alpha_ratio={best_ratio:.2f})")
+                    text, method = best_text, best_method
+                else:
+                    print("FAILED")
+                    raise ExtractionError(
+                        "Could not extract text from PDF.\n"
+                        "Install one of: poppler-utils (pdftotext), pdfplumber, pypdf, or pdfminer.six\n"
+                        "  sudo apt install poppler-utils\n"
+                        "  pip3 install pdfplumber   # best for Cyrillic / non-Latin fonts\n"
+                        "  pip3 install pypdf\n"
+                        "  pip3 install pdfminer.six"
+                    )
 
                         
         pages = count_pages(input_str)


### PR DESCRIPTION
## Problem

On many digitally-generated PDFs whose fonts are subsetted with no ToUnicode CMap, `pdftotext` (and `pypdf`) drop non-Latin glyphs to punctuation. A Russian book extracts as bare `", . , ,"`. Since `pdftotext` runs first and its non-empty **but garbage** output wins, the fallback chain never runs and the entire book comes out unreadable. Cyrillic, Greek, and similar scripts are affected; Latin text is unaffected.

## Fix

- **`parsers/pdf.py`**: add `extract_with_pdfplumber()` — pdfplumber decodes these fonts correctly — plus `alpha_ratio()` / `looks_corrupt()`, a cheap gate that flags punctuation-dominated output (`alpha_ratio < 0.35`, calibrated on real garbage ~0.02–0.11 vs clean text ~0.51–0.96).
- **`utils.py`**: the PDF text path is now a gated loop `pdftotext → pdfplumber → pypdf → pdfminer` — the first non-empty **and non-corrupt** result wins. Docling (technical mode) is gated the same way. If every extractor looks corrupt (an unusual scan), the least-bad result is kept instead of hard-failing.
- **`config.py` / `dependencies.py`**: register `pdfplumber`; `--check` and the install prompt surface it (flagged best for Cyrillic / non-Latin fonts).

## Compatibility

Backward compatible. For Latin PDFs `pdftotext` still wins on the first try; `pdfplumber` is optional (already a common dependency) and only used when `pdftotext` output is empty or garbled.

## Testing

Verified on a 542-page Russian PDF: `pdftotext` alpha_ratio **0.11** (flagged corrupt) → falls through to `pdfplumber` alpha_ratio **0.92** (clean Cyrillic). Gate unit-checked: flags real garbage, passes clean prose, ignores empty/short strings.