### PR TITLE
feat: add first-class Grok Build support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -58,7 +58,7 @@ Closes #<!-- issue number, or "n/a" with a one-line reason if there is no issue 
 - [ ] Tests added/updated for behavior changes
 - [ ] `pytest -q` is green on a clean checkout
 - [ ] `ruff check .` is clean
-- [ ] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
+- [ ] `for lens in claude copilot amp grok; do python3 tools/validate_skill.py --lens "$lens" SKILL.md; done` passes (if `SKILL.md` changed)
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]`
 - [ ] No raw book text shipped; no net `SKILL.md` bloat without justification
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,18 +85,21 @@ jobs:
         run: zizmor .github/workflows/ || true
 
   validate-skill:
-    name: validate SKILL.md (Claude Code rules)
+    name: validate SKILL.md (${{ matrix.lens }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lens: [claude, copilot, amp, grok]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Audit SKILL.md against Claude Code skill rules
-        # Fails on Claude-breaking issues (missing name/description, oversized
-        # description, a tool restriction that omits Bash while the skill shells
-        # out). Cross-agent metadata Claude ignores is reported as WARN only.
-        run: python3 tools/validate_skill.py SKILL.md
+      - name: Audit SKILL.md against host skill rules
+        # This gate checks the portable frontmatter contract and selected host
+        # rules. Focused unit tests exercise lens-specific allowed-tools behavior.
+        run: python3 tools/validate_skill.py --lens "${{ matrix.lens }}" SKILL.md
 
   dependency-review:
     name: dependency review (PR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Grok Build as a first-class target** — native `.grok/skills` discovery,
+  shared `.agents/skills` guidance, automatic-reload and inspection instructions,
+  a `validate_skill.py --lens grok` compatibility audit, focused validator tests,
+  and cross-host CI validation. The validator models Grok's declarative
+  `allowed-tools` behavior without treating it as an enforced permission boundary,
+  and the docs explain that Claude compatibility is configurable.
 - **Thai chapter headings** — `บทที่ N`, `ตอนที่ N` and `ภาคที่ N` are now detected as
   chapter boundaries, with Thai numerals (๐–๙) as well as Arabic digits. Thai-language
   books previously had no heading detection at all and fell back to length-based
@@ -16,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Clarified the two install paths so they are not confused: **`git clone` into a
-  skills folder** registers the `/book-to-skill` agent skill (Claude Code / Copilot
-  CLI / Amp), while **`pip install book-to-skill`** installs only the standalone
-  extraction CLI and does not register the skill. README and the docs landing now
-  show both explicitly.
+  skills folder** registers the `/book-to-skill` agent skill (Grok Build / Claude
+  Code / Copilot CLI / Amp), while **`pip install book-to-skill`** installs only
+  the standalone extraction CLI and does not register the skill. README and the
+  docs landing now show both explicitly.
 - README now leads with the measured headline (24×–51× fewer tokens than a
   context-dump) and a 3-step "how it works", so the value lands in the first
   screen instead of being buried mid-page.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">book-to-skill</h1>
 
 <p align="center">
-  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in GitHub Copilot CLI, Amp, or Claude Code.</strong>
+  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in Grok Build, GitHub Copilot CLI, Amp, or Claude Code.</strong>
 </p>
 
 <p align="center">
@@ -64,13 +64,13 @@ The usual workarounds don't help:
 
 Once installed, you just type `/your-book-slug replication` and the agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
 
-Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
+Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — Grok Build, GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
 
 ---
 
 ## 📦 What it generates
 
-Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Amp or cross-agent, `~/.claude/skills/<slug>/` for Claude Code):
+Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.grok/skills/<slug>/` for Grok Build, `~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for a Grok/Copilot/Amp shared install, or `~/.claude/skills/<slug>/` for Claude Code):
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -130,7 +130,7 @@ After the skill is created, use it like any other agent skill:
 /designing-data-intensive-apps "what chapters do you have?"
 ```
 
-In GitHub Copilot CLI you may need to run `/skills reload` after the file is written so the new skill appears in `/skills list`. Claude Code and Amp pick it up on the next session.
+In GitHub Copilot CLI you may need to run `/skills reload` after the file is written so the new skill appears in `/skills list`. Grok Build watches skill files and normally discovers the new skill within seconds; `/skills` opens its skill viewer and `grok inspect --json` shows the resolved source path. Claude Code and Amp pick it up on the next session.
 
 ---
 
@@ -202,10 +202,13 @@ scripts/extract.py <paths…> --mode <technical|text>
                │
                ▼
           Skill written to one of:
+            ~/.grok/skills/<slug>/      (Grok Build)
             ~/.copilot/skills/<slug>/   (GitHub Copilot CLI)
-            ~/.agents/skills/<slug>/    (Copilot CLI or Amp, cross-agent)
+            ~/.agents/skills/<slug>/    (Grok, Copilot CLI, or Amp; cross-agent)
             ~/.claude/skills/<slug>/    (Claude Code)
-          /tmp/book_skill_work/         🗑️  cleaned up
+            project-local roots         (.grok/skills, .github/skills,
+                                         .agents/skills, .claude/skills)
+          /tmp/book_skill_work/          🗑️  cleaned up
 ```
 
 **Extraction benchmark** (103-page technical book, CPU only):
@@ -350,10 +353,22 @@ book-to-skill is built for a different job: you want to go deep on a specific to
 ## 📥 Install
 
 > **Two ways to use it, do not confuse them:**
-> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, or Amp) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
+> - **As an agent skill** (the `/book-to-skill` command in Grok Build, Claude Code, Copilot CLI, or Amp) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
 > - **As a standalone CLI** (just the text extractor) → `pip install book-to-skill`, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
+
+**Grok Build** (native personal skill):
+
+```bash
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.grok/skills/book-to-skill
+grok inspect --json  # verify the discovered source path
+```
+
+Grok Build reloads skills automatically after files change. `/skills` opens the
+skill viewer. Grok also scans `.agents/skills` and, by default, Claude skill
+roots; Claude compatibility can be disabled, so prefer `.grok/skills` or
+`.agents/skills` for a Grok install.
 
 **GitHub Copilot CLI** (personal skill):
 
@@ -364,7 +379,7 @@ git clone https://github.com/virgiliojr94/book-to-skill.git ~/.copilot/skills/bo
 /skills info book-to-skill
 ```
 
-Or the cross-agent path that Copilot CLI and Amp both discover:
+Or the cross-agent path that Grok Build, Copilot CLI, and Amp discover:
 
 ```bash
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
@@ -422,8 +437,8 @@ book-to-skill/
 │       └── parsers/      # Format-specific parsers (pdf, epub, docx, html, rtf, calibre, text)
 ├── tools/
 │   ├── discovery_tax.py  # measures token cost vs context-dump / discovery loop
-│   └── validate_skill.py # checks a generated SKILL.md against host rules (--lens claude|copilot|amp)
-├── tests/                # pytest suite (extraction, detection, discovery tax)
+│   └── validate_skill.py # host-rule audit (--lens claude|copilot|amp|grok)
+├── tests/                # pytest suite (extraction, detection, validation, discovery tax)
 ├── docs/
 │   ├── PERFORMANCE.md    # measured benchmarks, discovery tax, cost
 │   └── ARCHITECTURE.md   # pipeline + component map

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Grok Build, GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 ---
 
 <!--
 Cross-agent notes (informational; ignored by host agents):
-  - Compatible skill roots: GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills,
-    .github/skills, .claude/skills, .agents/skills), Amp (.agents/skills,
-    ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills).
+  - Compatible skill roots: Grok Build (~/.grok/skills, .grok/skills, and
+    .agents/skills at each tier), GitHub Copilot CLI (~/.copilot/skills,
+    ~/.agents/skills, .github/skills, .claude/skills, .agents/skills), Amp
+    (.agents/skills, ~/.config/agents/skills, ~/.config/amp/skills), and Claude
+    Code (~/.claude/skills). Grok scans Claude roots by default, but that
+    compatibility can be disabled.
   - `allowed-tools` is intentionally omitted to stay agent-neutral: Copilot CLI uses
-    `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`, Amp
-    adds `shell_command`. The skill needs shell (to run extract.py) and file
-    read/write — each host will prompt for those on first use.
+    `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`,
+    Amp adds `shell_command`, and Grok uses native snake_case names while also
+    resolving Claude aliases. The skill needs shell (to run extract.py) and
+    file read/write — each host applies its own permission policy.
   - Argument hint: <path-to-document-folder-or-glob>... [skill-name-slug]
 -->
 
@@ -21,7 +25,7 @@ Transform written knowledge into actionable agent skills by extracting structure
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Grok Build, GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -64,16 +68,20 @@ Four paths available. Route based on what the user asks:
 
 ## Skill Locations
 
-This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
+This converter can run from multiple skill systems. These are supported
+destinations, grouped by host rather than listed as one global precedence:
 
-1. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
-2. Cross-agent personal skills (Copilot + Amp): `~/.agents/skills/`
-3. Claude Code personal skills: `~/.claude/skills/`
-4. Project-local Copilot skills: `.github/skills/`
-5. Project-local Claude skills: `.claude/skills/`
-6. Project-local Amp / Copilot skills: `.agents/skills/`
-7. Amp global skills: `~/.config/agents/skills/`
-8. Amp legacy global skills: `~/.config/amp/skills/`
+- Grok Build native skills: `~/.grok/skills/`, `.grok/skills/`
+- GitHub Copilot CLI skills: `~/.copilot/skills/`, `.github/skills/`
+- Cross-agent skills (Grok + Copilot + Amp): `~/.agents/skills/`, `.agents/skills/`
+- Claude Code skills: `~/.claude/skills/`, `.claude/skills/`
+- Amp global skills: `~/.config/agents/skills/`, `~/.config/amp/skills/`
+
+Each host applies its own discovery precedence. Grok ranks skills by scope
+(current directory, then repository, then user), scans `.agents/skills/`
+alongside `.grok/skills/` at each tier, and scans Claude skill roots by default
+unless Claude compatibility is disabled. Do not infer host precedence from the
+list above.
 
 For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
 
@@ -131,12 +139,14 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 for candidate in \
-  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
+  ".grok/skills/book-to-skill/scripts/extract.py" \
   ".github/skills/book-to-skill/scripts/extract.py" \
   ".claude/skills/book-to-skill/scripts/extract.py" \
   ".agents/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.grok/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
+  "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
 do
@@ -300,19 +310,28 @@ Otherwise, propose two options and let the user choose:
 
 Default to author-concept format if the book has a strong methodological identity.
 
-Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem for existing skill homes and pick by **the host the user is running in**:
+Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem
+for existing skill homes and pick by **the host the user is running in**. The
+arrows below express recommended write destinations, not the host's complete
+discovery precedence:
 
-| Host agent | Personal skill root (probe in order) | Project-local root |
+| Host agent | Suggested personal destination | Suggested project destination |
 |---|---|---|
 | **GitHub Copilot CLI** | `~/.copilot/skills` → `~/.agents/skills` | `.github/skills` → `.claude/skills` → `.agents/skills` |
 | **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
+| **Grok Build** | `~/.grok/skills` → `~/.agents/skills` | `.grok/skills` → `.agents/skills` |
+
+Grok also scans Claude skill roots by default, but users can disable that
+compatibility with Grok configuration or `GROK_CLAUDE_SKILLS_ENABLED=false`;
+prefer the native or shared destinations above for a Grok-specific install.
 
 Selection rules:
 1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
-2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
-3. If the user explicitly asked for project-local output, prefer the project-local row.
-4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, or Claude Code?"
+2. If **more than one** exists, ask which destination to use and remember the choice for the session.
+3. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
+4. If the user explicitly asked for project-local output, prefer the project-local row.
+5. If you cannot identify the host, ask: "Which agent are you running this in — Grok Build, GitHub Copilot CLI, Amp, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:
@@ -575,10 +594,12 @@ Usage:
   Ask <skill_name> about <topic>        → find and explain a topic
   Ask <skill_name> for ch<N>            → dive into a specific chapter
 
-Reload (if your agent doesn't auto-detect new skills):
+Discovery refresh / verification:
   GitHub Copilot CLI:  /skills reload
   Claude Code:         restart the session
   Amp:                 restart the session
+  Grok Build:          auto-reloads within seconds; /skills opens the skill
+                       viewer, and `grok inspect --json` shows the resolved source path
 
 Share this skill (Copilot ecosystem, optional):
   gh skill publish $SKILLS_HOME/<skill_name>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,10 +32,11 @@ document into clean text + metadata; the agent turns that into a structured skil
                                    │
                                    ▼
                 <SKILLS_HOME>/<slug>/  ← chosen per host:
+                  ~/.grok/skills/      Grok Build
                   ~/.copilot/skills/   GitHub Copilot CLI
-                  ~/.agents/skills/    Copilot CLI or Amp (cross-agent)
+                  ~/.agents/skills/    Grok, Copilot CLI, or Amp (cross-agent)
                   ~/.claude/skills/    Claude Code
-                  .github|.claude|.agents/skills/  project-local
+                  .grok|.github|.claude|.agents/skills/  project-local
                   SKILL.md         core frameworks + chapter & topic index (~4K)
                   chapters/*.md    on-demand, loaded only when asked
                   glossary.md      terms
@@ -65,7 +66,7 @@ document into clean text + metadata; the agent turns that into a structured skil
 | `scripts/extractor/parsers/` | one module per format |
 | `scripts/extractor/dependencies.py` | optional-dependency probing + `--check` |
 | `tools/discovery_tax.py` | measures token cost vs context-dump / discovery loop |
-| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude|copilot|amp`) |
+| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude\|copilot\|amp\|grok`) |
 | `SKILL.md` | the generator spec (Steps 0–10 + fold-in workflow) |
 
 ## Extending

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,17 +45,27 @@ Turn any book or document into a structured, on-demand agent skill — named fra
 
     ---
 
-    One `SKILL.md` runs on Claude Code, GitHub Copilot CLI, and Amp through the
-    open Agent Skills standard.
+    One `SKILL.md` runs on Grok Build, Claude Code, GitHub Copilot CLI, and Amp
+    through the open Agent Skills standard.
 
 </div>
 
 ## Install
 
-**As an agent skill** (gives you the `/book-to-skill` command in Claude Code, Copilot CLI, Amp):
+**As an agent skill** (gives you the `/book-to-skill` command in Grok Build,
+Claude Code, Copilot CLI, or Amp):
 
 ```bash
+# Choose the destination for your host:
+# Grok Build
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.grok/skills/book-to-skill
+# Claude Code
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
+# GitHub Copilot CLI
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.copilot/skills/book-to-skill
+# Grok Build, Copilot CLI, or Amp (shared path)
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
+
 # then, in your agent session:
 /book-to-skill /path/to/book.pdf [skill-name]
 ```

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -1,0 +1,145 @@
+import pytest
+
+from tools.validate_skill import LENSES, audit, split_tool_list
+
+
+def write_skill(tmp_path, frontmatter, body="Use the skill.\n"):
+    path = tmp_path / "SKILL.md"
+    path.write_text(f"---\n{frontmatter}---\n{body}", encoding="utf-8")
+    return path
+
+
+def test_split_tool_list_matches_grok_comma_and_parenthesis_rules():
+    value = "Bash(git log --format=%h,%s), Grep read_file"
+
+    assert split_tool_list(value) == [
+        "Bash(git log --format=%h,%s)",
+        "Grep",
+        "read_file",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("lens", "allowed_tools"),
+    [
+        ("claude", "Bash Read"),
+        ("copilot", "bash write"),
+        ("amp", "Bash shell_command"),
+    ],
+)
+def test_existing_lenses_still_accept_their_shell_tools(
+    tmp_path, lens, allowed_tools
+):
+    path = write_skill(
+        tmp_path,
+        f"name: example\ndescription: Example skill\nallowed-tools: {allowed_tools}\n",
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    assert audit(path, lens=lens) == ([], [])
+
+
+def test_grok_accepts_native_tools_aliases_and_documented_lowercase(tmp_path):
+    path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: run_terminal_command, Read, bash, grep\n"
+        ),
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    assert audit(path, lens="grok") == ([], [])
+
+
+def test_grok_recognizes_optional_frontmatter(tmp_path):
+    path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "when-to-use: Use for examples\n"
+            "when_to_use: Legacy spelling is also parsed\n"
+            "argument-hint: <path>\n"
+            "user-invocable: true\n"
+            "disable-model-invocation: false\n"
+            "model: grok-code-fast-1\n"
+            "effort: high\n"
+            "license: MIT\n"
+            "compatibility: Requires Python\n"
+            "paths: docs/**\n"
+            "metadata:\n"
+            "  author: Example\n"
+        ),
+    )
+
+    assert audit(path, lens="grok") == ([], [])
+
+
+def test_grok_warns_when_declaration_omits_shell_tool(tmp_path):
+    path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: read_file\n"
+        ),
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    errors, warns = audit(path, lens="grok")
+
+    assert errors == []
+    assert len(warns) == 1
+    assert "currently treats this field as declarative" in warns[0]
+
+
+def test_claude_errors_when_declaration_omits_shell_tool(tmp_path):
+    path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: Read\n"
+        ),
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    errors, warns = audit(path, lens="claude")
+
+    assert len(errors) == 1
+    assert "'Bash'" in errors[0]
+    assert warns == []
+
+
+@pytest.mark.parametrize(
+    ("lens", "expects_error"),
+    [
+        ("claude", True),
+        ("copilot", False),
+        ("amp", False),
+        ("grok", False),
+    ],
+)
+def test_entirely_external_tool_lists_follow_lens_severity(
+    tmp_path, lens, expects_error
+):
+    path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: linear__list_issues\n"
+        ),
+    )
+
+    errors, warns = audit(path, lens=lens)
+
+    assert bool(errors) is expects_error
+    assert len(warns) == 1
+    assert "linear__list_issues" in warns[0]
+
+
+def test_grok_lens_is_available():
+    assert LENSES["grok"]["label"] == "Grok Build"

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -2,13 +2,15 @@
 """Audit a SKILL.md against Agent Skills rules for a chosen host (lens).
 
 Severity:
-  ERROR  -> breaks/degrades the skill on the chosen host (fails CI)
+  ERROR  -> violates the portable skill contract or breaks/degrades the skill
+            on the chosen host (fails CI)
   WARN   -> the host ignores it, or it's a soft guideline (does not fail CI)
 
 Lenses:
   claude   — Claude Code rules (default; back-compat)
   copilot  — GitHub Copilot CLI rules
   amp      — Sourcegraph Amp rules
+  grok     — Grok Build rules
 
 The SKILL.md format itself is an open standard
 (https://github.com/agentskills/agentskills) — `name` + `description` are the
@@ -22,8 +24,9 @@ Refs:
   Copilot    https://docs.github.com/en/copilot/concepts/agents/about-agent-skills
              https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills
   Amp        https://ampcode.com/manual#skills
+  Grok       https://docs.x.ai/build/features/skills-plugins-marketplaces
 
-Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp] [path/to/SKILL.md]
+Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp|grok] [path/to/SKILL.md]
 """
 import argparse
 import re
@@ -53,6 +56,26 @@ COPILOT_CLI_TOOLS = {"shell", "bash", "write"}
 # Amp accepts Claude's tool names plus its own `shell_command` shorthand.
 AMP_TOOLS = CLAUDE_CODE_TOOLS | {"shell_command"}
 
+# Grok exposes native snake_case tools and resolves Claude-compatible aliases.
+# `allowed-tools` is currently descriptive in Grok rather than an enforced
+# permission boundary, so omissions and unknown external/MCP tools remain WARNs.
+GROK_TOOLS = {
+    "run_terminal_command", "run_terminal_cmd", "read_file", "search_replace",
+    "write", "grep", "list_dir", "web_fetch", "web_search", "lsp",
+    "ask_user_question", "todo_write", "task", "spawn_subagent",
+    "enter_plan_mode", "exit_plan_mode", "get_task_output",
+    "get_terminal_command_output", "kill_task", "kill_terminal_command",
+    "wait_tasks", "monitor", "image_gen", "image_edit", "deploy_app",
+    "image_to_video", "reference_to_video", "scheduler_create",
+    "scheduler_delete", "scheduler_list", "skill", "search_tool",
+    "Bash", "Read", "Write", "Edit", "MultiEdit", "NotebookEdit",
+    "PowerShell", "Grep", "Glob", "LS", "LSP", "WebSearch", "WebFetch",
+    "DeployApp", "TodoWrite", "AskUserQuestion", "TaskOutput", "BashOutput",
+    "BashOutputTool", "AgentOutputTool", "TaskStop", "KillShell", "KillBash",
+    "Skill", "ToolSearch", "Agent", "Task", "EnterPlanMode", "ExitPlanMode",
+    "CronCreate", "CronDelete", "CronList", "ListMcpResourcesTool",
+}
+
 LENSES = {
     "claude": {
         "label": "Claude Code",
@@ -60,7 +83,10 @@ LENSES = {
         "recognized_keys": {"name", "description", "allowed-tools", "license"},
         "reserved_name_words": {"anthropic", "claude"},
         "bash_tool_names": {"Bash"},
+        "case_sensitive_tools": True,
+        "missing_shell_severity": "error",
         "unknown_tool_severity": "error",
+        "unknown_tool_note": "not recognized by Claude Code",
     },
     "copilot": {
         "label": "GitHub Copilot CLI",
@@ -68,8 +94,11 @@ LENSES = {
         "recognized_keys": {"name", "description", "allowed-tools", "license"},
         "reserved_name_words": set(),
         "bash_tool_names": {"shell", "bash"},
+        "case_sensitive_tools": True,
+        "missing_shell_severity": "error",
         # Unknown tokens are likely MCP server names — Copilot accepts them.
         "unknown_tool_severity": "warn",
+        "unknown_tool_note": "may be free-form MCP-server names",
     },
     "amp": {
         "label": "Amp",
@@ -80,7 +109,32 @@ LENSES = {
         },
         "reserved_name_words": set(),
         "bash_tool_names": {"shell_command", "Bash"},
+        "case_sensitive_tools": True,
+        "missing_shell_severity": "error",
         "unknown_tool_severity": "warn",
+        "unknown_tool_note": "may refer to external tools",
+    },
+    "grok": {
+        "label": "Grok Build",
+        "tools": GROK_TOOLS,
+        "recognized_keys": {
+            "name", "description", "when-to-use", "when_to_use",
+            "allowed-tools", "argument-hint", "user-invocable",
+            "disable-model-invocation", "model", "effort", "license",
+            "compatibility", "metadata", "paths",
+        },
+        "reserved_name_words": set(),
+        "bash_tool_names": {"run_terminal_command", "run_terminal_cmd", "Bash"},
+        # Grok's own docs use lowercase tool examples, while its Claude aliases
+        # are capitalized. Advisory validation accepts either casing.
+        "case_sensitive_tools": False,
+        "missing_shell_severity": "warn",
+        "missing_shell_note": (
+            "Grok Build currently treats this field as declarative, so the "
+            "declaration does not describe the tools used"
+        ),
+        "unknown_tool_severity": "warn",
+        "unknown_tool_note": "may refer to external or MCP tools",
     },
 }
 
@@ -124,6 +178,33 @@ def tool_base(entry):
     return entry.split("(", 1)[0].strip()
 
 
+def split_tool_list(value):
+    """Split comma/space-delimited tools, preserving separators inside ()."""
+    items, current, depth = [], [], 0
+    for char in value:
+        if char == "(":
+            depth += 1
+            current.append(char)
+        elif char == ")":
+            depth -= 1
+            current.append(char)
+        elif depth <= 0 and (char == "," or char.isspace()):
+            item = "".join(current).strip()
+            if item:
+                items.append(item)
+            current = []
+        else:
+            current.append(char)
+    item = "".join(current).strip()
+    if item:
+        items.append(item)
+    return items
+
+
+def normalized_tool_name(name, rules):
+    return name if rules["case_sensitive_tools"] else name.casefold()
+
+
 def audit(path, lens="claude"):
     rules = LENSES[lens]
     label = rules["label"]
@@ -157,32 +238,41 @@ def audit(path, lens="claude"):
     if not tools:
         inline = get_scalar(fm, "allowed-tools")
         if inline:
-            tools = inline.split()
-    if tools:  # a restriction is declared -> the host enforces it
-        bases = {tool_base(t) for t in tools}
-        known = {b for b in bases if b in rules["tools"]}
-        unknown = [t for t in tools if tool_base(t) not in rules["tools"]]
+            tools = split_tool_list(inline)
+    if tools:
+        bases = {normalized_tool_name(tool_base(t), rules) for t in tools}
+        known_tools = {
+            normalized_tool_name(tool, rules) for tool in rules["tools"]
+        }
+        shell_tools = {
+            normalized_tool_name(tool, rules)
+            for tool in rules["bash_tool_names"]
+        }
+        known = bases & known_tools
+        unknown = [
+            t for t in tools
+            if normalized_tool_name(tool_base(t), rules) not in known_tools
+        ]
         uses_bash = bool(re.search(r"```bash", body)) or "python3 " in body
-        if uses_bash and not (bases & rules["bash_tool_names"]):
+        if uses_bash and not (bases & shell_tools):
             bash_names = " or ".join(f"'{n}'" for n in sorted(rules["bash_tool_names"]))
-            errors.append(
-                f"allowed-tools declares a restriction but omits {bash_names}, yet the "
-                f"skill runs bash/python3 — under {label} those steps would be blocked"
-            )
+            if rules["missing_shell_severity"] == "error":
+                errors.append(
+                    f"allowed-tools declares a restriction but omits {bash_names}, yet the "
+                    f"skill runs bash/python3 — under {label} those steps would be blocked"
+                )
+            else:
+                warns.append(
+                    f"allowed-tools omits {bash_names}, yet the skill runs bash/python3; "
+                    f"{rules['missing_shell_note']}"
+                )
         if not known and rules["tools"]:
-            # Claude: hard error (none of the listed tools are recognized).
-            # Copilot/Amp: tokens are likely MCP names — handled by the warn path.
             if rules["unknown_tool_severity"] == "error":
                 errors.append(f"allowed-tools: no recognized {label} tool in the list")
         if unknown:
             msg = (f"allowed-tools: {unknown} are not {label} built-in tool names "
-                   f"(treated as MCP-server names by Copilot, ignored by Claude)")
-            if rules["unknown_tool_severity"] == "error":
-                # Already covered by the 'no recognized tool' error if list is all-unknown;
-                # otherwise it's a soft note.
-                warns.append(msg)
-            else:
-                warns.append(msg)
+                   f"({rules['unknown_tool_note']})")
+            warns.append(msg)
 
     for k in top_level_keys(fm):
         if k not in rules["recognized_keys"]:
@@ -217,4 +307,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary (Required)
Adds first-class Grok Build support to book-to-skill: native discovery/install guidance, slash-command usage, host-aware destinations and helper lookup, a Grok validator lens, regression tests, and CI coverage. The same portable `SKILL.md` remains compatible with Claude Code, GitHub Copilot CLI, and Amp.

## Type of change (Required)
- [x] ✨ Feature (non-breaking change that adds capability)
- [x] 🧹 Chore / CI / tooling

## What it does (Required)
- **Improves:** expands the CI host-compatibility matrix from 3 to 4 lenses and verifies Grok's declarative tool metadata without weakening existing host checks.
- **Adds:** documented `~/.grok/skills`, `.grok/skills`, and shared `.agents/skills` discovery; `/book-to-skill` invocation; `grok inspect --json` verification; Grok-aware destination/reload behavior; and `validate_skill.py --lens grok`.

## Motivation & context (Required)
Closes #n/a — no tracking issue; this contribution adds the requested Grok Build integration.

book-to-skill already emits the portable Agent Skills format, but it did not model Grok's native roots, invocation, reload behavior, or declarative `allowed-tools` semantics. Users therefore lacked a supported installation path and a way to audit compatibility before publishing a generated skill.

## How it works (Required)
The PR teaches the converter and documentation Grok's native and cross-agent discovery roots, then adds a host lens that accepts Grok's snake_case tools and Claude-compatible aliases while treating `allowed-tools` as descriptive rather than an enforced permission boundary. The lens is unit-tested and added to the repository CI matrix; existing Claude/Copilot/Amp semantics stay covered.

## Evidence (Required)
- **Tests:** 176 tests passed on each supported interpreter (Python 3.9, 3.10, 3.11, 3.12, and 3.13). Focused tests cover Grok native tool names, aliases, optional frontmatter, declarative tool warnings, external tools, and lens registration.
- **Before / after:** `--lens grok` was not a valid target on `master`; this branch validates Grok successfully. A live Grok Build 0.2.112 fixture discovered the project-scoped skill from a nested directory and completed explicit `/book-to-skill` invocation.

```text
$ grok inspect --json
source: project
userInvocable: true

$ /book-to-skill
{"skill_name":"book-to-skill","first_mode":"### 1. Full Conversion (Default)","grok_personal_root":"~/.grok/skills"}

$ for py in 3.9 3.10 3.11 3.12 3.13; do pytest tests/ -q; done
176 passed (each interpreter)
```

Additional clean gates: Ruff E9/F, Claude/Copilot/Amp/Grok lenses, official skill quick validation, workflow YAML parsing, sdist/wheel build, dependency-free extraction smoke, MkDocs build, and the Bandit high-severity/medium-confidence gate. Grok Build also performed the final diff/test review.

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)
The terminal evidence above is the changed user-facing output: native discovery and explicit skill invocation both resolve the expected Grok metadata.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `for lens in claude copilot amp grok; do python3 tools/validate_skill.py --lens "$lens" SKILL.md; done` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; the small `SKILL.md` increase is limited to Grok discovery, routing, destination, and reload instructions

## Breaking changes & back-compat (Optional)
None. Existing host lenses and workflows remain supported.

## Notes for reviewers (Optional)
This PR is independent of the companion Codex PR and targets `master` directly. Both are individually mergeable now; because they touch shared host lists and the validator CI matrix, the second one merged may need a small rebase.