### PR TITLE
feat: add first-class OpenAI Codex support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -58,7 +58,7 @@ Closes #<!-- issue number, or "n/a" with a one-line reason if there is no issue 
 - [ ] Tests added/updated for behavior changes
 - [ ] `pytest -q` is green on a clean checkout
 - [ ] `ruff check .` is clean
-- [ ] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
+- [ ] `for lens in claude codex copilot amp; do python3 tools/validate_skill.py --lens "$lens" SKILL.md; done` passes (if `SKILL.md` changed)
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]`
 - [ ] No raw book text shipped; no net `SKILL.md` bloat without justification
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,18 +85,21 @@ jobs:
         run: zizmor .github/workflows/ || true
 
   validate-skill:
-    name: validate SKILL.md (Claude Code rules)
+    name: validate SKILL.md (${{ matrix.lens }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lens: [claude, codex, copilot, amp]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Audit SKILL.md against Claude Code skill rules
-        # Fails on Claude-breaking issues (missing name/description, oversized
-        # description, a tool restriction that omits Bash while the skill shells
-        # out). Cross-agent metadata Claude ignores is reported as WARN only.
-        run: python3 tools/validate_skill.py SKILL.md
+      - name: Audit SKILL.md against host skill rules
+        # This gate checks the portable frontmatter contract and selected host
+        # rules. Focused unit tests exercise lens-specific allowed-tools behavior.
+        run: python3 tools/validate_skill.py --lens "${{ matrix.lens }}" SKILL.md
 
   dependency-review:
     name: dependency review (PR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **OpenAI Codex as a first-class target** — personal and repository
+  `.agents/skills` discovery plus the `/etc/codex/skills` administrator scope,
+  `$skill-name` invocation guidance, minimal `agents/openai.yaml` interface metadata, a
+  `validate_skill.py --lens codex` compatibility audit, focused tests, and
+  four-host CI validation. The Codex lens treats `allowed-tools` as ignored
+  metadata rather than a permission boundary, matching `codex-cli 0.142.4`.
 - **Thai chapter headings** — `บทที่ N`, `ตอนที่ N` and `ภาคที่ N` are now detected as
   chapter boundaries, with Thai numerals (๐–๙) as well as Arabic digits. Thai-language
   books previously had no heading detection at all and fell back to length-based
@@ -16,10 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 - Clarified the two install paths so they are not confused: **`git clone` into a
-  skills folder** registers the `/book-to-skill` agent skill (Claude Code / Copilot
-  CLI / Amp), while **`pip install book-to-skill`** installs only the standalone
-  extraction CLI and does not register the skill. README and the docs landing now
-  show both explicitly.
+  skills folder** registers the agent skill (`$book-to-skill` in Codex and
+  `/book-to-skill` in Claude Code / Copilot CLI / Amp), while
+  **`pip install book-to-skill`** installs only the standalone extraction CLI
+  and does not register the skill. README and the docs landing show both
+  explicitly.
 - README now leads with the measured headline (24×–51× fewer tokens than a
   context-dump) and a 3-step "how it works", so the value lands in the first
   screen instead of being buried mid-page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,9 @@ Run the checks the CI runs before opening a PR:
 ```bash
 ruff check .
 pytest -q
-python3 tools/validate_skill.py SKILL.md
+for lens in claude codex copilot amp; do
+  python3 tools/validate_skill.py --lens "$lens" SKILL.md
+done
 ```
 
 ## Pull requests
@@ -40,7 +42,7 @@ python3 tools/validate_skill.py SKILL.md
   `chore:`, `test:`, `ci:` … (e.g. `fix(extractor): scan full text`).
 - Add or update tests for any behavior change.
 - Update `CHANGELOG.md` under an `## [Unreleased]` section.
-- CI must be green (lint, test matrix py3.10–3.13, smoke, SKILL.md validation).
+- CI must be green (lint, test matrix py3.9–3.13, smoke, SKILL.md validation).
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">book-to-skill</h1>
 
 <p align="center">
-  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in GitHub Copilot CLI, Amp, or Claude Code.</strong>
+  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in OpenAI Codex, GitHub Copilot CLI, Amp, or Claude Code.</strong>
 </p>
 
 <p align="center">
@@ -45,9 +45,9 @@
 
 **How it works, in 3 steps:**
 
-1. **Point** it at a file, folder, or glob — `/book-to-skill ./my-book.pdf`
+1. **Point** it at a file, folder, or glob — `/book-to-skill ./my-book.pdf` (Codex: `$book-to-skill ./my-book.pdf`)
 2. **It distills** the book into a skill — frameworks, decision rules, anti-patterns, and per-chapter files. Structure, not a summary.
-3. **Your agent loads it on demand** — ask `/my-book replication` and it reads the right chapter and answers from the real content, no hallucination.
+3. **Your agent loads it on demand** — ask `/my-book replication` (Codex: `$my-book replication`) and it reads the right chapter and answers from the real content, no hallucination.
 
 ---
 
@@ -62,15 +62,15 @@ The usual workarounds don't help:
 
 **book-to-skill solves this by turning the book into a structured skill your agent loads on demand.**
 
-Once installed, you just type `/your-book-slug replication` and the agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
+Once installed, invoke `/your-book-slug replication` (or `$your-book-slug replication` in Codex) and the agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
 
-Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
+Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — OpenAI Codex, GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
 
 ---
 
 ## 📦 What it generates
 
-Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Amp or cross-agent, `~/.claude/skills/<slug>/` for Claude Code):
+Running `/book-to-skill your-book.pdf` (Codex: `$book-to-skill your-book.pdf`) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Codex, Amp, or a cross-agent install, `~/.claude/skills/<slug>/` for Claude Code):
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -103,6 +103,10 @@ If you re-open a document often enough to wish you'd memorized it, it's a candid
 /book-to-skill <path-to-document-folder-or-glob>... [skill-name-slug]
 ```
 
+Codex CLI and the Codex IDE extension use `$book-to-skill` instead. The examples
+below use the slash form; replace the leading `/book-to-skill` with
+`$book-to-skill` when running them in Codex.
+
 Supported document formats: PDF, EPUB, DOCX, TXT, Markdown, reStructuredText, AsciiDoc, HTML, RTF, MOBI/AZW/AZW3.
 
 **Examples:**
@@ -130,7 +134,11 @@ After the skill is created, use it like any other agent skill:
 /designing-data-intensive-apps "what chapters do you have?"
 ```
 
-In GitHub Copilot CLI you may need to run `/skills reload` after the file is written so the new skill appears in `/skills list`. Claude Code and Amp pick it up on the next session.
+In Codex, use `$designing-data-intensive-apps` instead of the slash form; Codex
+detects skill changes automatically, and `/skills` opens the selector. Restart
+Codex if the skill does not appear. In GitHub Copilot CLI you may need to run
+`/skills reload` after the file is written so the new skill appears in
+`/skills list`. Claude Code and Amp pick it up on the next session.
 
 ---
 
@@ -190,7 +198,7 @@ scripts/extract.py <paths…> --mode <technical|text>
      └── /tmp/book_skill_work/metadata.json   (aggregated stats + per-source array)
                │
                ▼
-          Claude analyzes structure
+          Agent analyzes structure
           (title, author, chapters, ToC — spanning all sources)
           ── or, if targeting an existing skill: folds new content in (Mode 4)
                │
@@ -203,7 +211,7 @@ scripts/extract.py <paths…> --mode <technical|text>
                ▼
           Skill written to one of:
             ~/.copilot/skills/<slug>/   (GitHub Copilot CLI)
-            ~/.agents/skills/<slug>/    (Copilot CLI or Amp, cross-agent)
+            ~/.agents/skills/<slug>/    (Codex, Copilot CLI, or Amp)
             ~/.claude/skills/<slug>/    (Claude Code)
           /tmp/book_skill_work/         🗑️  cleaned up
 ```
@@ -237,7 +245,7 @@ PDF every session.
 1. **Density over completeness** — a 1,000-token summary beats a 10,000-token excerpt
 2. **Practitioner voice** — "Use X when Y", not "The book explains X"
 3. **Front-loaded SKILL.md** — compaction keeps the first ~5,000 tokens; the most important content comes first
-4. **On-demand chapters** — the topic index tells Claude which file to read; chapters load only when needed
+4. **On-demand chapters** — the topic index tells the agent which file to read; chapters load only when needed
 5. **Never raw text** — always synthesize, summarize, extract signal from the source
 
 </details>
@@ -350,10 +358,24 @@ book-to-skill is built for a different job: you want to go deep on a specific to
 ## 📥 Install
 
 > **Two ways to use it, do not confuse them:**
-> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, or Amp) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
+> - **As an agent skill** (`/book-to-skill` in Claude Code, Copilot CLI, or Amp; `$book-to-skill` in Codex) → **`git clone` into your skills folder** (below). This registers the skill and its full convert-a-book flow.
 > - **As a standalone CLI** (just the text extractor) → `pip install book-to-skill`, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
+
+**OpenAI Codex** (personal skill):
+
+```bash
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
+```
+
+Codex discovers personal skills from `~/.agents/skills` and project skills from
+`.agents/skills` in the current directory and every ancestor through the
+repository root. It detects changes automatically; run `/skills` or type
+`$book-to-skill` to invoke the converter explicitly, and restart Codex if the
+skill is absent. These details follow the official
+[Codex skill documentation](https://learn.chatgpt.com/docs/build-skills.md) and
+were verified with `codex-cli 0.142.4`.
 
 **GitHub Copilot CLI** (personal skill):
 
@@ -364,11 +386,8 @@ git clone https://github.com/virgiliojr94/book-to-skill.git ~/.copilot/skills/bo
 /skills info book-to-skill
 ```
 
-Or the cross-agent path that Copilot CLI and Amp both discover:
-
-```bash
-git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
-```
+The Codex destination above, `~/.agents/skills/book-to-skill`, is also the
+cross-agent path that Copilot CLI and Amp discover.
 
 **Claude Code**:
 
@@ -384,12 +403,16 @@ Or manually using standard `git clone` (ensures modular engine files are fetched
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 ```
 
-Then in any agent session:
+Then invoke it in your agent session:
 
-```bash
+```text
+# Claude Code, Copilot CLI, or Amp
 /book-to-skill ~/path/to/your-book.pdf
-# or
 /book-to-skill ~/path/to/your-book.epub
+
+# OpenAI Codex CLI or IDE extension
+$book-to-skill ~/path/to/your-book.pdf
+$book-to-skill ~/path/to/your-book.epub
 ```
 
 ### Standalone CLI (pip)
@@ -397,7 +420,7 @@ Then in any agent session:
 `pip install book-to-skill` is a **separate, optional** path. It installs only the
 text-extraction engine as a CLI, for scripting or to grab the optional extractors;
 it does **not** register the `/book-to-skill` agent skill (use the `git clone` above
-for that).
+for that; Codex uses `$book-to-skill`).
 
 ```bash
 pip install "book-to-skill[pdf,epub,docx]"   # engine + optional extractors
@@ -412,6 +435,8 @@ book-to-skill --check                          # report which extractors are ins
 ```
 book-to-skill/
 ├── SKILL.md              # Skill definition + step-by-step instructions (the generator spec)
+├── agents/
+│   └── openai.yaml       # Codex/ChatGPT interface metadata
 ├── scripts/
 │   ├── extract.py        # Thin entrypoint wrapper
 │   └── extractor/        # Modular extraction package
@@ -422,8 +447,8 @@ book-to-skill/
 │       └── parsers/      # Format-specific parsers (pdf, epub, docx, html, rtf, calibre, text)
 ├── tools/
 │   ├── discovery_tax.py  # measures token cost vs context-dump / discovery loop
-│   └── validate_skill.py # checks a generated SKILL.md against host rules (--lens claude|copilot|amp)
-├── tests/                # pytest suite (extraction, detection, discovery tax)
+│   └── validate_skill.py # host-rule audit (--lens claude|codex|copilot|amp)
+├── tests/                # pytest suite (extraction, detection, host validation, discovery tax)
 ├── docs/
 │   ├── PERFORMANCE.md    # measured benchmarks, discovery tax, cost
 │   └── ARCHITECTURE.md   # pipeline + component map

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,17 +1,21 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through OpenAI Codex, GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 ---
 
 <!--
 Cross-agent notes (informational; ignored by host agents):
-  - Compatible skill roots: GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills,
-    .github/skills, .claude/skills, .agents/skills), Amp (.agents/skills,
-    ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills).
+  - Compatible skill roots: Codex (~/.agents/skills, /etc/codex/skills, and
+    .agents/skills from the current directory through the repository root),
+    GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills, .github/skills,
+    .claude/skills, .agents/skills), Amp (~/.agents/skills,
+    ~/.config/agents/skills, ~/.config/amp/skills, .agents/skills), and Claude
+    Code (~/.claude/skills).
   - `allowed-tools` is intentionally omitted to stay agent-neutral: Copilot CLI uses
     `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`, Amp
-    adds `shell_command`. The skill needs shell (to run extract.py) and file
-    read/write — each host will prompt for those on first use.
+    adds `shell_command`, and Codex 0.142.4 ignores this field. The skill needs
+    shell (to run extract.py) and file read/write — each host applies its own
+    runtime tool, sandbox, and approval policy.
   - Argument hint: <path-to-document-folder-or-glob>... [skill-name-slug]
 -->
 
@@ -21,7 +25,7 @@ Transform written knowledge into actionable agent skills by extracting structure
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format Codex, GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -64,16 +68,21 @@ Four paths available. Route based on what the user asks:
 
 ## Skill Locations
 
-This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
+This converter can run from multiple skill systems. Discovery roots and their
+precedence are host-specific:
 
-1. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
-2. Cross-agent personal skills (Copilot + Amp): `~/.agents/skills/`
-3. Claude Code personal skills: `~/.claude/skills/`
-4. Project-local Copilot skills: `.github/skills/`
-5. Project-local Claude skills: `.claude/skills/`
-6. Project-local Amp / Copilot skills: `.agents/skills/`
-7. Amp global skills: `~/.config/agents/skills/`
-8. Amp legacy global skills: `~/.config/amp/skills/`
+- **OpenAI Codex:** `.agents/skills/` from the current directory through the
+  repository root, then `~/.agents/skills/`, then `/etc/codex/skills/`
+- **GitHub Copilot CLI:** `~/.copilot/skills/`, `~/.agents/skills/`,
+  `.github/skills/`, `.claude/skills/`, then `.agents/skills/`
+- **Amp:** `~/.agents/skills/`, `~/.config/agents/skills/`,
+  `~/.config/amp/skills/`, then `.agents/skills/`
+- **Claude Code:** `~/.claude/skills/`, then `.claude/skills/`
+
+The Step 2 helper lookup mirrors the active host's trust order: Codex uses its
+project-before-user precedence, while the existing Claude, Copilot, and Amp
+paths retain their personal-before-project behavior. The Codex administrator
+root is always a last-resort fallback.
 
 For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
 
@@ -126,25 +135,86 @@ Store the answer as `BOOK_TYPE`:
 
 ## Step 2 — Extract text from the source documents
 
-Run the extraction script, passing the input paths:
+Set `HOST_AGENT` to `codex`, `copilot`, `amp`, or `claude` for the agent running
+this skill. Then run the extraction script, passing the input paths:
 
 ```bash
+HOST_AGENT="${HOST_AGENT:-<codex|copilot|amp|claude>}"
+case "$HOST_AGENT" in
+  codex|copilot|amp|claude) ;;
+  *)
+    echo "Set HOST_AGENT to codex, copilot, amp, or claude" >&2
+    exit 1
+    ;;
+esac
+
 SCRIPT_PATH=""
-for candidate in \
-  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
-  ".github/skills/book-to-skill/scripts/extract.py" \
-  ".claude/skills/book-to-skill/scripts/extract.py" \
-  ".agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
-do
-  if [ -f "$candidate" ]; then
-    SCRIPT_PATH="$candidate"
-    break
+find_codex_project_helper() {
+  SEARCH_DIR="$(pwd -P)"
+  SEARCH_ROOT="$SEARCH_DIR"
+  if command -v git >/dev/null 2>&1; then
+    DETECTED_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || :)"
+    if [ -n "$DETECTED_ROOT" ]; then
+      RESOLVED_ROOT="$(cd "$DETECTED_ROOT" 2>/dev/null && pwd -P)" || RESOLVED_ROOT=""
+      # Keep SEARCH_ROOT at the physical CWD when Git returns an unusable path.
+      # That fails closed to CWD-only lookup instead of walking past the repo.
+      if [ -n "$RESOLVED_ROOT" ]; then
+        SEARCH_ROOT="$RESOLVED_ROOT"
+      fi
+    fi
   fi
-done
+  while [ -n "$SEARCH_DIR" ]; do
+    candidate="$SEARCH_DIR/.agents/skills/book-to-skill/scripts/extract.py"
+    if [ -f "$candidate" ]; then
+      SCRIPT_PATH="$candidate"
+      return
+    fi
+    [ "$SEARCH_DIR" = "$SEARCH_ROOT" ] && return
+    PARENT_DIR="$(dirname "$SEARCH_DIR")"
+    [ "$PARENT_DIR" = "$SEARCH_DIR" ] && return
+    SEARCH_DIR="$PARENT_DIR"
+  done
+}
+
+select_first_helper() {
+  for candidate in "$@"; do
+    if [ -f "$candidate" ]; then
+      SCRIPT_PATH="$candidate"
+      return
+    fi
+  done
+}
+
+# Each host follows its own discovery order. In particular, only Codex allows a
+# repository helper to precede the corresponding personal installation.
+case "$HOST_AGENT" in
+codex)
+  find_codex_project_helper
+  [ -n "$SCRIPT_PATH" ] || select_first_helper \
+    "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
+    "/etc/codex/skills/book-to-skill/scripts/extract.py"
+  ;;
+copilot)
+  select_first_helper \
+    "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
+    "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
+    ".github/skills/book-to-skill/scripts/extract.py" \
+    ".claude/skills/book-to-skill/scripts/extract.py" \
+    ".agents/skills/book-to-skill/scripts/extract.py"
+  ;;
+amp)
+  select_first_helper \
+    "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
+    "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
+    "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py" \
+    ".agents/skills/book-to-skill/scripts/extract.py"
+  ;;
+claude)
+  select_first_helper \
+    "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
+    ".claude/skills/book-to-skill/scripts/extract.py"
+  ;;
+esac
 
 if [ -z "$SCRIPT_PATH" ]; then
   echo "Could not find scripts/extract.py for book-to-skill" >&2
@@ -307,12 +377,13 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 | **GitHub Copilot CLI** | `~/.copilot/skills` → `~/.agents/skills` | `.github/skills` → `.claude/skills` → `.agents/skills` |
 | **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
+| **OpenAI Codex** | `~/.agents/skills` | `.agents/skills` at the appropriate CWD-to-repo-root scope |
 
 Selection rules:
 1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
 2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
 3. If the user explicitly asked for project-local output, prefer the project-local row.
-4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, or Claude Code?"
+4. If you cannot identify the host, ask: "Which agent are you running this in — OpenAI Codex, GitHub Copilot CLI, Amp, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:
@@ -329,6 +400,9 @@ If the user selects **Update / Fold-in**, proceed immediately to the **Update / 
 ```bash
 mkdir -p "$SKILLS_HOME/<skill_name>/chapters"
 ```
+
+Do not copy this converter's `agents/openai.yaml` into a generated skill; that
+metadata identifies `book-to-skill`, not the generated book knowledge.
 
 ---
 
@@ -575,7 +649,9 @@ Usage:
   Ask <skill_name> about <topic>        → find and explain a topic
   Ask <skill_name> for ch<N>            → dive into a specific chapter
 
-Reload (if your agent doesn't auto-detect new skills):
+Discovery refresh / verification:
+  OpenAI Codex:       auto-detects changes; run /skills or type $<skill_name>
+                      to mention it explicitly; restart Codex if it is absent
   GitHub Copilot CLI:  /skills reload
   Claude Code:         restart the session
   Amp:                 restart the session

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Book to Skill"
+  short_description: "Turn documents into reusable agent skills"
+  default_prompt: "Use $book-to-skill to convert a document into a structured, reusable agent skill."

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,9 +33,10 @@ document into clean text + metadata; the agent turns that into a structured skil
                                    ▼
                 <SKILLS_HOME>/<slug>/  ← chosen per host:
                   ~/.copilot/skills/   GitHub Copilot CLI
-                  ~/.agents/skills/    Copilot CLI or Amp (cross-agent)
+                  ~/.agents/skills/    Codex, Copilot CLI, or Amp
                   ~/.claude/skills/    Claude Code
                   .github|.claude|.agents/skills/  project-local
+                  (Codex scans .agents/skills from CWD through the repo root)
                   SKILL.md         core frameworks + chapter & topic index (~4K)
                   chapters/*.md    on-demand, loaded only when asked
                   glossary.md      terms
@@ -65,7 +66,8 @@ document into clean text + metadata; the agent turns that into a structured skil
 | `scripts/extractor/parsers/` | one module per format |
 | `scripts/extractor/dependencies.py` | optional-dependency probing + `--check` |
 | `tools/discovery_tax.py` | measures token cost vs context-dump / discovery loop |
-| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude|copilot|amp`) |
+| `agents/openai.yaml` | optional Codex/ChatGPT interface metadata for the converter skill |
+| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude\|codex\|copilot\|amp`) |
 | `SKILL.md` | the generator spec (Steps 0–10 + fold-in workflow) |
 
 ## Extending

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,20 +45,35 @@ Turn any book or document into a structured, on-demand agent skill — named fra
 
     ---
 
-    One `SKILL.md` runs on Claude Code, GitHub Copilot CLI, and Amp through the
-    open Agent Skills standard.
+    One `SKILL.md` runs on OpenAI Codex, Claude Code, GitHub Copilot CLI, and Amp
+    through the open Agent Skills standard.
 
 </div>
 
 ## Install
 
-**As an agent skill** (gives you the `/book-to-skill` command in Claude Code, Copilot CLI, Amp):
+**As an agent skill** (`/book-to-skill` in Claude Code, Copilot CLI, or Amp;
+`$book-to-skill` in Codex):
 
 ```bash
+# OpenAI Codex (also shared with Copilot CLI and Amp)
+git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
+# Claude Code
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
-# then, in your agent session:
-/book-to-skill /path/to/book.pdf [skill-name]
 ```
+
+Then invoke the skill inside the agent, not in your shell:
+
+```text
+# Claude Code, Copilot CLI, or Amp
+/book-to-skill /path/to/book.pdf [skill-name]
+# OpenAI Codex
+$book-to-skill /path/to/book.pdf [skill-name]
+```
+
+Codex also discovers project skills from `.agents/skills` between the current
+directory and repository root. It detects changes automatically; use `/skills`
+or type `$book-to-skill`, and restart Codex if the skill does not appear.
 
 **As a standalone CLI** (just the text extractor, optional):
 

--- a/tests/test_codex_metadata.py
+++ b/tests/test_codex_metadata.py
@@ -1,0 +1,300 @@
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAI_METADATA = ROOT / "agents" / "openai.yaml"
+
+
+def metadata_scalar(key):
+    text = OPENAI_METADATA.read_text(encoding="utf-8")
+    match = re.search(rf"^\s+{re.escape(key)}:\s+\"([^\"]+)\"$", text, re.MULTILINE)
+    assert match is not None, f"missing quoted interface.{key}"
+    return match.group(1)
+
+
+def documented_lookup():
+    skill_text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    block_start = skill_text.index('```bash\nHOST_AGENT="') + len("```bash\n")
+    block_end = skill_text.index("\nPYTHON_BIN=", block_start)
+    return skill_text[block_start:block_end]
+
+
+def required_shell_tools():
+    shell = shutil.which("sh")
+    git = shutil.which("git")
+    if shell is None or git is None:
+        pytest.skip("a POSIX shell and git are required for the documented lookup")
+    return shell, git
+
+
+def test_codex_metadata_has_valid_interface_contract():
+    text = OPENAI_METADATA.read_text(encoding="utf-8")
+    short_description = metadata_scalar("short_description")
+    default_prompt = metadata_scalar("default_prompt")
+
+    assert metadata_scalar("display_name") == "Book to Skill"
+    assert 25 <= len(short_description) <= 64
+    assert "$book-to-skill" in default_prompt
+    assert "\npolicy:" not in text
+    assert "\ndependencies:" not in text
+    assert "icon_" not in text
+
+
+def test_documented_helper_lookup_finds_ancestor_agents_skill(tmp_path):
+    shell, git = required_shell_tools()
+    project = tmp_path / "project"
+    nested_cwd = project / "packages" / "reader"
+    helper = (
+        project
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    nested_cwd.mkdir(parents=True)
+    helper.parent.mkdir(parents=True)
+    helper.write_text("# helper fixture\n", encoding="utf-8")
+    subprocess.run([git, "init", "-q", project], check=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "empty-home")
+    env["HOST_AGENT"] = "codex"
+    result = subprocess.run(
+        [shell, "-c", f'{documented_lookup()}\nprintf "%s" "$SCRIPT_PATH"\n'],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout) == helper
+
+
+@pytest.mark.parametrize(
+    ("host_agent", "personal_root"),
+    [
+        ("copilot", Path(".copilot/skills")),
+        ("amp", Path(".agents/skills")),
+        ("claude", Path(".claude/skills")),
+    ],
+)
+def test_existing_hosts_keep_personal_helper_precedence(
+    tmp_path, host_agent, personal_root
+):
+    shell, git = required_shell_tools()
+    project = tmp_path / "project"
+    nested_cwd = project / "packages" / "reader"
+    project_helper = (
+        nested_cwd
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    personal_helper = (
+        tmp_path
+        / "home"
+        / personal_root
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    nested_cwd.mkdir(parents=True)
+    project_helper.parent.mkdir(parents=True)
+    personal_helper.parent.mkdir(parents=True)
+    project_helper.write_text("# project helper fixture\n", encoding="utf-8")
+    personal_helper.write_text("# personal helper fixture\n", encoding="utf-8")
+    subprocess.run([git, "init", "-q", project], check=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["HOST_AGENT"] = host_agent
+    result = subprocess.run(
+        [shell, "-c", f'{documented_lookup()}\nprintf "%s" "$SCRIPT_PATH"\n'],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout) == personal_helper
+
+
+def test_codex_project_helper_precedes_personal_install(tmp_path):
+    shell, git = required_shell_tools()
+    project = tmp_path / "project"
+    nested_cwd = project / "packages" / "reader"
+    project_helper = (
+        project
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    personal_helper = (
+        tmp_path
+        / "home"
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    nested_cwd.mkdir(parents=True)
+    project_helper.parent.mkdir(parents=True)
+    personal_helper.parent.mkdir(parents=True)
+    project_helper.write_text("# project helper fixture\n", encoding="utf-8")
+    personal_helper.write_text("# personal helper fixture\n", encoding="utf-8")
+    subprocess.run([git, "init", "-q", project], check=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["HOST_AGENT"] = "codex"
+    result = subprocess.run(
+        [shell, "-c", f'{documented_lookup()}\nprintf "%s" "$SCRIPT_PATH"\n'],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout) == project_helper
+
+
+def test_codex_personal_helper_precedes_other_host_roots(tmp_path):
+    shell, git = required_shell_tools()
+    project = tmp_path / "project"
+    nested_cwd = project / "packages" / "reader"
+    codex_helper = (
+        tmp_path
+        / "home"
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    copilot_helper = (
+        tmp_path
+        / "home"
+        / ".copilot"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    nested_cwd.mkdir(parents=True)
+    codex_helper.parent.mkdir(parents=True)
+    copilot_helper.parent.mkdir(parents=True)
+    codex_helper.write_text("# Codex helper fixture\n", encoding="utf-8")
+    copilot_helper.write_text("# Copilot helper fixture\n", encoding="utf-8")
+    subprocess.run([git, "init", "-q", project], check=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["HOST_AGENT"] = "codex"
+    result = subprocess.run(
+        [shell, "-c", f'{documented_lookup()}\nprintf "%s" "$SCRIPT_PATH"\n'],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout) == codex_helper
+
+
+def test_documented_helper_lookup_stops_at_repository_root(tmp_path):
+    shell, git = required_shell_tools()
+    project = tmp_path / "parent" / "project"
+    nested_cwd = project / "packages" / "reader"
+    outside_helper = (
+        tmp_path
+        / "parent"
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    nested_cwd.mkdir(parents=True)
+    outside_helper.parent.mkdir(parents=True)
+    outside_helper.write_text("# outside trust boundary\n", encoding="utf-8")
+    subprocess.run([git, "init", "-q", project], check=True)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "empty-home")
+    env["HOST_AGENT"] = "codex"
+    result = subprocess.run(
+        [shell, "-c", documented_lookup()],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "Could not find scripts/extract.py" in result.stderr
+    assert str(outside_helper) not in result.stdout
+
+
+def test_documented_helper_lookup_fails_closed_for_unusable_git_root(tmp_path):
+    shell, _ = required_shell_tools()
+    project = tmp_path / "parent" / "project"
+    nested_cwd = project / "packages" / "reader"
+    outside_helper = (
+        tmp_path
+        / "parent"
+        / ".agents"
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    fake_bin = tmp_path / "fake-bin"
+    fake_git = fake_bin / "git"
+    nested_cwd.mkdir(parents=True)
+    outside_helper.parent.mkdir(parents=True)
+    fake_bin.mkdir()
+    outside_helper.write_text("# outside trust boundary\n", encoding="utf-8")
+    fake_git.write_text(
+        "#!/bin/sh\nprintf '%s\\n' '/path/that/does/not/exist'\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "empty-home")
+    env["HOST_AGENT"] = "codex"
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    result = subprocess.run(
+        [shell, "-c", documented_lookup()],
+        cwd=nested_cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 1
+    assert "Could not find scripts/extract.py" in result.stderr
+    assert str(outside_helper) not in result.stdout

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -1,0 +1,116 @@
+import pytest
+
+from tools.validate_skill import LENSES, audit
+
+
+def write_skill(tmp_path, frontmatter, body="Use the skill.\n"):
+    skill_path = tmp_path / "SKILL.md"
+    skill_path.write_text(
+        f"---\n{frontmatter}---\n{body}",
+        encoding="utf-8",
+    )
+    return skill_path
+
+
+@pytest.mark.parametrize(
+    ("lens", "allowed_tools"),
+    [
+        ("claude", "Bash Read"),
+        ("copilot", "bash write"),
+        ("amp", "Bash shell_command"),
+    ],
+)
+def test_existing_lenses_still_accept_their_shell_tools(
+    tmp_path, lens, allowed_tools
+):
+    skill_path = write_skill(
+        tmp_path,
+        f"name: example\ndescription: Example skill\nallowed-tools: {allowed_tools}\n",
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    assert audit(skill_path, lens=lens) == ([], [])
+
+
+def test_codex_does_not_treat_allowed_tools_as_permissions(tmp_path):
+    skill_path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: Read\n"
+        ),
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    errors, warns = audit(skill_path, lens="codex")
+
+    assert errors == []
+    assert len(warns) == 1
+    assert "not enforced by OpenAI Codex 0.142.4" in warns[0]
+    assert "omits" not in warns[0]
+
+
+def test_claude_still_errors_when_declaration_omits_shell_tool(tmp_path):
+    skill_path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: Read\n"
+        ),
+        "```bash\npython3 scripts/example.py\n```\n",
+    )
+
+    errors, warns = audit(skill_path, lens="claude")
+
+    assert len(errors) == 1
+    assert "'Bash'" in errors[0]
+    assert warns == []
+
+
+@pytest.mark.parametrize(
+    ("lens", "expects_error", "echoes_tool_name"),
+    [
+        ("claude", True, True),
+        ("copilot", False, True),
+        ("amp", False, True),
+        ("codex", False, False),
+    ],
+)
+def test_external_tool_lists_follow_lens_semantics(
+    tmp_path, lens, expects_error, echoes_tool_name
+):
+    skill_path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "allowed-tools: linear__list_issues\n"
+        ),
+    )
+
+    errors, warns = audit(skill_path, lens=lens)
+
+    assert bool(errors) is expects_error
+    assert len(warns) == 1
+    assert ("linear__list_issues" in warns[0]) is echoes_tool_name
+
+
+def test_codex_recognizes_portable_frontmatter(tmp_path):
+    skill_path = write_skill(
+        tmp_path,
+        (
+            "name: example\n"
+            "description: Example skill\n"
+            "license: MIT\n"
+            "metadata:\n"
+            "  short-description: Short example\n"
+        ),
+    )
+
+    assert audit(skill_path, lens="codex") == ([], [])
+
+
+def test_codex_lens_is_available():
+    assert LENSES["codex"]["label"] == "OpenAI Codex"

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -7,14 +7,14 @@ Severity:
 
 Lenses:
   claude   — Claude Code rules (default; back-compat)
+  codex    — OpenAI Codex rules
   copilot  — GitHub Copilot CLI rules
   amp      — Sourcegraph Amp rules
 
 The SKILL.md format itself is an open standard
 (https://github.com/agentskills/agentskills) — `name` + `description` are the
-only universally-required fields. Lenses differ on which `allowed-tools` names
-are recognized and which extra frontmatter keys are accepted vs. silently
-ignored.
+only universally-required fields. Lenses differ on which extra frontmatter
+keys are accepted and whether `allowed-tools` is enforced or ignored.
 
 Refs:
   Claude     https://code.claude.com/docs/en/skills
@@ -22,8 +22,13 @@ Refs:
   Copilot    https://docs.github.com/en/copilot/concepts/agents/about-agent-skills
              https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills
   Amp        https://ampcode.com/manual#skills
+  Codex      https://learn.chatgpt.com/docs/build-skills.md
 
-Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp] [path/to/SKILL.md]
+Codex behavior is pinned to codex-cli 0.142.4. Its loader does not enforce
+`allowed-tools`; runtime tool availability, sandboxing, and approval policy
+remain authoritative.
+
+Usage: python3 tools/validate_skill.py [--lens claude|codex|copilot|amp] [path/to/SKILL.md]
 """
 import argparse
 import re
@@ -60,6 +65,7 @@ LENSES = {
         "recognized_keys": {"name", "description", "allowed-tools", "license"},
         "reserved_name_words": {"anthropic", "claude"},
         "bash_tool_names": {"Bash"},
+        "analyze_allowed_tools": True,
         "unknown_tool_severity": "error",
     },
     "copilot": {
@@ -68,6 +74,7 @@ LENSES = {
         "recognized_keys": {"name", "description", "allowed-tools", "license"},
         "reserved_name_words": set(),
         "bash_tool_names": {"shell", "bash"},
+        "analyze_allowed_tools": True,
         # Unknown tokens are likely MCP server names — Copilot accepts them.
         "unknown_tool_severity": "warn",
     },
@@ -80,6 +87,25 @@ LENSES = {
         },
         "reserved_name_words": set(),
         "bash_tool_names": {"shell_command", "Bash"},
+        "analyze_allowed_tools": True,
+        "unknown_tool_severity": "warn",
+    },
+    "codex": {
+        "label": "OpenAI Codex",
+        "tools": set(),
+        # OpenAI's portable skill validator accepts these fields. The current
+        # Codex loader consumes name, description, and metadata while safely
+        # ignoring the remaining portable metadata.
+        "recognized_keys": {
+            "name", "description", "license", "allowed-tools", "metadata",
+        },
+        "reserved_name_words": set(),
+        "bash_tool_names": set(),
+        "analyze_allowed_tools": False,
+        "allowed_tools_note": (
+            "accepted as portable metadata but not enforced by OpenAI Codex "
+            "0.142.4; runtime tools, sandboxing, and approval policy still apply"
+        ),
         "unknown_tool_severity": "warn",
     },
 }
@@ -158,30 +184,38 @@ def audit(path, lens="claude"):
         inline = get_scalar(fm, "allowed-tools")
         if inline:
             tools = inline.split()
-    if tools:  # a restriction is declared -> the host enforces it
-        bases = {tool_base(t) for t in tools}
-        known = {b for b in bases if b in rules["tools"]}
-        unknown = [t for t in tools if tool_base(t) not in rules["tools"]]
-        uses_bash = bool(re.search(r"```bash", body)) or "python3 " in body
-        if uses_bash and not (bases & rules["bash_tool_names"]):
-            bash_names = " or ".join(f"'{n}'" for n in sorted(rules["bash_tool_names"]))
-            errors.append(
-                f"allowed-tools declares a restriction but omits {bash_names}, yet the "
-                f"skill runs bash/python3 — under {label} those steps would be blocked"
-            )
-        if not known and rules["tools"]:
-            # Claude: hard error (none of the listed tools are recognized).
-            # Copilot/Amp: tokens are likely MCP names — handled by the warn path.
-            if rules["unknown_tool_severity"] == "error":
-                errors.append(f"allowed-tools: no recognized {label} tool in the list")
-        if unknown:
-            msg = (f"allowed-tools: {unknown} are not {label} built-in tool names "
-                   f"(treated as MCP-server names by Copilot, ignored by Claude)")
-            if rules["unknown_tool_severity"] == "error":
-                # Already covered by the 'no recognized tool' error if list is all-unknown;
-                # otherwise it's a soft note.
-                warns.append(msg)
-            else:
+    if tools:
+        if not rules["analyze_allowed_tools"]:
+            # Codex does not interpret this field as a permission grant. Host
+            # tool checks here would create false policy errors and misdescribe
+            # the sandbox that actually governs execution.
+            warns.append(f"allowed-tools: {rules['allowed_tools_note']}")
+        else:
+            bases = {tool_base(t) for t in tools}
+            known = {b for b in bases if b in rules["tools"]}
+            unknown = [t for t in tools if tool_base(t) not in rules["tools"]]
+            uses_bash = bool(re.search(r"```bash", body)) or "python3 " in body
+            if uses_bash and not (bases & rules["bash_tool_names"]):
+                bash_names = " or ".join(
+                    f"'{n}'" for n in sorted(rules["bash_tool_names"])
+                )
+                errors.append(
+                    f"allowed-tools declares a restriction but omits {bash_names}, "
+                    f"yet the skill runs bash/python3 — under {label} those steps "
+                    "would be blocked"
+                )
+            if not known and rules["tools"]:
+                # Claude: hard error (none of the listed tools are recognized).
+                # Copilot/Amp: tokens are likely MCP names — handled below.
+                if rules["unknown_tool_severity"] == "error":
+                    errors.append(
+                        f"allowed-tools: no recognized {label} tool in the list"
+                    )
+            if unknown:
+                msg = (
+                    f"allowed-tools: {unknown} are not {label} built-in tool names "
+                    "(treated as MCP-server names by Copilot, ignored by Claude)"
+                )
                 warns.append(msg)
 
     for k in top_level_keys(fm):
@@ -217,4 +251,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary (Required)
Adds first-class OpenAI Codex support to book-to-skill: native skill metadata, repository/user/admin discovery guidance, `$book-to-skill` invocation, host-aware destination and helper resolution, a Codex validator lens, regression tests, and CI coverage. The implementation is an independent change against `master` and contains no Grok-specific code.

## Type of change (Required)
- [x] ✨ Feature (non-breaking change that adds capability)
- [x] 🔒 Security
- [x] 🧹 Chore / CI / tooling

## What it does (Required)
- **Fixes:** prevents shared helper lookup from crossing the Git-root trust boundary or letting one host's project/personal roots silently shadow another host's selected installation.
- **Improves:** expands the CI host-compatibility matrix from 3 to 4 lenses and preserves Claude/Copilot/Amp tool checks while modeling Codex's runtime-controlled permissions.
- **Adds:** `agents/openai.yaml`, `$book-to-skill` usage, Codex project/user/admin roots, `/skills` verification guidance, `validate_skill.py --lens codex`, and executable discovery/precedence tests.

## Motivation & context (Required)
Closes #n/a — no tracking issue; this contribution adds the requested OpenAI Codex integration.

Codex discovers skills from `.agents/skills` between the current directory and repository root, then user and administrator scopes. The project previously documented neither those roots nor `$skill` invocation, and its validator could not represent Codex's treatment of `allowed-tools` as non-enforced metadata.

## How it works (Required)
The PR adds minimal OpenAI interface metadata and teaches the portable skill how Codex discovers, invokes, reloads, and writes generated skills. Helper resolution is explicitly host-aware: Codex follows project → user → admin precedence with a Git-root-bounded, fail-closed ancestor walk; Copilot, Amp, and Claude retain matching host-specific personal/project orders. The Codex lens validates portable frontmatter but reports that runtime tools, sandbox, and approvals—not `allowed-tools`—control access in Codex 0.142.4.

## Evidence (Required)
- **Tests:** 183 tests passed on every supported interpreter (Python 3.9, 3.10, 3.11, 3.12, and 3.13); 20 focused metadata/validator tests cover interface constraints, explicit host precedence, dual installs, foreign-root rejection, failed-root resolution, Codex permission semantics, and existing-host behavior.
- **Before / after:** `--lens codex` was not a valid target on `master`; this branch passes all four host lenses. Codex CLI 0.142.4 discovered the exact committed project skill from a nested directory and completed explicit `$book-to-skill` invocation in a read-only, ephemeral session.

```text
$ codex --version
codex-cli 0.142.4

$ codex exec --ephemeral --sandbox read-only -m gpt-5.4 ... 'Use $book-to-skill ...'
SKILL_NAME=book-to-skill
FIRST_NUMBERED_MODE=1. Full Conversion (Default)
CODEX_PERSONAL_ROOT=~/.agents/skills/

$ for py in 3.9 3.10 3.11 3.12 3.13; do pytest tests/ -q; done
183 passed (each interpreter)

$ pytest tests/test_codex_metadata.py tests/test_validate_skill.py -q
20 passed
```

Additional clean gates: Ruff E9/F, Claude/Codex/Copilot/Amp lenses, official skill quick validation, four YAML files, sdist/wheel build, dependency-free extraction smoke, MkDocs build, Bandit high-severity/medium-confidence, and `git diff --check`. Grok Build's high-effort release review independently reproduced the focused/full tests, Ruff, and four lenses, then returned APPROVE after two trust-boundary findings were fixed.

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)
The terminal evidence above is the changed user-facing output: native Codex discovery and `$book-to-skill` activation resolve the expected repository skill and metadata.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `for lens in claude codex copilot amp; do python3 tools/validate_skill.py --lens "$lens" SKILL.md; done` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; `SKILL.md` growth is justified by Codex discovery, trust-order helper routing, destination selection, and reload instructions

## Breaking changes & back-compat (Optional)
None. Existing hosts keep their documented skill roots and validator semantics. `allowed-tools` remains omitted from this cross-agent skill so each runtime enforces its own tool/sandbox/approval policy.

## Notes for reviewers (Optional)
This PR is independent of the companion Grok Build PR and targets `master` directly. Both are individually mergeable now; because they touch shared host lists and the validator CI matrix, the second one merged may need a small rebase. The native Codex test used `-m gpt-5.4` because this machine's configured newer model requires a newer CLI than the integration's pinned Codex 0.142.4 test version.