### PR TITLE
fix(extractor): exclude source banners from chapter detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PyPDF2` is end-of-life and no longer receives security fixes (#54).
 
 ### Fixed
+- Consolidated chapter detection now analyzes extracted source text without the generated
+  `SOURCE:` boundary banners, preventing those banners from becoming phantom setext headings
+  and collapsing `chapters_detected` to 2 for short source paths (#81).
 - **`Chapter I.` — a chapter word followed by a Roman numeral — is now detected.** It
   matched neither existing pattern (`_EXPLICIT_CHAPTER` required Arabic digits after the
   chapter word; `_ROMAN_HEAD` required the numeral to start the line), so books using

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -646,8 +646,11 @@ def main():
     total_words = len(consolidated_text.split())
     total_tokens = estimate_tokens(consolidated_text)
     
-    # Detect structure on consolidated text
-    consolidated_structure = detect_structure(consolidated_text)
+    # Detect structure from source content only. The generated SOURCE banners in
+    # full_text.txt use rows of "=", which can otherwise become phantom setext
+    # headings and make the result depend on the source-path length.
+    structure_text = "\n\n".join(src["text"] for src in extracted_sources)
+    consolidated_structure = detect_structure(structure_text)
     
     metadata = {
         "source_file": "Consolidated from multiple sources" if len(extracted_sources) > 1 else extracted_sources[0]["source_file"],

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -366,6 +366,49 @@ class TestBatchResilience:
         meta = json.loads(out_meta.read_text(encoding="utf-8"))
         assert meta["total_sources"] == 1
 
+    @pytest.mark.parametrize(
+        "reported_source",
+        ["/x/sample.md", "/deep/" + ("nested/" * 12) + "sample.md"],
+    )
+    def test_source_banner_does_not_change_structural_chapter_count(
+        self, tmp_path, monkeypatch, reported_source
+    ):
+        """The generated SOURCE banner must not become a phantom setext heading."""
+        source = _make_md_file(
+            tmp_path / "sample.md",
+            "# The Pragmatic Widget\n\n"
+            "## Foundations\n\nBody.\n\n"
+            "## Design Rules\n\nBody.\n\n"
+            "## Trade-offs\n\nBody.\n\n"
+            "## Operating Model\n\nBody.\n\n"
+            "## Closing\n\nBody.\n",
+        )
+        out_dir = tmp_path / "output"
+        out_text = out_dir / "full_text.txt"
+        out_meta = out_dir / "metadata.json"
+        real_extract = extract_single_file
+
+        def extract_with_reported_source(*args, **kwargs):
+            result = real_extract(*args, **kwargs)
+            result["source_file"] = reported_source
+            return result
+
+        monkeypatch.setattr("sys.argv", ["extract.py", str(source), "--install-missing", "no"])
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_DIR", out_dir)
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_TEXT", out_text)
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_META", out_meta)
+        monkeypatch.setattr("book_to_skill.utils.prepare_dependencies", lambda *a: None)
+        monkeypatch.setattr(
+            "book_to_skill.utils.extract_single_file", extract_with_reported_source
+        )
+
+        main()
+
+        metadata = json.loads(out_meta.read_text(encoding="utf-8"))
+        assert metadata["sources"][0]["chapters_detected"] == 5
+        assert metadata["chapters_detected"] == 5
+        assert "SOURCE: sample.md" in out_text.read_text(encoding="utf-8")
+
     def test_extraction_error_is_not_system_exit(self):
         """ExtractionError should NOT be a subclass of SystemExit."""
         assert not issubclass(ExtractionError, SystemExit)


### PR DESCRIPTION
## Summary (Required)

Exclude generated `SOURCE:` boundary banners from consolidated structure detection so short source paths no longer collapse structural chapter counts to 2. The emitted `full_text.txt` remains unchanged.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** consolidated chapter detection no longer parses the extractor's generated `SOURCE:` banners as setext headings.
- **Improves:** top-level `chapters_detected` now agrees with the per-source count for structural-fallback books regardless of source-path length.

## Motivation & context (Required)

The generated banner uses 80-character `=` rules. For a short source path, the second rule turns the preceding `SOURCE:` line into a phantom depth-1 setext heading. Combined with a real H1 title, that makes `_structural_chapter_count()` return 2 before reaching the actual chapter level.

Fixes #81

## How it works (Required for anything non-trivial)

The extraction flow still writes the same banner-delimited `full_text.txt` and still includes those bytes in output metrics. Only structure detection receives a separate view built by joining the already-extracted source texts without generated presentation banners.

This preserves cross-source numeric chapter deduplication and table-of-contents detection without coupling the general parser to the current banner format. The alternative—special-casing banners inside `detect_structure()`—would make parser behavior depend on generated output formatting.

## Evidence (Required)

- **Tests:** added an integration regression that runs the real extraction flow for both short and long reported source paths, verifies per-source and top-level counts remain 5, and verifies the source banner is still emitted.
- **Before / after:** the short-path case fails on `master` with a top-level count of 2 and passes after the fix with 5.

```text
Before (master c6bc1b7):
sources[0].chapters_detected = 5
chapters_detected = 2
assert 2 == 5

After:
$ python -m pytest -q tests/test_book_to_skill.py::TestBatchResilience::test_source_banner_does_not_change_structural_chapter_count
2 passed in 0.09s

$ python -m pytest -q
165 passed in 0.15s

$ ruff check .
All checks passed!
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

```text
Before: Chapters: 2 detected overall
After:  Chapters: 5 detected overall
```

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Korean heading support from #82 is intentionally out of scope; this fixes the language-independent fallback path only.
