### PR TITLE
fix(security): strip word joiners from extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before a generated skill is accepted or published. Findings identify only the
   rule and file/line location and never echo attacker-controlled text (#73).
 - **Invisible-Unicode extraction hardening** — every parser result now removes
-  zero-width U+200B/U+200C/U+200D/U+FEFF characters and the Unicode tag block
+  zero-width U+200B/U+200C/U+200D/U+2060/U+FEFF characters and the Unicode tag block
   U+E0000-U+E007F before metrics or `full_text.txt` are produced, reports the
   removal count, and rejects sources containing no visible content after the scrub.
 - **DOCX XXE / Billion Laughs hardening** — the DOCX extractor now scans the

--- a/book_to_skill/sanitize.py
+++ b/book_to_skill/sanitize.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-_ZERO_WIDTH_CODEPOINTS = frozenset({0x200B, 0x200C, 0x200D, 0xFEFF})
+_ZERO_WIDTH_CODEPOINTS = frozenset({0x200B, 0x200C, 0x200D, 0x2060, 0xFEFF})
 _TAG_BLOCK_START = 0xE0000
 _TAG_BLOCK_END = 0xE007F
 

--- a/tests/test_sanitize_extracted_text.py
+++ b/tests/test_sanitize_extracted_text.py
@@ -13,6 +13,7 @@ INVISIBLE_CODEPOINTS = (
     "\u200b"
     "\u200c"
     "\u200d"
+    "\u2060"
     "\ufeff"
     "\U000e0000"
     "\U000e0069"


### PR DESCRIPTION
## Summary

Strip the Unicode U+2060 word joiner from extracted text. This completes the existing invisible-Unicode scrub so it matches the generated-skill scanner.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [x] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** U+2060 passed through extraction even though the repository scanner classifies it as invisible Unicode.
- **Improves:** all parser outputs now remove this word joiner before metrics and `full_text.txt` are written.

## Motivation & context

Closes #n/a — scanner and extraction sanitization used inconsistent invisible-Unicode sets.

## How it works

Adds U+2060 to the existing frozen sanitizer set and extends the established regression fixture. No parser, ordering, CLI, or public API behavior changes.

## Evidence

- **Tests:** `pytest -q` — 163 passed; `pytest -q tests/test_sanitize_extracted_text.py tests/test_scan_generated_skill.py` — 15 passed.
- **Checks:** `ruff check .` and `python3 tools/validate_skill.py SKILL.md` pass.
- **Before / after:** input `before<U+2060>after` previously remained unchanged with a removal count of 0; it now becomes `beforeafter` with a removal count of 1.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
