### PR TITLE
feat(skill): optional GitHub publishing for generated skills (Step 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Two halves: a deterministic Python **extractor** (document → clean text + meta
 
 ## 🚀 Usage
 
-`/book-to-skill <path|folder|glob> [skill-name]` — plus analyze-only, generate-from-analysis, and update/fold-in modes.
+`/book-to-skill <path|folder|glob> [skill-name]` — plus analyze-only, generate-from-analysis, and update/fold-in modes. After a conversion, the converter can publish the skill to GitHub (private by default) so any host installs it with `npx skills add`.
 
 ▶️ **All modes and examples → [docs/usage.md](docs/usage.md)**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -593,18 +593,18 @@ After the Step 10 report, offer once — and only if the Step 9.5 scan passed:
 
 > "Want me to publish this skill to GitHub so any Agent Skills host can install it with `npx skills add`? (private / public / skip)"
 
-If the user declines, stop here. Requirements: the `gh` CLI, authenticated (check `gh auth status`); if unavailable, print the commands below for the user to run manually instead.
+If the user declines, stop here. Requirements: the `gh` CLI, authenticated (check `gh auth status`). If `gh` is missing or unauthenticated, offer to set it up (`brew install gh` or https://cli.github.com, then `gh auth login`) — or use the no-`gh` path: the user creates an empty repo of the chosen visibility in the GitHub web UI, then you run the `git init`/`add`/`commit` commands below followed by `git remote add origin <repo-url> && git push -u origin main`. The visibility rule below applies to the web-created repo exactly the same.
 
 **Visibility is `--private` by default — this is a hard rule, not a suggestion.** Run `gh repo create` with `--private` in every case except one: the user's reply to the question above (or a later explicit instruction) literally contains the word "public". A paraphrase, an ambiguous answer, silence, or your own inference is NOT consent — when in doubt, `--private`. A private repo can be flipped public later; a public push of book-derived content cannot be un-published.
 
-**Copyright gate — always apply before creating the repo:** chapter files are synthesized summaries, not raw text, but they still derive from the source material. Per the README's Copyright & fair use policy, skills generated from **third-party copyrighted books must stay private**; offer public only when the source is the user's own writing, internal material they hold rights to, or openly licensed content — and state which case applies.
+**Copyright gate — always apply before creating the repo:** chapter files are synthesized summaries, not raw text, but they still derive from the source material. Per the README's Copyright & fair use policy, skills generated from **third-party copyrighted books must stay private**; offer public only when the source is the user's own writing, openly licensed content, or material the user explicitly confirms they are authorized to redistribute publicly — and state which case applies. Having access to internal company material is not permission to disclose it: skills from internal docs stay **private** unless the user states they hold publication rights.
 
 If accepted:
 
 1. Add two repo files inside `$SKILLS_HOME/<skill_name>/` (never overwrite an existing file):
    - `README.md` — the skill title, a one-paragraph description ("Agent skill generated from *<Title>* by <Author> with [book-to-skill](https://github.com/virgiliojr94/book-to-skill)"), the install command from step 3 below, the file inventory, and a note that the content is synthesized summaries, not the book text.
-   - `gemini-extension.json` — `{"name": "<skill_name>", "version": "1.0.0", "description": "<description from the SKILL.md frontmatter>"}` so Gemini CLI can load the repo as an extension.
-2. Initialize the skill folder as a git repository and create the remote (default repo name `<skill_name>`; let the user override — some prefer a `<skill_name>-skill` suffix):
+   - `gemini-extension.json` — `{"name": "<skill_name>", "version": "1.0.0", "description": "<description from the SKILL.md frontmatter>", "contextFileName": "SKILL.md"}` — `contextFileName` is what makes Gemini CLI actually load the skill instructions as context, not just the manifest.
+2. Initialize the skill folder as a git repository and create the remote (default repo name `<skill_name>`; let the user override — some prefer a `<skill_name>-skill` suffix). **Nested-repo guard:** first check whether the skill folder already sits inside a git repository (`git -C "$SKILLS_HOME/<skill_name>" rev-parse --show-toplevel` — always the case for project-local roots like `.claude/skills/`). If it does, do NOT `git init` in place: the outer repository would record the folder as an embedded repo (gitlink, mode 160000) without `.gitmodules`, and fresh clones of the outer project would silently omit the skill. Instead, copy the skill folder to a scratch directory, run the commands below from the copy, and tell the user the published repo — not the project-local folder — is the remote's working copy.
 
 ```bash
 cd "$SKILLS_HOME/<skill_name>"

--- a/SKILL.md
+++ b/SKILL.md
@@ -580,9 +580,52 @@ Reload (if your agent doesn't auto-detect new skills):
   Claude Code:         restart the session
   Amp:                 restart the session
 
-Share this skill (Copilot ecosystem, optional):
-  gh skill publish $SKILLS_HOME/<skill_name>
+Share this skill (optional):
+  GitHub repo, installable on any host (Step 11):  say "publish"
+  Copilot ecosystem:  gh skill publish $SKILLS_HOME/<skill_name>
 ```
+
+---
+
+## Step 11 — Publish the generated skill to GitHub (optional)
+
+After the Step 10 report, offer once — and only if the Step 9.5 scan passed:
+
+> "Want me to publish this skill to GitHub so any Agent Skills host can install it with `npx skills add`? (private / public / skip)"
+
+If the user declines, stop here. Requirements: the `gh` CLI, authenticated (check `gh auth status`); if unavailable, print the commands below for the user to run manually instead.
+
+**Visibility is `--private` by default — this is a hard rule, not a suggestion.** Run `gh repo create` with `--private` in every case except one: the user's reply to the question above (or a later explicit instruction) literally contains the word "public". A paraphrase, an ambiguous answer, silence, or your own inference is NOT consent — when in doubt, `--private`. A private repo can be flipped public later; a public push of book-derived content cannot be un-published.
+
+**Copyright gate — always apply before creating the repo:** chapter files are synthesized summaries, not raw text, but they still derive from the source material. Per the README's Copyright & fair use policy, skills generated from **third-party copyrighted books must stay private**; offer public only when the source is the user's own writing, internal material they hold rights to, or openly licensed content — and state which case applies.
+
+If accepted:
+
+1. Add two repo files inside `$SKILLS_HOME/<skill_name>/` (never overwrite an existing file):
+   - `README.md` — the skill title, a one-paragraph description ("Agent skill generated from *<Title>* by <Author> with [book-to-skill](https://github.com/virgiliojr94/book-to-skill)"), the install command from step 3 below, the file inventory, and a note that the content is synthesized summaries, not the book text.
+   - `gemini-extension.json` — `{"name": "<skill_name>", "version": "1.0.0", "description": "<description from the SKILL.md frontmatter>"}` so Gemini CLI can load the repo as an extension.
+2. Initialize the skill folder as a git repository and create the remote (default repo name `<skill_name>`; let the user override — some prefer a `<skill_name>-skill` suffix):
+
+```bash
+cd "$SKILLS_HOME/<skill_name>"
+git init -b main
+git add -A
+git commit -m "Add <skill_name> skill"
+gh repo create <repo_name> --private --source . --push
+# --private is the default; substitute --public ONLY under the visibility rule above
+# (the user literally said "public" AND the copyright gate allows it)
+```
+
+3. Report the repo URL and the cross-host install command:
+
+```
+✅ Published: https://github.com/<owner>/<repo_name> (<private|public>)
+
+Install on any Agent Skills host:
+  npx skills add https://github.com/<owner>/<repo_name> --skill <skill_name>
+```
+
+The root-level `SKILL.md` layout is exactly what the `skills` CLI detects, so the repo is installable as-is — no restructuring needed. The local folder stays the live install for this machine; later Update/Fold-in runs can commit and push their changes to the same remote.
 
 ---
 
@@ -631,7 +674,7 @@ Update the master skill file `$SKILLS_HOME/<skill_name>/SKILL.md`:
 - **Topic Index**: Merge the new topics alphabetically. If an existing topic is also covered in the new chapters, append the new chapter links to its line (e.g. `- **Topic** → ch05, ch13`).
 
 ### 6. Scan, Cleanup, and Report
-Once the files are successfully written and merged, run **Step 9.5**, then proceed to **Step 10** to perform cleanup and print a custom update report summarizing the newly added chapters, merged glossary terms, and updated indices.
+Once the files are successfully written and merged, run **Step 9.5**, then proceed to **Step 10** to perform cleanup and print a custom update report summarizing the newly added chapters, merged glossary terms, and updated indices. If the skill folder is a git repository with a remote (published via **Step 11**), offer to commit the update and push it.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -591,19 +591,21 @@ Share this skill (optional):
 
 After the Step 10 report, offer once — and only if the Step 9.5 scan passed:
 
-> "Want me to publish this skill to GitHub so any Agent Skills host can install it with `npx skills add`? (private / public / skip)"
+> "Want me to publish this skill to GitHub so any Agent Skills host can install it with `npx skills add`? (yes / skip)"
 
 If the user declines, stop here. Requirements: the `gh` CLI, authenticated (check `gh auth status`). If `gh` is missing or unauthenticated, offer to set it up (`brew install gh` or https://cli.github.com, then `gh auth login`) — or use the no-`gh` path: the user creates an empty repo of the chosen visibility in the GitHub web UI, then you run the `git init`/`add`/`commit` commands below followed by `git remote add origin <repo-url> && git push -u origin main`. The visibility rule below applies to the web-created repo exactly the same.
 
-**Visibility is `--private` by default — this is a hard rule, not a suggestion.** Run `gh repo create` with `--private` in every case except one: the user's reply to the question above (or a later explicit instruction) literally contains the word "public". A paraphrase, an ambiguous answer, silence, or your own inference is NOT consent — when in doubt, `--private`. A private repo can be flipped public later; a public push of book-derived content cannot be un-published.
+**Visibility is a separate closed question — never inferred, never read out of an earlier answer.** Once the user accepts, ask it on its own and require a one-word reply:
+
+> "Private or public repository? Reply with one word: `private` or `public`."
+
+**The reply must *be* `public`, not merely contain it — a hard rule, not a suggestion.** Run `gh repo create` with `--private` in every case except one: the answer to the visibility question is the bare word `public`. Substring matching is forbidden, because a sentence about **the source's licence is not a visibility answer** — "it's public domain", "the book is public domain", "it's publicly available" all describe the material, not the repository, and all resolve to `--private`. A paraphrase, a sentence, an ambiguous answer, silence, or your own inference is NOT consent: re-ask once, and if the reply is still not the bare word, use `--private` and say so in the report. A private repo can be flipped public later; a public push of book-derived content cannot be un-published.
 
 **Copyright gate — always apply before creating the repo:** chapter files are synthesized summaries, not raw text, but they still derive from the source material. Per the README's Copyright & fair use policy, skills generated from **third-party copyrighted books must stay private**; offer public only when the source is the user's own writing, openly licensed content, or material the user explicitly confirms they are authorized to redistribute publicly — and state which case applies. Having access to internal company material is not permission to disclose it: skills from internal docs stay **private** unless the user states they hold publication rights.
 
 If accepted:
 
-1. Add two repo files inside `$SKILLS_HOME/<skill_name>/` (never overwrite an existing file):
-   - `README.md` — the skill title, a one-paragraph description ("Agent skill generated from *<Title>* by <Author> with [book-to-skill](https://github.com/virgiliojr94/book-to-skill)"), the install command from step 3 below, the file inventory, and a note that the content is synthesized summaries, not the book text.
-   - `gemini-extension.json` — `{"name": "<skill_name>", "version": "1.0.0", "description": "<description from the SKILL.md frontmatter>", "contextFileName": "SKILL.md"}` — `contextFileName` is what makes Gemini CLI actually load the skill instructions as context, not just the manifest.
+1. Add a repo `README.md` inside `$SKILLS_HOME/<skill_name>/` (never overwrite an existing file) — the skill title, a one-paragraph description ("Agent skill generated from *<Title>* by <Author> with [book-to-skill](https://github.com/virgiliojr94/book-to-skill)"), the install command from step 3 below, the file inventory, and a note that the content is synthesized summaries, not the book text.
 2. Initialize the skill folder as a git repository and create the remote (default repo name `<skill_name>`; let the user override — some prefer a `<skill_name>-skill` suffix). **Nested-repo guard:** first check whether the skill folder already sits inside a git repository (`git -C "$SKILLS_HOME/<skill_name>" rev-parse --show-toplevel` — always the case for project-local roots like `.claude/skills/`). If it does, do NOT `git init` in place: the outer repository would record the folder as an embedded repo (gitlink, mode 160000) without `.gitmodules`, and fresh clones of the outer project would silently omit the skill. Instead, copy the skill folder to a scratch directory, run the commands below from the copy, and tell the user the published repo — not the project-local folder — is the remote's working copy.
 
 ```bash
@@ -613,7 +615,7 @@ git add -A
 git commit -m "Add <skill_name> skill"
 gh repo create <repo_name> --private --source . --push
 # --private is the default; substitute --public ONLY under the visibility rule above
-# (the user literally said "public" AND the copyright gate allows it)
+# (the visibility answer WAS the bare word "public" AND the copyright gate allows it)
 ```
 
 3. Report the repo URL and the cross-host install command:
@@ -625,7 +627,15 @@ Install on any Agent Skills host:
   npx skills add https://github.com/<owner>/<repo_name> --skill <skill_name>
 ```
 
-The root-level `SKILL.md` layout is exactly what the `skills` CLI detects, so the repo is installable as-is — no restructuring needed. The local folder stays the live install for this machine; later Update/Fold-in runs can commit and push their changes to the same remote.
+   When the nested-repo guard fired and the repo was published from a scratch copy, add one line — that local folder never gains a remote, so the Update/Fold-in push offer will never appear for it:
+
+```
+⚠️  Published from a copy: <skill folder> sits inside another git repository, so it has
+    no remote of its own. To publish a later update, re-run Step 11, or clone
+    https://github.com/<owner>/<repo_name> and fold new material into the clone.
+```
+
+The root-level `SKILL.md` layout is exactly what the `skills` CLI detects, so the repo is installable as-is — no restructuring needed. Outside the nested-repo case the local folder stays the live install for this machine and is the remote's working copy, so later Update/Fold-in runs can commit and push their changes to the same remote.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,13 +50,13 @@ Both accounts, and how to add yours, are in [book-to-skill-use-cases](https://gi
 
 ## 📤 Publish your generated skill (optional)
 
-After a conversion, the converter offers to push the skill to GitHub as its own repository. The `gh repo create` command defaults to **`--private`**; a public repo is created only when you explicitly answer "public" - chapter files are synthesized from the source material, and skills generated from third-party copyrighted books must stay private (see [Copyright & fair use](../README.md#%EF%B8%8F-copyright--fair-use)). A published skill installs on any Agent Skills host in one command:
+After a conversion, the converter offers to push the skill to GitHub as its own repository. Visibility is asked as its own question and the `gh repo create` command defaults to **`--private`**; a public repo is created only when your answer is the bare word `public`. A sentence about the source's licence is not a visibility answer - "it's public domain" describes the book, not the repository, and still gets you a private repo. Chapter files are synthesized from the source material, and skills generated from third-party copyrighted books must stay private (see [Copyright & fair use](../README.md#%EF%B8%8F-copyright--fair-use)). A published skill installs on any Agent Skills host in one command:
 
 ```bash
 npx skills add https://github.com/<you>/<your-book-slug> --skill <your-book-slug>
 ```
 
-Requires the [`gh` CLI](https://cli.github.com), authenticated. The generated repo ships with a README and a `gemini-extension.json`, and the skill folder becomes the git working copy, so later fold-in updates can push to the same remote.
+Requires the [`gh` CLI](https://cli.github.com), authenticated. The generated repo ships with a README, and the skill folder becomes the git working copy, so later fold-in updates can push to the same remote.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,6 +48,15 @@ Both accounts, and how to add yours, are in [book-to-skill-use-cases](https://gi
 
 ---
 
+## 📤 Publish your generated skill (optional)
+
+After a conversion, the converter offers to push the skill to GitHub as its own repository. The `gh repo create` command defaults to **`--private`**; a public repo is created only when you explicitly answer "public" - chapter files are synthesized from the source material, and skills generated from third-party copyrighted books must stay private (see [Copyright & fair use](../README.md#%EF%B8%8F-copyright--fair-use)). A published skill installs on any Agent Skills host in one command:
+
+```bash
+npx skills add https://github.com/<you>/<your-book-slug> --skill <your-book-slug>
+```
+
+Requires the [`gh` CLI](https://cli.github.com), authenticated. The generated repo ships with a README and a `gemini-extension.json`, and the skill folder becomes the git working copy, so later fold-in updates can push to the same remote.
 
 ---
 

--- a/tests/test_publish_visibility_gate.py
+++ b/tests/test_publish_visibility_gate.py
@@ -1,0 +1,134 @@
+"""Regression tests for the Step 11 publish visibility gate in SKILL.md.
+
+Step 11 creates a GitHub repository from book-derived content. Its safety
+property is that `gh repo create` runs with `--private` unless the user gives a
+bare-word `public` answer to a question asked solely about repository
+visibility. A regression here is invisible in review and only surfaces as a
+public repository that should not exist, so the rule is asserted two ways:
+
+1. the prose in SKILL.md still states the rule the model is meant to follow;
+2. a reference implementation of that rule rejects the inputs a naive
+   substring check would wrongly accept.
+
+Test 2 does not execute anything from SKILL.md - nothing in this project does.
+It pins the intended semantics next to the prose, so that a future edit
+loosening the wording fails test 1 while test 2 still shows what the wording
+was supposed to mean.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_MD = REPO_ROOT / "SKILL.md"
+
+
+def _step_11() -> str:
+    """The Step 11 section of SKILL.md, up to the next top-level heading."""
+    if not SKILL_MD.is_file():
+        pytest.skip("SKILL.md not present (e.g. installed sdist)")
+    text = SKILL_MD.read_text(encoding="utf-8")
+    marker = "## Step 11"
+    start = text.find(marker)
+    assert start != -1, "SKILL.md no longer has a Step 11 section"
+    end = text.find("\n## ", start + len(marker))
+    return text[start:] if end == -1 else text[start:end]
+
+
+def _is_public_answer(reply: str) -> bool:
+    """The visibility gate as specified: the reply must *be* `public`.
+
+    Normalization is deliberately minimal - surrounding whitespace, casing, and
+    trailing punctuation only. Anything that leaves more than the single word
+    is a sentence, and a sentence is not a visibility answer.
+    """
+    return reply.strip().strip(".!?,;:").strip().casefold() == "public"
+
+
+def test_repo_create_command_defaults_to_private():
+    """The literal command in SKILL.md must carry --private.
+
+    The maintainer's requirement is that the *command default* be private, so a
+    model misreading the surrounding prose still cannot create a public repo.
+    """
+    section = _step_11()
+    create_lines = [ln for ln in section.splitlines() if "gh repo create" in ln]
+    assert create_lines, "Step 11 no longer contains a `gh repo create` command"
+    command = next((ln for ln in create_lines if ln.strip().startswith("gh repo create")), None)
+    assert command is not None, "no runnable `gh repo create` line in Step 11"
+    assert "--private" in command, f"`gh repo create` lost its --private default: {command!r}"
+    assert "--public" not in command, f"`gh repo create` hardcodes --public: {command!r}"
+
+
+def test_visibility_is_asked_as_its_own_closed_question():
+    """Visibility must not be inferred from the publish offer or earlier turns."""
+    section = _step_11().casefold()
+    assert "separate closed question" in section, (
+        "Step 11 no longer states that visibility is asked as its own closed question"
+    )
+    assert "reply with one word" in section, (
+        "Step 11 no longer requires a one-word visibility answer"
+    )
+
+
+def test_gate_forbids_substring_matching_and_names_the_licence_trap():
+    """`public` must be the whole answer, and a licence statement must not count.
+
+    "public domain" is ordinary vocabulary in this project - Moby-Dick is a
+    benchmark book and the copyright gate actively asks users about the
+    source's licence - so a user answering that question could otherwise
+    satisfy the visibility gate without ever choosing to publish publicly.
+    """
+    section = _step_11().casefold()
+    assert "substring matching is forbidden" in section, (
+        "Step 11 no longer forbids substring matching on the visibility answer"
+    )
+    assert "public domain" in section, (
+        "Step 11 no longer names the 'public domain' licence sentence as a non-answer"
+    )
+    assert "not a visibility answer" in section, (
+        "Step 11 no longer states that a licence sentence is not a visibility answer"
+    )
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "public",
+        "Public",
+        "  public  ",
+        "public.",
+        "PUBLIC!",
+    ],
+)
+def test_bare_word_public_opens_the_gate(reply):
+    assert _is_public_answer(reply) is True
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        # The Step 10 trigger word that enters Step 11 at all.
+        "publish",
+        "publish it",
+        # Statements about the source's licence, not the repository.
+        "it is public domain",
+        "the book is in the public domain",
+        "it's publicly available",
+        "public domain",
+        # Paraphrase, ambiguity, silence, and the safe answer.
+        "make it public",
+        "public is fine i guess",
+        "",
+        "   ",
+        "yes",
+        "private",
+    ],
+)
+def test_everything_else_stays_private(reply):
+    assert _is_public_answer(reply) is False, (
+        f"{reply!r} must not satisfy the visibility gate - it would create a public "
+        "repository from book-derived content"
+    )


### PR DESCRIPTION
## Summary (Required)
Adds an optional **Step 11 — Publish the generated skill to GitHub**. After a conversion finishes (and only when the Step 9.5 security scan passed), the converter offers to create a GitHub repository for the generated skill via the `gh` CLI and prints the cross-host install command (`npx skills add <repo-url> --skill <slug>`). Visibility is asked as its own closed question and `gh repo create` is **`--private` by default as a hard rule** - `--public` requires the visibility answer to *be* the bare word "public" AND the copyright gate to allow it.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** `SKILL.md` Step 11 - a one-time post-report offer to publish. On acceptance the converter (1) drops a repo `README.md` into the skill folder, never overwriting an existing file; (2) runs `git init` + `gh repo create <name> --private --source . --push` in the skill folder itself, so the live install becomes the git working copy; (3) reports the repo URL and `npx skills add` command.
- **Adds:** a **hard visibility rule**. Visibility is a separate closed question asked after the publish offer ("Reply with one word: `private` or `public`"), and the gate opens only when the answer *is* `public` - substring matching is explicitly forbidden, so a sentence about the source's licence ("it's public domain", "it's publicly available") describes the material rather than the repository and still resolves to `--private`. Paraphrase, ambiguity, silence and model inference are all explicitly NOT consent: re-ask once, then fall back to `--private` and say so in the report. Stacked on top is the **copyright gate** reusing the README's Copyright & fair use policy: third-party copyrighted books stay private regardless, and access to internal material is not permission to disclose it.
- **Adds:** `tests/test_publish_visibility_gate.py` - asserts the literal `gh repo create` line keeps `--private`, that the anti-substring wording and the "public domain" carve-out survive, and a reference implementation of the gate that accepts `public` / `Public` / `public.` while rejecting `publish`, `it is public domain`, `the book is in the public domain`, `it's publicly available` and `make it public`.
- **Adds:** Update/Fold-in tie-in (a fold-in run offers to commit and push if the folder has a remote), plus a report line for the nested-repo case, where publishing from a scratch copy leaves the local folder without a remote and the push offer can therefore never fire. A "Publish your generated skill" section in `docs/usage.md` and a one-line pointer in the README Usage section.

## Motivation & context (Required)
Closes n/a - no open issue. Generated skills currently live and die on the machine that generated them; sharing one across machines or with a team means manually copying folders. The Agent Skills ecosystem already has a standard distribution channel - a git repo with a root `SKILL.md`, installable via the `skills` CLI - and generated skills already have exactly that layout. This turns publishing into a guided, policy-aware step.

## How it works (Required for anything non-trivial)
Instruction-level change to `SKILL.md`, plus one test file. The generated skill's root-level `SKILL.md` layout is what the `skills` CLI detects, so the repo is installable as-is. Gating: offered only after the Step 9.5 scan passed (matching the existing "do not publish until findings are resolved" rule); `gh auth status` checked first; without `gh`, an executable fallback is printed (install/auth, or a web-created repo plus `git remote add origin && git push -u origin main`). A nested-repo guard publishes from a scratch copy when the skill folder sits inside an existing repository, so the outer project never records a gitlink without `.gitmodules`.

Rejected alternatives: defaulting visibility to a model-judged suggestion (review pointed out the *command default* must be private so a misread cannot publish); and matching the visibility answer by substring, which let a licence statement about the source open a public repo.

## Evidence (Required)
- **Tests:** `uv run --with pytest -m pytest -q` - 437 passed, 1 skipped on a clean checkout; `ruff check .` clean; `python3 tools/validate_skill.py SKILL.md` passes (pre-existing body-length soft warning, 700 lines).
- **Weight:** +1,238 tok / +53 lines against `master` measured with `tiktoken` (o200k).
- **Layout evidence:** the flow this PR documents is exactly how this repo itself is distributed - root `SKILL.md`, installable via `npx skills add virgiliojr94/book-to-skill --skill book-to-skill`. A generated skill folder matches the same detection rule, verified against a freshly generated 35-chapter skill:

```
$ ls ~/.agents/skills/clean-architecture-book
SKILL.md  chapters/  cheatsheet.md  glossary.md  patterns.md
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
- All review points addressed. Latest round: the visibility gate is now a closed question matched on the bare word rather than a substring search; `gemini-extension.json` is dropped as a separate feature; the nested-repo report line closes the "publish once, never update" gap; and the visibility-gate test is included here rather than deferred, since that regression is invisible until a public repo exists that should not.
- Rebased on `c4c5e94`. The only conflict was `docs/usage.md` against the new "What people do with it" section - both kept.
- No `CHANGELOG.md` edit (git-cliff per #104).
