### PR TITLE
fix(rtf): skip control destination groups in the dependency-free fallback

### DIFF
--- a/book_to_skill/parsers/rtf.py
+++ b/book_to_skill/parsers/rtf.py
@@ -19,13 +19,112 @@ def _rtf_unicode_repl(match: re.Match) -> str:
     return chr(cp)
 
 
+# RTF groups whose contents are metadata or formatting tables rather than
+# document text. Stripping only the control words inside them (what the cleanup
+# below does) leaves the residue behind: font and style *names*, the generator
+# string, and the \info title/author all end up in the extracted book text.
+_SKIP_DESTINATIONS = frozenset({
+    "fonttbl",            # {\fonttbl{\f0\fnil Calibri;}}   -> "Calibri;"
+    "colortbl",           # {\colortbl;\red255...;}          -> ";;;"
+    "stylesheet",         # {\stylesheet{\s0 Normal;}}       -> "Normal;"
+    "info",               # {\info{\title X}{\author Y}}     -> "XY"
+    "listtable", "listoverridetable", "revtbl", "rsidtbl",
+    "latentstyles", "datastore", "themedata", "colorschememapping",
+    "filetbl", "xmlnstbl", "pgptbl", "protusertbl", "userprops",
+    "docvar",
+    "pict", "objdata",    # binary image / OLE payloads as hex text
+    "bkmkstart", "bkmkend",
+})
+
+# The first control word of a group, allowing the "\*" ignorable-destination
+# prefix: "{\fonttbl", "{\*\generator", "{\*\bkmkstart".
+_GROUP_DESTINATION = re.compile(r"\\\*?\\?([a-zA-Z]+)")
+
+
+def _strip_destination_groups(raw: str) -> str:
+    """Remove RTF groups that hold no document text.
+
+    Tracks brace depth so a whole group is dropped, not just its control words.
+    Per the RTF spec a reader that does not understand a ``\\*`` destination must
+    skip the entire group, which also handles ``\\*\\generator`` and any vendor
+    extension without naming it. Escaped ``\\{`` / ``\\}`` / ``\\\\`` are not
+    treated as delimiters.
+
+    A useful side effect: for a field, ``{\\field{\\*\\fldinst HYPERLINK ...}
+    {\\fldrslt visible text}}`` keeps the result and drops the instruction.
+    """
+    out: list[str] = []
+    index = 0
+    depth = 0
+    skip_at_depth = 0  # non-zero while inside a skipped group
+    length = len(raw)
+
+    while index < length:
+        char = raw[index]
+
+        # Escaped literal: "\{", "\}", "\\" are text, never group delimiters.
+        if char == "\\" and index + 1 < length and raw[index + 1] in "{}\\":
+            if not skip_at_depth:
+                out.append(raw[index:index + 2])
+            index += 2
+            continue
+
+        if char == "{":
+            depth += 1
+            if not skip_at_depth:
+                match = _GROUP_DESTINATION.match(raw, index + 1)
+                ignorable = raw.startswith("{\\*", index)
+                if ignorable or (match and match.group(1) in _SKIP_DESTINATIONS):
+                    skip_at_depth = depth
+                else:
+                    out.append(char)
+            index += 1
+            continue
+
+        if char == "}":
+            if skip_at_depth and depth == skip_at_depth:
+                skip_at_depth = 0
+            elif not skip_at_depth:
+                out.append(char)
+            depth -= 1
+            index += 1
+            continue
+
+        if not skip_at_depth:
+            out.append(char)
+        index += 1
+
+    if skip_at_depth:
+        # Unterminated destination group: the file is malformed and everything
+        # after the unclosed brace was just dropped, which could be the whole
+        # book. Leaking some metadata residue is the lesser evil, so fall back
+        # to the unscanned text rather than returning a truncated document.
+        return raw
+
+    return "".join(out)
+
+
 def strip_rtf_fallback(raw: str) -> str:
+    # Drop metadata/table groups wholesale first, so their contents never reach
+    # the control-word cleanup that would otherwise strip the markup and leave
+    # the names behind as if they were prose.
+    raw = _strip_destination_groups(raw)
     raw = _RTF_UNICODE.sub(_rtf_unicode_repl, raw)   # decode \uN escapes first
     raw = re.sub(r"\\'[0-9a-fA-F]{2}", " ", raw)
     raw = re.sub(r"\\par[d]?", "\n", raw)
     raw = re.sub(r"\\tab", "\t", raw)
+    # Park the three escaped literals ("\\", "\{", "\}") on placeholders before
+    # the sweeps below, which would otherwise strip the backslash as a control
+    # symbol and then delete the brace along with the real group delimiters —
+    # leaving a stray "\" where the book said "{a, b}". Longest escape first.
+    raw = (
+        raw.replace("\\\\", "\x01")
+        .replace("\\{", "\x02")
+        .replace("\\}", "\x03")
+    )
     raw = re.sub(r"\\[a-zA-Z]+-?\d* ?", "", raw)
     raw = raw.replace("{", "").replace("}", "")
+    raw = raw.replace("\x01", "\\").replace("\x02", "{").replace("\x03", "}")
     return html.unescape(raw)
 
 

--- a/tests/test_rtf_destination_groups.py
+++ b/tests/test_rtf_destination_groups.py
@@ -1,0 +1,144 @@
+"""The dependency-free RTF fallback must drop non-content destination groups.
+
+`strip_rtf_fallback` deleted control *words* and then removed all braces, so
+everything inside `\\fonttbl`, `\\colortbl`, `\\stylesheet`, `\\*\\generator` and
+`\\info` survived as literal text: font names, style names, the generator
+string, and the document title and author all landed in the extracted book text.
+
+That junk pollutes the Step 8 glossary, shifts `words` / `estimated_tokens` in
+metadata.json, and leaks `\\info` metadata into a file the user may publish as a
+skill. Only the fallback is affected — `striprtf` handles this correctly — so it
+was also a divergence between the two RTF paths.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.parsers.rtf import strip_rtf_fallback
+
+# A realistic header: font table, colour table, stylesheet, generator, \info.
+FULL_HEADER_RTF = (
+    r"{\rtf1\ansi\ansicpg1252\deff0"
+    "\n" r"{\fonttbl{\f0\fnil\fcharset0 Calibri;}{\f1\fswiss Helvetica Neue;}}"
+    "\n" r"{\colortbl;\red255\green0\blue0;\red0\green0\blue255;}"
+    "\n" r"{\stylesheet{\s0\snext0 Normal;}{\s1\sbasedon0 heading 1;}}"
+    "\n" r"{\*\generator Riched20 10.0.19041;}"
+    "\n" r"{\info{\title Secret Draft}{\author Jane Roe}}"
+    "\n" r"\pard\f0\fs24 Chapter 1\par"
+    "\n" r"Real body text here.\par}"
+)
+
+LEAK_PROBES = [
+    "Calibri",
+    "Helvetica Neue",
+    "Normal",
+    "heading 1",
+    "Riched20",
+    "Secret Draft",
+    "Jane Roe",
+]
+
+
+class TestDestinationGroupsDropped:
+    @pytest.mark.parametrize("probe", LEAK_PROBES)
+    def test_probe_does_not_leak(self, probe):
+        assert probe not in strip_rtf_fallback(FULL_HEADER_RTF)
+
+    def test_body_text_survives(self):
+        out = strip_rtf_fallback(FULL_HEADER_RTF)
+        assert "Chapter 1" in out
+        assert "Real body text here." in out
+
+    def test_chapter_heading_is_on_its_own_line(self):
+        lines = [ln for ln in strip_rtf_fallback(FULL_HEADER_RTF).splitlines()
+                 if ln.strip()]
+        assert lines[0].strip() == "Chapter 1"
+
+    def test_info_metadata_not_exposed(self):
+        """\\info carries title/author (and can carry comments and revisions)."""
+        rtf = r"{\rtf1{\info{\title Confidential}{\author A. Person}}Body.\par}"
+        out = strip_rtf_fallback(rtf)
+        assert out.strip() == "Body."
+
+    def test_pict_binary_payload_dropped(self):
+        rtf = (r"{\rtf1{\pict\wmetafile8 0102030405060708090a0b0c}"
+               r"Caption here.\par}")
+        out = strip_rtf_fallback(rtf)
+        assert "0102030405" not in out
+        assert "Caption here." in out
+
+    def test_nested_group_inside_skipped_group(self):
+        rtf = (r"{\rtf1 {\stylesheet{\s1\sbasedon0{\*\ud junk}heading 1;}}"
+               r"Body.\par}")
+        out = strip_rtf_fallback(rtf)
+        assert "heading 1" not in out
+        assert "junk" not in out
+        assert "Body." in out
+
+    def test_content_group_after_skipped_group_is_kept(self):
+        rtf = r"{\rtf1{\fonttbl{\f0 Arial;}}{\b Bold text}\par tail\par}"
+        out = strip_rtf_fallback(rtf)
+        assert "Arial" not in out
+        assert "Bold text" in out
+        assert "tail" in out
+
+
+class TestIgnorableDestinations:
+    """Per the RTF spec an unknown "\\*" destination must be skipped whole."""
+
+    def test_unknown_star_destination_skipped(self):
+        rtf = r"{\rtf1{\*\somevendorext payload text}Body.\par}"
+        out = strip_rtf_fallback(rtf)
+        assert "payload text" not in out
+        assert "Body." in out
+
+    def test_field_keeps_result_drops_instruction(self):
+        rtf = (r"{\rtf1 See {\field{\*\fldinst HYPERLINK bm1}"
+               r"{\fldrslt chapter 4}} now.\par}")
+        out = strip_rtf_fallback(rtf)
+        assert "HYPERLINK" not in out
+        assert "See chapter 4 now." in out.replace("\n", " ")
+
+
+class TestEscapedLiteralsSurvive:
+    """"\\{", "\\}" and "\\\\" are text, not delimiters or control symbols."""
+
+    def test_escaped_braces_become_literal_braces(self):
+        out = strip_rtf_fallback(r"{\rtf1 A set \{a, b\} of items.\par}")
+        assert "{a, b}" in out
+
+    def test_escaped_backslash_preserved(self):
+        out = strip_rtf_fallback(r"{\rtf1 Path C:\\temp\\out\par}")
+        assert r"C:\temp\out" in out
+
+
+class TestExistingBehaviourPreserved:
+    """Regression net for the \\uN decoding added in #52."""
+
+    _BS = "\\"
+
+    def test_unicode_escapes_still_decode(self):
+        text = (r"{\rtf1{\fonttbl{\f0 Arial;}}"
+                + self._BS + "u8220" + self._BS + "'93Hi"
+                + self._BS + "u8221" + self._BS + "'94" + r"\par}")
+        out = strip_rtf_fallback(text)
+        assert "\u201cHi\u201d" in out
+        assert "Arial" not in out
+
+    def test_par_and_tab_still_convert(self):
+        out = strip_rtf_fallback(r"{\rtf1 a\par b\tab c}")
+        assert "\n" in out
+        assert "\t" in out
+
+
+class TestMalformedInputIsNotTruncated:
+    def test_unterminated_skipped_group_falls_back(self):
+        """Losing the whole body would be worse than leaking table residue."""
+        rtf = r"{\rtf1{\fonttbl{\f0 Arial; Body text never closed"
+        out = strip_rtf_fallback(rtf)
+        assert "Body text never closed" in out


### PR DESCRIPTION
## Summary

The dependency-free RTF fallback stripped control *words* and then removed all braces, but never skipped RTF **destination groups**. Everything inside `\fonttbl`, `\colortbl`, `\stylesheet`, `\*\generator` and `\info` therefore survived as literal text — font names, style names, the generator string, and the document title and author all landed in the extracted book text. All seven leak probes leaked before; none leak now.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** `strip_rtf_fallback` had no concept of a destination group. `re.sub(r"\\[a-zA-Z]+-?\d* ?", "", raw)` removed `\fonttbl` and `\f0\fnil\fcharset0`, then `.replace("{", "")` removed the braces — leaving `Calibri;` sitting in the prose as though the book had said it.
- **Improves:** 7 of 7 leak probes eliminated. Also fixes escaped-brace mangling: `A set \{a, b\}` extracted as `A set \a, b\` and now extracts as `A set {a, b}`.

## Motivation & context

Closes n/a — found while auditing the dependency-free extraction paths; no existing issue.

Four concrete consequences of the leak:

1. **Glossary pollution.** Font and style names (`Calibri`, `Helvetica Neue`, `heading 1`, `Normal`) are exactly the kind of short capitalised tokens Step 8 picks up as candidate terms.
2. **Metadata exposure.** `\info` carries `\title` and `\author`, and can also carry `\doccomm` comments and revision data. That is copied into a file the user may publish as a skill — the README's own workflow.
3. **Skewed cost pre-flight.** The residue inflates `words` and `estimated_tokens` in `metadata.json`.
4. **Path divergence.** `striprtf` handles destination groups correctly, so a user with the optional dependency installed got clean text and a user without it got junk — the same fallback-vs-library gap as #52, #60, #61 and #64.

## How it works

`_strip_destination_groups` is a brace-depth scanner that runs *before* the existing control-word cleanup, so a skipped group's contents never reach the sweeps that would strip its markup and leave the names behind.

- **Named non-content destinations** are listed explicitly in `_SKIP_DESTINATIONS` with a comment showing what each one used to leak.
- **`\*` ignorable destinations are skipped generically.** Per the RTF spec a reader that does not understand a `\*` destination must skip the whole group, so this covers `\*\generator`, `\*\bkmkstart` and any vendor extension without having to enumerate them. It also gives correct field handling for free: `{\field{\*\fldinst HYPERLINK …}{\fldrslt visible text}}` keeps the result and drops the instruction.
- **Escaped literals** `\{`, `\}`, `\\` are not treated as delimiters. The scanner has to special-case them anyway to count depth correctly, so the pre-existing mangling (a stray `\` where the book said `{a, b}`) is fixed in the same pass via placeholder parking around the brace sweep. Flagging this as a small adjacent fix rather than hiding it.
- **Malformed input cannot truncate.** If a destination group is never closed, the scan would drop everything after the unclosed brace — possibly the entire book. In that case it returns the unscanned text instead, so this change cannot lose a document that previously extracted. Verified by `test_unterminated_skipped_group_falls_back`.

Deliberately **not** skipped: `\footnote` (real content), and `\upr` — it wraps duplicate ANSI/Unicode representations of the same run, so skipping it would lose text.

## Evidence

**Before / after** on a realistic RTF header (font table, colour table, stylesheet, generator, `\info`):

```
BEFORE
'\nCalibri;Helvetica Neue;\n;;;\nNormal;heading 1;\n\\*Riched20 10.0.19041;
 \nSecret DraftJane Roe\n\nChapter 1\n\nReal body text here.\n'

  Calibri          LEAKED
  Helvetica Neue   LEAKED
  Normal           LEAKED
  heading 1        LEAKED
  Riched20         LEAKED
  Secret Draft     LEAKED
  Jane Roe         LEAKED

AFTER
'\n\n\n\n\n\n\nChapter 1\n\nReal body text here.\n'

  Calibri          ok
  Helvetica Neue   ok
  Normal           ok
  heading 1        ok
  Riched20         ok
  Secret Draft     ok
  Jane Roe         ok

content kept: True
```

**Edge cases**, all passing:

```
escaped braces are literal text                  PASS  -> 'A set {a, b} of items.'
field keeps result, drops instruction            PASS  -> 'See chapter 4 now.'
nested skip inside skip                          PASS  -> 'Body.'
content group after skipped group                PASS  -> 'Bold text\n tail'
unicode escape survives outside skipped groups   PASS  -> '“Hi”'
pict binary payload dropped                      PASS  -> 'Caption here.'
escaped backslash preserved                      PASS  -> 'Path C:\temp\out'

unterminated skipped group -> 'Arial; Body text never closed'   (falls back, not truncated)
```

**Tests** — new `tests/test_rtf_destination_groups.py`, 20 cases in five groups:

- `TestDestinationGroupsDropped` — the seven probes (parametrized), body text survives, the heading is on its own line, `\info` not exposed, `\pict` hex payload dropped, nested-skip, and a content group after a skipped group still kept.
- `TestIgnorableDestinations` — an unknown `\*` vendor destination is skipped; the field instruction/result split.
- `TestEscapedLiteralsSurvive` — `\{`/`\}`/`\\`.
- `TestExistingBehaviourPreserved` — regression net for the `\uN` decoding from #52, and `\par`/`\tab`.
- `TestMalformedInputIsNotTruncated` — the unterminated-group fallback.

RED against unmodified `master`: **17 failed, 3 passed**. GREEN with the fix:

```
$ python -m pytest tests/ -q
213 passed in 2.32s

$ ruff check .
All checks passed!
```

## Screenshots / output

The before/after text dumps above are the output; a terminal diff shows the leaked font/metadata strings more precisely than an image would.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] `CHANGELOG.md` **not** edited — per #104 the entry comes from this PR's Conventional Commit title
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

The escaped-literal fix is technically a second bug in the same function. I folded it in because the depth scanner must handle `\{`/`\}` correctly regardless, so fixing the downstream mangling was two lines rather than a separate PR that would conflict with this one. Happy to split it out if you would rather keep the diff to destinations only.

`_SKIP_DESTINATIONS` is deliberately a conservative allowlist-of-exclusions rather than "skip every unrecognised destination". A more aggressive rule would drop unknown *non-`\*`* destinations too, but the `\*` prefix exists precisely to mark "safe to skip", so anything without it may well be content and I would rather under-skip than eat a chapter.

Three leftover blank lines appear where the header groups were (visible in the AFTER dump). Harmless — `detect_structure` is line-based and blank lines do not affect it — but if you would prefer the fallback to collapse runs of blank lines, that is an easy follow-up.
