### PR TITLE
fix(extract): write metadata.json as UTF-8

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -736,7 +736,14 @@ def main():
         **consolidated_structure,
     }
     
-    OUTPUT_META.write_text(json.dumps(metadata, indent=2, ensure_ascii=False))
+    # encoding="utf-8" is required, not cosmetic: the payload is dumped with
+    # ensure_ascii=False, so any non-ASCII chapter heading, filename or path
+    # reaches the encoder verbatim. Without it, write_text() falls back to the
+    # locale encoding and raises UnicodeEncodeError on a Windows cp1252 host or
+    # under LC_ALL=C — after every source has already been extracted.
+    OUTPUT_META.write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     
     page_line = f"   Total Pages: {total_pages}"
     print("\nExtraction complete:")

--- a/tests/test_metadata_encoding.py
+++ b/tests/test_metadata_encoding.py
@@ -1,0 +1,86 @@
+"""metadata.json must be written as UTF-8, not in the host's locale encoding.
+
+`main()` dumps the metadata with ``ensure_ascii=False``, so non-ASCII text is
+passed through verbatim instead of being escaped to ``\\uXXXX``. Any CJK, Thai
+or Korean chapter heading — or an accented filename or path — therefore reaches
+the file encoder as-is. Without an explicit ``encoding=``, ``write_text()`` uses
+the locale encoding and raises ``UnicodeEncodeError`` on a Windows cp1252 host
+or under ``LC_ALL=C``.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import main
+
+
+class TestMetadataOutputEncoding:
+    # Two "第N章" headings, so chapters_detected is a meaningful assertion too.
+    CJK_SOURCE = "第一章 緒論\n\nBody one.\n\n第二章 架構\n\nBody two.\n"
+
+    def _run_main(self, tmp_path, monkeypatch):
+        source = tmp_path / "cjk.md"
+        source.write_text(self.CJK_SOURCE, encoding="utf-8")
+
+        out_dir = tmp_path / "output"
+        out_meta = out_dir / "metadata.json"
+        monkeypatch.setenv("BOOK_SKILL_WORKDIR", str(out_dir))
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_DIR", out_dir)
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_TEXT", out_dir / "full_text.txt")
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_META", out_meta)
+        monkeypatch.setattr("book_to_skill.utils.prepare_dependencies", lambda *a: None)
+        monkeypatch.setattr(
+            "sys.argv", ["extract.py", str(source), "--install-missing", "no"]
+        )
+
+        main()
+        return out_meta
+
+    def test_metadata_write_declares_utf8(self, tmp_path, monkeypatch):
+        """The metadata write must pass encoding="utf-8" explicitly.
+
+        This is the platform-independent regression guard. On a UTF-8 host the
+        locale default happens to produce the right bytes, so a round-trip
+        assertion alone would pass on unfixed code in CI; only the declared
+        encoding proves the fix. Mirrors TestPdftotextEncoding, which asserts
+        the same way on the pdftotext subprocess call.
+        """
+        captured = {}
+        original_write_text = Path.write_text
+
+        def recording_write_text(self, data, encoding=None, **kwargs):
+            if self.name == "metadata.json":
+                captured["encoding"] = encoding
+            return original_write_text(self, data, encoding=encoding, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", recording_write_text)
+        self._run_main(tmp_path, monkeypatch)
+
+        assert captured.get("encoding") == "utf-8", (
+            "metadata.json was written with the locale encoding; it must declare "
+            'encoding="utf-8" because the JSON is dumped with ensure_ascii=False'
+        )
+
+    def test_non_ascii_headings_round_trip_as_utf8(self, tmp_path, monkeypatch):
+        """The CJK headings survive the write and decode back as UTF-8."""
+        out_meta = self._run_main(tmp_path, monkeypatch)
+
+        meta = json.loads(out_meta.read_bytes().decode("utf-8"))
+        assert meta["chapters_detected"] == 2
+        assert "第一章 緒論" in meta["chapter_headings_sample"]
+        assert "第二章 架構" in meta["chapter_headings_sample"]
+
+    def test_metadata_is_valid_utf8_on_disk(self, tmp_path, monkeypatch):
+        """The bytes on disk are UTF-8, whatever the host locale encoding is."""
+        out_meta = self._run_main(tmp_path, monkeypatch)
+
+        raw = out_meta.read_bytes()
+        # Would raise UnicodeDecodeError if the file had been written as cp1252
+        # or another single-byte codec that happened not to fail on write.
+        decoded = raw.decode("utf-8")
+        assert "第一章" in decoded
+        assert "第一章 緒論".encode("utf-8") in raw


### PR DESCRIPTION
## Summary

`metadata.json` is dumped with `ensure_ascii=False` but written without an explicit encoding, so `write_text()` falls back to the host locale encoding. Any non-ASCII chapter heading — CJK, Thai, Korean — raises `UnicodeEncodeError` and aborts the run on a Windows cp1252 host or under `LC_ALL=C`. This adds `encoding="utf-8"` to that one write.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** extraction crashes with `UnicodeEncodeError` when the book has any non-ASCII chapter heading, filename or path, on any host whose locale encoding is not UTF-8. Root cause: `utils.py:713` calls `OUTPUT_META.write_text(json.dumps(..., ensure_ascii=False))` with no `encoding=`. Because `ensure_ascii=False` deliberately does *not* escape non-ASCII to `\uXXXX`, that text reaches the file encoder verbatim — so the locale codec has to be able to represent it, and cp1252/ASCII cannot.

This is the only unencoded text write in the package. The `full_text.txt` write two lines above already passes `encoding="utf-8"`; this one was missed.

## Motivation & context

Closes n/a — found while testing the multilingual heading detection on Windows; no existing issue.

The blast radius is exactly the population the project has been investing in all year: CJK (#36, #46), Thai (#72), Korean (#82/#84). A Chinese or Korean book cannot be converted at all on a default Windows install.

Two things make it worse than a normal crash:

1. It fires **after** every source has been extracted and after `full_text.txt` has been written — so all the expensive work is done and then thrown away.
2. It leaves the workdir half-built. `metadata.json` still holds the **previous** run's content, and that is the file the agent reads in Step 3. A re-run can silently plan chapters from a different book's structure.

It also reproduces on Linux/macOS under `LC_ALL=C` or `LANG=POSIX` (ASCII codec), which is common in Docker images and CI runners — so this is not Windows-only.

## How it works

One-line fix: pass `encoding="utf-8"`, matching the `OUTPUT_TEXT` write directly above. Comment added explaining that the encoding is load-bearing rather than cosmetic, since `ensure_ascii=False` is what puts non-ASCII in front of the encoder.

Rejected alternative: dropping `ensure_ascii=False` to get pure-ASCII output. That would work, but it would make `chapter_headings_sample` unreadable (`"第一章"` instead of `"第一章"`) for anyone inspecting the metadata by hand, and it would be a regression against the intent of #36, which added `ensure_ascii=False` on purpose.

## Evidence

**Tests** — new `tests/test_metadata_encoding.py`, 3 cases:

- `test_metadata_write_declares_utf8` — asserts the `metadata.json` write passes `encoding="utf-8"`. This is the platform-independent guard: on a UTF-8 CI host the locale default happens to produce correct bytes, so a round-trip assertion alone would pass on unfixed code. Only the declared encoding proves the fix. Same approach as the existing `TestPdftotextEncoding`, which asserts on the subprocess `encoding` kwarg.
- `test_non_ascii_headings_round_trip_as_utf8` — `第一章 緒論` / `第二章 架構` survive the write, and `chapters_detected == 2`.
- `test_metadata_is_valid_utf8_on_disk` — the bytes on disk decode as UTF-8 and contain the UTF-8 encoding of the heading.

Put in a new file rather than appended to `test_book_to_skill.py` to keep the diff conflict-free against the other open PRs touching that file (#89, #90).

**Before** — v1.3.0, Windows, `locale.getencoding() == 'cp1252'`, Python 3.14, source is a 2-chapter Chinese Markdown file:

```
$ python scripts/extract.py cjk.md --mode text --install-missing no
Extracting text document: ...\cjk.md
Traceback (most recent call last):
  File "book_to_skill/utils.py", line 713, in main
    OUTPUT_META.write_text(json.dumps(metadata, indent=2, ensure_ascii=False))
  File "encodings/cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 1265-1267:
character maps to <undefined>
```

`full_text.txt` was written; `metadata.json` was not.

**RED** — the three new tests against unmodified v1.3.0:

```
FAILED tests/test_metadata_encoding.py::TestMetadataOutputEncoding::test_metadata_write_declares_utf8
FAILED tests/test_metadata_encoding.py::TestMetadataOutputEncoding::test_non_ascii_headings_round_trip_as_utf8
FAILED tests/test_metadata_encoding.py::TestMetadataOutputEncoding::test_metadata_is_valid_utf8_on_disk
3 failed in 1.44s
```

with `E UnicodeEncodeError: 'charmap' codec can't encode characters in position 1082-1084`.

**GREEN** — with the fix, full suite:

```
$ python -m pytest tests/ -q
196 passed in 2.38s

$ ruff check .
All checks passed!
```

(Rebased onto `master` after #103/#104 merged; 193 existing + 3 new.)

`metadata.json` now contains readable headings:

```json
"chapters_detected": 2,
"chapter_headings_sample": [
  "第一章 緒論",
  "第二章 架構"
]
```

## Screenshots / output

Covered by the before/after terminal output above — the change is a crash vs. no crash, which the traceback and the `187 passed` line show more precisely than an image would.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] `CHANGELOG.md` **not** edited — rebased onto #104, so the entry comes from the Conventional Commit PR title instead
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

The `Path.write_text` monkeypatch in the first test is deliberately narrow — it filters on `self.name == "metadata.json"` and delegates to the original, so it does not change behaviour for `full_text.txt` or any other write.

Worth considering as a follow-up (happy to send it separately, out of scope here): a CI job running the test matrix under `LC_ALL=C` would have caught this class of bug, and would catch the next one. I audited the rest of the package while here — `grep` for `write_text`/`read_text`/`open` shows every other text I/O call already declares an encoding, and the only remaining `open()` calls are binary (`"rb"`), so this was the last instance.
