### PR TITLE
docs: offer npx skills add install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ Two halves: a deterministic Python **extractor** (document → clean text + meta
 ## 📥 Install
 
 ```bash
-# Agent skill (registers /book-to-skill) — clone into your skills folder:
+# One command, any host — via the cross-agent skills CLI:
+npx skills add virgiliojr94/book-to-skill
+
+# Or manually — clone into your skills folder (registers /book-to-skill):
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 # (Copilot CLI: ~/.copilot/skills/ · Amp/cross-agent: ~/.agents/skills/)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,8 @@ Turn any book or document into a structured, on-demand agent skill — named fra
 **As an agent skill** (gives you the `/book-to-skill` command in Claude Code, Copilot CLI, Amp):
 
 ```bash
+npx skills add virgiliojr94/book-to-skill
+# or manually:
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 # then, in your agent session:
 /book-to-skill /path/to/book.pdf [skill-name]

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,14 @@ seo_title: "Install book-to-skill - Claude Code, Copilot CLI, Amp, or pip"
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
 
+**One command, any host** — the [`skills` CLI](https://skills.sh) resolves the repo, detects the root `SKILL.md`, and installs the complete skill (including `scripts/extract.py` and `tools/`) into the skills folder of every host you select:
+
+```bash
+npx skills add virgiliojr94/book-to-skill
+```
+
+Prefer a manual install? Every per-host `git clone` path below works exactly the same.
+
 **GitHub Copilot CLI** (personal skill):
 
 ```bash


### PR DESCRIPTION
## Summary (Required)
Documents installation through the cross-agent `skills` CLI (skills.sh): `npx skills add virgiliojr94/book-to-skill`. The CLI already detects the root `SKILL.md` and installs the complete skill - including `scripts/extract.py` and `tools/` - for every supported host in one command; the docs just never offered this path. `git clone` stays documented as the manual alternative.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** an `npx skills add virgiliojr94/book-to-skill` install method to the README Install section, `docs/install.md` (one-command block above the per-host clones), and `docs/index.md`. For users on any Agent Skills host who want a one-command install instead of picking the right `git clone` target per agent.

## Motivation & context (Required)
Closes n/a - no open issue; small docs gap. The install docs say the skill "follows the open Agent Skills standard, so a single install works for any compatible host", but the only agent-skill install offered is a per-host `git clone`. The `skills` CLI is the standard's one-command installer, it already works against this repo unmodified (evidence below), and the repo is already indexed at https://skills.sh/virgiliojr94/book-to-skill.

## How it works (Required for anything non-trivial)
Docs only - no code changes. The `skills` CLI resolves the repo, finds the root `SKILL.md`, and copies/symlinks the whole skill directory into each selected agent's skills folder. Because it installs the entire repo directory, the `scripts/extract.py` discovery list in `SKILL.md` resolves exactly as with a manual `git clone`.

## Evidence (Required)
- **Tests:** none needed (docs only). `ruff check .` clean, `pytest -q` 188 passed on a clean checkout.
- **Before / after:** before - no npx path documented. After - the documented command, run against this repo as-is:

```
$ npx skills add virgiliojr94/book-to-skill --skill book-to-skill -a claude-code -y --copy
◇  Source: https://github.com/virgiliojr94/book-to-skill.git
◇  Repository cloned
◇  Found 1 skill
◇  Installation complete
◇  Installed 1 skill
│  ✓ book-to-skill (copied)
│    → ./.claude/skills/book-to-skill

$ ls .claude/skills/book-to-skill/scripts
banner.txt  extract.py
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Reworked per review: the default-root/symlink generator change was pulled out into its own PR so it can be weighed on its own terms, this PR is docs-only again, the branch is rebased on latest `master` (post-restructure, so `docs/install.md` gets the one-command block), and the hand-written `CHANGELOG.md` entry is gone per the git-cliff policy from #104.
