### PR TITLE
docs: add video-to-skill as a related project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   treated as headings.
 
 ### Documentation
+- Added the independently maintained
+  [video-to-skill](https://github.com/Lum1104/video-to-skill) project to the
+  README's related projects section.
 - Clarified the two install paths so they are not confused: **`git clone` into a
   skills folder** registers the `/book-to-skill` agent skill (Claude Code / Copilot
   CLI / Amp), while **`pip install book-to-skill`** installs only the standalone

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   <a href="#-how-it-works">How it works</a> ·
   <a href="#-the-discovery-loop-tax">Discovery Loop Tax</a> ·
   <a href="#-faq">FAQ</a> ·
+  <a href="#-related-projects">Related projects</a> ·
   <a href="#-install">Install</a> ·
   <a href="CHANGELOG.md">Changelog</a> ·
   <a href="docs/PERFORMANCE.md">Performance</a> ·
@@ -342,6 +343,12 @@ It also shines for books Claude doesn't know at all: niche technical references,
 Absolutely true — if your workflow is "I have 80 separate books and I want to search across all of them," NotebookLM is the right tool.
 
 book-to-skill is built for a different job: you want to go deep on a specific topic or library, having multiple related documents (papers, chapters, notes) folded into a single unified skill, and even updating it over time as new material arrives! This integrates your customized knowledge base right into your coding or writing workflow, rather than in a separate browser tab.
+
+---
+
+## 🔗 Related projects
+
+- **[video-to-skill](https://github.com/Lum1104/video-to-skill)** — an independently maintained project inspired by book-to-skill that creates evidence-grounded agent skills from videos, playlists, courses, and local media.
 
 ---
 


### PR DESCRIPTION
## Summary (Required)

Adds a `Related projects` section to the README linking [video-to-skill](https://github.com/Lum1104/video-to-skill), the independently maintained project raised in #87, plus a nav anchor and a CHANGELOG entry. Documentation only; no code paths change.

Closes #87

## Type of change (Required)

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Adds:** a `Related projects` section to the README, listing video-to-skill with a one-line description of its video/playlist/course focus.
- **Adds:** a `Related projects` link to the README's existing top navigation row, so the new section is reachable from the header.
- **Adds:** a CHANGELOG entry under `## [Unreleased]` in the `### Documentation` subsection.

## Motivation & context (Required)

In #87 the author of video-to-skill introduced it as a separate project inspired by book-to-skill that builds evidence-grounded agent skills from videos, playlists, courses, and local media. You agreed to link it from a new related-projects section and left the issue open to track that documentation change.

The README currently has no such section, so there is no first-party path from book-to-skill to the adjacent multimodal implementation. This PR adds only that pointer.

## How it works (Required for anything non-trivial)

Not applicable - this is a documentation-only change with no runtime behavior.

The section is placed after the FAQ and before Install, which keeps the existing reading order (what it is, how it works, FAQ, related work, install) intact. Wording is deliberately limited to what #87 establishes: it names the project as independently maintained and describes its video/course scope, without implying compatibility, endorsement, shared maintenance, or any integration that does not exist.

## Evidence (Required)

- **Tests:** `python3 -m pytest -q` gives 188 passed on this branch. No tests were added; the change touches no code.
- **Before / after:** before, the README had no related-projects section and no way to discover video-to-skill from this repo. After, the nav row includes `Related projects` and the section links to `https://github.com/Lum1104/video-to-skill`.
- `python3 tools/validate_skill.py SKILL.md` passes with no blocking issues (one pre-existing soft warning about body length). `SKILL.md` is unchanged by this PR; run for completeness.

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No rendered-behavior change beyond the added README section, which is plain Markdown: a `Related projects` heading followed by a single bullet linking video-to-skill and describing it as independently maintained, covering videos, playlists, courses, and local media.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
  Verified: `git log HEAD..upstream/master` is empty.
- [x] `pytest -q` is green on a clean checkout
  188 passed.
- [ ] `ruff check .` is clean
  Not run: `ruff` is not installed in this environment. This PR changes only `README.md` and `CHANGELOG.md`, so no Python is touched.
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
  `SKILL.md` is unchanged; validator run anyway and passes.
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
  Added under the existing `### Documentation` subsection.
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
  No `SKILL.md` change; no book text added.

## Breaking changes & back-compat (Optional)

None. Documentation only; no public interface, CLI flag, or behavior changes.

## Notes for reviewers (Optional)

Two judgment calls worth a look:

1. Placement. I put the section between FAQ and Install. If you would rather it sit at the bottom near Changelog/Performance, it is a one-block move.
2. Wording. I described the project as independently maintained so no reader infers shared ownership or a support commitment. Happy to reframe.

I left `ruff` unticked rather than claim a check I did not run.
