### PR TITLE
fix: CJK-aware token estimate (rescued from #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CJK-aware token estimate** — `estimate_tokens` now counts CJK codepoints
+  directly (against `CJK_CHARS_PER_TOKEN`) instead of whitespace-delimited words,
+  fixing a ~1000× undercount for space-less Chinese/Japanese books in the cost
+  pre-flight. Latin behavior is unchanged and the estimate stays deterministic
+  and dependency-free (rescued from #70).
+
 ### Removed
 - **Stale tracked bytecode** — `scripts/__pycache__/extract.cpython-313.pyc` was committed
   alongside the EPUB-support change and has been tracked ever since, despite `.gitignore`

--- a/book_to_skill/config.py
+++ b/book_to_skill/config.py
@@ -11,7 +11,11 @@ OUTPUT_DIR = Path(
 OUTPUT_TEXT = OUTPUT_DIR / "full_text.txt"
 OUTPUT_META = OUTPUT_DIR / "metadata.json"
 
-WORDS_PER_TOKEN = 0.75  # approximate
+WORDS_PER_TOKEN = 0.75  # approximate (Latin / whitespace-delimited text)
+# CJK scripts carry little or no whitespace, so word-splitting under-counts them
+# by orders of magnitude. Count CJK codepoints directly against this
+# chars-per-token ratio instead (see estimate_tokens in utils.py).
+CJK_CHARS_PER_TOKEN = 1.5  # approximate for cl100k-style tokenizers
 
 TEXT_EXTENSIONS = {".txt", ".text", ".md", ".markdown", ".rst", ".adoc", ".asciidoc"}
 HTML_EXTENSIONS = {".html", ".htm", ".xhtml"}

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -16,6 +16,7 @@ from book_to_skill.config import (
     OUTPUT_TEXT,
     OUTPUT_META,
     WORDS_PER_TOKEN,
+    CJK_CHARS_PER_TOKEN,
     SUPPORTED_EXTENSIONS,
     TEXT_EXTENSIONS,
     HTML_EXTENSIONS,
@@ -47,8 +48,32 @@ from book_to_skill.parsers.epub import (
 from book_to_skill.sanitize import sanitize_extracted_text
 
 
+# CJK codepoints: ideographs + extensions, kana, hangul, CJK punctuation, and
+# fullwidth forms. These are not whitespace-delimited, so counting "words" on a
+# Chinese/Japanese book collapses it to a handful of tokens; count them directly.
+_CJK_RE = re.compile(
+    r"[　-〿぀-ヿ㐀-䶿一-鿿"
+    r"가-힣豈-﫿＀-￯]"
+)
+
+
 def estimate_tokens(text: str) -> int:
-    return int(len(text.split()) / WORDS_PER_TOKEN)
+    """Estimate the token count of ``text`` with a deterministic heuristic.
+
+    Latin / whitespace-delimited text is counted by words (``words /
+    WORDS_PER_TOKEN`` — the project's long-standing ratio). CJK characters are
+    counted directly against ``CJK_CHARS_PER_TOKEN`` because they carry little
+    or no whitespace; without this a space-less Chinese/Japanese book estimates
+    at a few tokens and the cost pre-flight under-reports by ~1000x. Kept
+    dependency-free on purpose so the same book always yields the same number.
+    """
+    if not text:
+        return 0
+    cjk = len(_CJK_RE.findall(text))
+    if not cjk:
+        return int(len(text.split()) / WORDS_PER_TOKEN)
+    latin_words = len(_CJK_RE.sub(" ", text).split())
+    return int(latin_words / WORDS_PER_TOKEN + cjk / CJK_CHARS_PER_TOKEN)
 
 
 # Explicit chapter heading: "Chapter 5", "Capítulo 5: ...", "Chapter 1. Intro".

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1570,3 +1570,26 @@ class TestParseArgumentsUnknownFlags:
         parse_arguments(["extract.py", "book.pdf", "notes.txt"])
         captured = capsys.readouterr()
         assert captured.err == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  CJK-aware token estimate (rescued from #70)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestCjkTokenEstimate:
+    """estimate_tokens counts CJK codepoints directly, not whitespace words."""
+
+    def test_latin_estimate_unchanged(self):
+        # The project's long-standing pinned ratio: 100 words -> 133 tokens.
+        assert estimate_tokens(" ".join(["word"] * 100)) == 133
+
+    def test_cjk_is_not_undercounted(self):
+        # 1500 space-less Chinese chars must estimate ~1000 tokens, not ~1.
+        assert estimate_tokens("中" * 1500) == 1000
+
+    def test_mixed_latin_and_cjk(self):
+        # Latin words + CJK chars are both counted.
+        assert estimate_tokens("hello 世界 " * 100) > 100
+
+    def test_empty_is_zero(self):
+        assert estimate_tokens("") == 0


### PR DESCRIPTION
## Summary (Required)

Rescues the CJK-aware token-estimate fix originally proposed in #70 (which stalled with a large multi-change diff and went stale). This lands **only** that one change, isolated and rebased on current `master`, with credit to the original author.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature
- [ ] ⚡ Performance
- [ ] ♻️ Refactor
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change

## What it does (Required)
`estimate_tokens` counted whitespace-delimited words. CJK scripts carry little or no whitespace, so a space-less Chinese/Japanese book collapsed to a few tokens. It now counts CJK codepoints directly against a new `CJK_CHARS_PER_TOKEN` constant, while Latin text keeps the `words / WORDS_PER_TOKEN` path.

## Motivation & context (Required)
The cost pre-flight (Step 2.5) under-reported CJK books by ~1000×, misleading users on cost/time for exactly the languages the chapter detector already supports (Chinese, Japanese, Korean). Rescued from #70; that PR is superseded by this focused version.

## How it works (Required for anything non-trivial)
A `_CJK_RE` character class (ideographs + extensions, kana, hangul, CJK punctuation, fullwidth forms) counts CJK codepoints; the estimate is `latin_words / WORDS_PER_TOKEN + cjk_chars / CJK_CHARS_PER_TOKEN`. Deterministic and dependency-free (no tiktoken) so the same book always yields the same number.

## Evidence (Required)
- **Tests:** `TestCjkTokenEstimate` — Latin pinned ratio unchanged (100 words → 133), 1500 CJK chars → 1000 (was ~1), mixed Latin+CJK counted, empty → 0.
- `python3 -m pytest tests/ -q` → 193 passed.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — N/A
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

Closes #70.
