### PR TITLE
fix(cli): support documented help flags

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -634,16 +634,32 @@ def print_banner() -> None:
         pass  # best-effort: never block extraction on the banner
 
 
+def print_usage() -> None:
+    """Print standalone CLI usage."""
+    print(
+        "Usage: book-to-skill <path-to-document-folder-or-glob>... "
+        "[--mode technical|text] [--install-missing ask|yes|no]",
+        file=sys.stderr,
+    )
+    print(
+        "       book-to-skill --check    # report which extractors are installed",
+        file=sys.stderr,
+    )
+    print(f"Supported formats: {supported_formats_message()}", file=sys.stderr)
+
+
 def main():
     print_banner()
+
+    if any(arg in {"-h", "--help"} for arg in sys.argv[1:]):
+        print_usage()
+        sys.exit(0)
 
     if "--check" in sys.argv[1:]:
         sys.exit(run_dependency_check())
 
     if len(sys.argv) < 2:
-        print("Usage: extract.py <path-to-document-folder-or-glob>... [--mode technical|text] [--install-missing ask|yes|no]", file=sys.stderr)
-        print("       extract.py --check    # report which extractors are installed", file=sys.stderr)
-        print(f"Supported formats: {supported_formats_message()}", file=sys.stderr)
+        print_usage()
         sys.exit(1)
         
     raw_input_paths, extraction_mode, install_mode = parse_arguments(sys.argv)

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1536,6 +1536,38 @@ class TestLowercaseRomanNumerals:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+#  CLI help entry point
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCliHelp:
+    """The documented help flags should print usage and exit successfully."""
+
+    @pytest.mark.parametrize("flag", ["--help", "-h"])
+    def test_help_flag_prints_console_script_usage(self, flag, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["book-to-skill", flag])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 0
+        assert "Usage: book-to-skill" in captured.err
+        assert "extract.py" not in captured.err
+        assert "Unknown flag" not in captured.err
+
+    def test_no_arguments_keeps_error_exit_with_same_usage(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.argv", ["book-to-skill"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code == 1
+        assert "Usage: book-to-skill" in captured.err
+        assert "extract.py" not in captured.err
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 #  Fix #5 — Unknown flag warning in parse_arguments
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary (Required)

Make the README's documented `book-to-skill --help` command and its `-h` alias print standalone CLI usage and exit successfully. The no-argument path reuses the same usage text while retaining its existing error exit.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `--help` and `-h` were treated as unknown flags because the usage block only ran when no arguments were present.
- **Improves:** the existing usage text now names the installed `book-to-skill` command instead of the repository-only `extract.py` shim.

## Motivation & context (Required)

The installation guide directs standalone CLI users to run `book-to-skill --help`, but that command currently prints an unknown-flag warning, no usage, and exits `1`.

Fixes #95

## How it works (Required for anything non-trivial)

A small `print_usage()` helper owns the existing usage output. Help flags dispatch to it before generic argument parsing and exit `0`; the no-argument path calls the same helper and keeps exit `1`. The parser, dependency check, and extraction paths are unchanged.

## Evidence (Required)

- **Tests:** focused help/unknown-flag set passes with 5 tests; full suite passes with 196 tests.
- **Before / after:** both help flags previously exited `1` with an unknown-flag warning; they now exit `0`, print `Usage: book-to-skill`, and do not emit that warning.

```text
Before: --help=1, -h=1; no usage; unknown-flag warning
After:  --help=0, -h=0; book-to-skill usage; no unknown-flag warning
No args remains exit 1 and prints the shared usage text
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

```text
Usage: book-to-skill <path-to-document-folder-or-glob>... [--mode technical|text] [--install-missing ask|yes|no]
       book-to-skill --check    # report which extractors are installed
Supported formats: ...
```

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title is a valid Conventional Commit; `CHANGELOG.md` is not hand-edited
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)

No breaking changes. Unknown flags still warn, no-argument invocation still exits `1`, and `--check` and extraction behavior are unchanged.
