### PR TITLE
fix(extract): detect a table of contents in any source, not just the first

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -742,6 +742,16 @@ def main():
     # headings and make the result depend on the source-path length.
     structure_text = "\n\n".join(src["text"] for src in extracted_sources)
     consolidated_structure = detect_structure(structure_text)
+    # has_toc is a per-source property, so it has to be combined per source
+    # rather than re-derived from the corpus. detect_structure only scans the
+    # first ~30k chars, because a table of contents sits in a book's front
+    # matter -- but on a consolidated corpus that window covers only the FIRST
+    # source, so a ToC in any later book was invisible and the answer flipped on
+    # input order alone. Each per-source result already scanned its own front
+    # matter, so OR them.
+    consolidated_structure["has_toc"] = any(
+        src["has_toc"] for src in extracted_sources
+    )
     
     metadata = {
         "source_file": "Consolidated from multiple sources" if len(extracted_sources) > 1 else extracted_sources[0]["source_file"],

--- a/tests/test_multi_source_toc.py
+++ b/tests/test_multi_source_toc.py
@@ -1,0 +1,94 @@
+"""Consolidated `has_toc` must not depend on the order of the input files.
+
+`detect_structure` only scans the first ~30,000 characters for a table-of-contents
+header, which is right for one book: a ToC lives in the front matter. But the
+consolidated value was derived by re-running that scan over the *joined* corpus,
+so the window only ever covered the first source. A ToC in any later book was
+invisible, and feeding the same two books in the other order produced the
+opposite answer.
+
+`main()` prints a "No table of contents detected" warning off this value and
+writes it to metadata.json, where Step 3 uses it to decide whether chapter
+mapping can trust a ToC or must fall back to a heading scan alone.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import main
+
+# Long enough that anything after it falls outside the 30k scan window.
+FILLER = "Filler prose about distributed systems. " * 1200
+NO_TOC_BOOK = "Chapter 1\n" + FILLER + "\n"
+TOC_BOOK = "Table of Contents\n\nChapter 2\nBody of the second book.\n"
+
+
+def _run(tmp_path, monkeypatch, *sources):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for index, text in enumerate(sources, start=1):
+        path = tmp_path / f"book{index}.md"
+        path.write_text(text, encoding="utf-8")
+        paths.append(str(path))
+
+    out_dir = tmp_path / "out"
+    out_meta = out_dir / "metadata.json"
+    monkeypatch.setenv("BOOK_SKILL_WORKDIR", str(out_dir))
+    monkeypatch.setattr("book_to_skill.utils.OUTPUT_DIR", out_dir)
+    monkeypatch.setattr("book_to_skill.utils.OUTPUT_TEXT", out_dir / "full_text.txt")
+    monkeypatch.setattr("book_to_skill.utils.OUTPUT_META", out_meta)
+    monkeypatch.setattr("book_to_skill.utils.prepare_dependencies", lambda *a: None)
+    monkeypatch.setattr(
+        "sys.argv", ["extract.py", *paths, "--install-missing", "no"]
+    )
+
+    main()
+    return json.loads(out_meta.read_text(encoding="utf-8"))
+
+
+class TestMultiSourceTocDetection:
+    def test_filler_book_pushes_second_book_past_the_window(self):
+        """Guards the premise: without this, the test would prove nothing."""
+        assert len(NO_TOC_BOOK) > 30000
+
+    def test_toc_in_second_source_is_detected(self, tmp_path, monkeypatch):
+        meta = _run(tmp_path, monkeypatch, NO_TOC_BOOK, TOC_BOOK)
+
+        assert meta["total_sources"] == 2
+        assert meta["has_toc"] is True
+
+    def test_result_is_independent_of_input_order(self, tmp_path, monkeypatch):
+        first = _run(tmp_path / "a", monkeypatch, NO_TOC_BOOK, TOC_BOOK)
+        second = _run(tmp_path / "b", monkeypatch, TOC_BOOK, NO_TOC_BOOK)
+
+        assert first["has_toc"] == second["has_toc"] is True
+
+    def test_agrees_with_the_per_source_records(self, tmp_path, monkeypatch):
+        meta = _run(tmp_path, monkeypatch, NO_TOC_BOOK, TOC_BOOK)
+
+        per_source = [src["has_toc"] for src in meta["sources"]]
+        assert per_source == [False, True]
+        assert meta["has_toc"] is any(per_source)
+
+    def test_no_toc_anywhere_stays_false(self, tmp_path, monkeypatch):
+        meta = _run(tmp_path, monkeypatch, NO_TOC_BOOK, "Chapter 2\nPlain body.\n")
+
+        assert meta["has_toc"] is False
+
+    def test_single_source_behaviour_unchanged(self, tmp_path, monkeypatch):
+        with_toc = _run(tmp_path / "a", monkeypatch, TOC_BOOK)
+        without = _run(tmp_path / "b", monkeypatch, NO_TOC_BOOK)
+
+        assert with_toc["has_toc"] is True
+        assert without["has_toc"] is False
+
+    def test_chapter_count_still_spans_all_sources(self, tmp_path, monkeypatch):
+        """The #83 fix must keep working alongside this one."""
+        meta = _run(tmp_path, monkeypatch, NO_TOC_BOOK, TOC_BOOK)
+
+        # Chapter 1 from the first book, Chapter 2 from the second.
+        assert meta["chapters_detected"] == 2


### PR DESCRIPTION
## Summary

The consolidated `has_toc` was derived by re-running the 30,000-character ToC scan over the *joined* corpus, so the window only ever covered the first source. A table of contents in any later book was invisible — and feeding the same two books in the opposite order produced the opposite answer.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** `has_toc` is a per-source property, but `main()` recomputed it from the concatenated corpus. `detect_structure` deliberately limits the scan to `text[:30000]` — right for one book, since a ToC sits in the front matter — so on a multi-source run the scan never reached source 2's front matter.
- **Improves:** the result no longer depends on input order, and the top-level value no longer contradicts the per-source records.

## Motivation & context

Closes n/a — found while auditing multi-source consolidation; no existing issue.

Multi-file input is a documented feature (folders, globs, and Mode 4 fold-ins), so this is reachable through normal use rather than a corner case.

Two concrete harms:

1. **`metadata.json` contradicts itself.** `sources[1].has_toc` is `True` while the top-level `has_toc` is `False`.
2. **The agent is actively misled.** `main()` prints `WARN: No table of contents detected — chapter mapping in Step 3 will rely on heading scan only, which may miss or duplicate sections` off the top-level value, and Step 3 reads that field. So the pipeline is told to distrust a ToC that does exist.

Same family as #81/#83: a consolidated value re-derived from the wrong text instead of combined from the per-source results.

## How it works

The per-source `has_toc` values are already correct — each was computed by `extract_single_file` against that source's own first 30k characters. So the consolidated value is now the `any()` of those, rather than a fresh scan:

```python
consolidated_structure["has_toc"] = any(src["has_toc"] for src in extracted_sources)
```

This mirrors how #83 fixed the consolidated chapter count (compute from source texts, not from `full_text.txt`) and how every other consolidated field in that block is built (`sum(...)` over sources).

Single-source behaviour is unchanged: `any()` over one source is that source's own value.

Rejected alternatives:

- **Widening or removing the 30k window in `detect_structure`.** It would fix the multi-source case by accident while making the single-source case worse — a "Contents" line anywhere in a 500-page book would count, including a chapter that happens to be titled "Contents". The window is a deliberate front-matter heuristic and should stay.
- **Teaching `detect_structure` about source boundaries.** That would couple a general text function to the extractor's consolidation format, which is exactly the coupling #83's author explicitly rejected.

## Evidence

**Before / after**, two Markdown sources — book 1 is 56 KB with no ToC, book 2 has a real one:

```
                                             before      after
book1 + book2  (ToC in the second source)    False       True
book2 + book1  (same corpus, other order)    True        True
```

Before, `metadata.json` disagreed with itself:

```json
"sources": [ {"has_toc": false}, {"has_toc": true} ],
"has_toc": false
```

**Tests** — new `tests/test_multi_source_toc.py`, 7 cases:

- `test_filler_book_pushes_second_book_past_the_window` — asserts the fixture is actually >30k, so the test cannot silently stop proving anything if the constant changes.
- `test_toc_in_second_source_is_detected` — the core case.
- `test_result_is_independent_of_input_order` — both orders agree.
- `test_agrees_with_the_per_source_records` — top-level equals `any()` of `sources[*].has_toc`.
- `test_no_toc_anywhere_stays_false` — no false positives introduced.
- `test_single_source_behaviour_unchanged` — with and without a ToC.
- `test_chapter_count_still_spans_all_sources` — the #83 fix keeps working alongside this one.

RED against unmodified `master`: **3 failed, 4 passed** (the three order/detection assertions fail; the premise and no-regression cases pass, as they should). GREEN with the fix:

```
$ python -m pytest tests/ -q
278 passed in 5.02s

$ ruff check .
All checks passed!
```

## Screenshots / output

The before/after table and the contradictory `metadata.json` excerpt above are the output; this is a boolean field, so there is nothing visual to capture.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] `CHANGELOG.md` **not** edited — per #104 the entry comes from this PR's Conventional Commit title
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

Minimal overlap with #112, which adds whitespace-separated CJK entries to `_TOC_HEADERS`. That changes *which strings* count as a ToC header; this changes *which text* gets searched. Different lines, and the two compose — #112 makes this fix apply to CJK corpora too.

One judgement call: I used `any()` rather than "the first source's value". `any()` says "somewhere in this corpus there is a ToC the agent could use", which is what Step 3 actually wants to know. If you would rather the semantics were "the corpus as a whole opens with a ToC", that would be `extracted_sources[0]["has_toc"]` instead — happy to switch, though I think `any()` is the more useful signal for a fold-in.
