### PR TITLE
fix(extractor): expand `~` in input paths

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -415,9 +415,18 @@ def resolve_input_files(paths: list[str]) -> list[Path]:
     User-given order is preserved for explicit file arguments.  Expanded
     results (directories, globs) are sorted deterministically so repeated
     runs produce the same output.
+
+    A leading "~" is expanded here rather than relying on the shell: a glob has
+    to be quoted to reach us unexpanded ("~/books/*.epub"), and quoting stops
+    the shell expanding the tilde too. `glob.glob` and `Path` both treat "~" as
+    a literal directory name, so without this the pattern silently matches
+    nothing.
     """
     resolved = []
-    for path_str in paths:
+    for raw_path in paths:
+        # Normalise "~" once, at the entry point, so both the glob branch and
+        # the file/directory branch below see a real path.
+        path_str = os.path.expanduser(raw_path)
         # Check if it has glob wildcards
         if any(char in path_str for char in ("*", "?", "[")):
             glob_matches = glob.glob(path_str, recursive=True)

--- a/tests/test_tilde_expansion.py
+++ b/tests/test_tilde_expansion.py
@@ -1,0 +1,81 @@
+"""Regression tests: a leading "~" in an input path is expanded.
+
+A glob has to be quoted to survive the shell and reach us as a pattern
+("~/books/*.epub"), but quoting also stops the shell expanding the tilde.
+`glob.glob` and `Path` both treat "~" as a literal directory name, so before
+this fix the README's own quoted-glob example matched nothing and exited with
+"No supported files found".
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import resolve_input_files  # noqa: E402
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Point ~ at a temp directory on POSIX and Windows alike."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+def test_tilde_glob_matches_files(fake_home):
+    """The README's quoted-glob example resolves instead of returning []."""
+    books = fake_home / "books"
+    books.mkdir()
+    (books / "one.md").write_text("# One", encoding="utf-8")
+    (books / "two.md").write_text("# Two", encoding="utf-8")
+
+    result = resolve_input_files(["~/books/*.md"])
+
+    assert [p.name for p in result] == ["one.md", "two.md"]
+
+
+def test_tilde_file_resolves_under_home(fake_home):
+    """A quoted "~/file.md" is a real path, not a "~" directory under cwd."""
+    target = fake_home / "book.md"
+    target.write_text("# Book", encoding="utf-8")
+
+    result = resolve_input_files(["~/book.md"])
+
+    assert result == [target.resolve()]
+    assert "~" not in str(result[0])
+
+
+def test_tilde_directory_is_walked(fake_home):
+    """Directory expansion sees through the tilde too."""
+    docs = fake_home / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("# A", encoding="utf-8")
+    (docs / "ignored.bin").write_text("binary", encoding="utf-8")
+
+    result = resolve_input_files(["~/docs"])
+
+    assert [p.name for p in result] == ["a.md"]
+
+
+def test_plain_paths_are_unchanged(tmp_path):
+    """expanduser is a no-op for paths that do not start with "~"."""
+    target = tmp_path / "plain.md"
+    target.write_text("# Plain", encoding="utf-8")
+
+    assert resolve_input_files([str(target)]) == [target.resolve()]
+
+
+def test_unresolvable_tilde_user_is_left_alone(tmp_path, monkeypatch):
+    """"~nosuchuser/..." has no expansion; it must stay reportable, not crash."""
+    monkeypatch.chdir(tmp_path)
+
+    result = resolve_input_files(["~nosuchuser-book-to-skill/book.md"])
+
+    assert len(result) == 1
+    assert result[0].name == "book.md"


### PR DESCRIPTION
## Summary (Required)

A leading `~` in an input path was never expanded, so the README's own quoted-glob example (`/book-to-skill "~/books/*.epub"`) silently matched zero files and the run died with `No supported files found`. This expands `~` once at the top of `resolve_input_files`, which fixes the glob, file and directory branches together.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `resolve_input_files()` treated `~` as a literal directory name. Root cause: a glob has to be **quoted** to reach the extractor unexpanded, and the same quoting stops the shell expanding the tilde — so `~` arrives verbatim, and neither `glob.glob()` nor `Path()` expands it. Two visible symptoms:
  - `"~/books/*.epub"` → `[]` → `ERROR: No supported files found matching: ~/books/*.epub`
  - `"~/book.pdf"` → `<cwd>/~/book.pdf` → `File not found: …/~/book.pdf`, which points at a path the user never typed.

## Motivation & context (Required)

Closes n/a — no existing issue; found while reproducing the documented usage examples on a clean checkout. `README.md` / `docs/USAGE.md` show `/book-to-skill "~/books/*.epub"` as a first-class example, and it is the one form of the command that cannot work, because the quoting the example needs is exactly what breaks it. A user hitting this sees "no supported files found" for a directory that plainly contains matching files.

## How it works (Required for anything non-trivial)

One call to `os.path.expanduser()` at the **top of the resolve loop**, before the glob-vs-path branch, rather than once inside each branch. Both branches consume the same `path_str`, so normalising at the entry point covers them together and cannot be half-applied if a third input shape is added later.

`expanduser` is safe to call unconditionally: it is the identity function for a string with no leading `~`, and it returns an unresolvable `~someuser` unchanged — so a nonexistent path still flows through to the existing "keep it so the error check can report it" branch instead of raising.

Rejected alternative: expanding inside the `glob` branch only. That would have left the plain-path case (`"~/book.pdf"` → `<cwd>/~/book.pdf`) producing its misleading error message.

## Evidence (Required)

- **Tests:** new `tests/test_tilde_expansion.py` (5 cases) — the quoted glob resolves, `~/file.md` lands under `$HOME` and contains no literal `~`, a `~/dir` input is walked and still extension-filtered, a plain path is unaffected, and an unresolvable `~nosuchuser/...` is still returned for error reporting rather than crashing. `HOME`/`USERPROFILE` are monkeypatched at a `tmp_path`, so the tests touch no real home directory.
- **Before / after:** run against a temp `$HOME` containing `books/one.md`, `books/two.md`, `book.md`.

```
### BEFORE (master b4b3733) ###
  ["~/books/*.md"] -> []
  ["~/book.md"]    -> ['/…/wt-master/~/book.md']          <- literal "~" dir under cwd

### AFTER (this branch) ###
  ["~/books/*.md"] -> ['/…/home/books/one.md', '/…/home/books/two.md']
  ["~/book.md"]    -> ['/…/home/book.md']
```

Reverting only the `utils.py` hunk turns 3 of the 5 new tests red, so they pin the fix rather than passing vacuously:

```
$ git stash push book_to_skill/utils.py && pytest tests/test_tilde_expansion.py -q
FAILED tests/test_tilde_expansion.py::test_tilde_glob_matches_files
FAILED tests/test_tilde_expansion.py::test_tilde_file_resolves_under_home
FAILED tests/test_tilde_expansion.py::test_tilde_directory_is_walked
3 failed, 2 passed in 0.09s
```

Full suite and lint on a clean checkout:

```
$ pytest -q
275 passed, 1 skipped in 0.41s        (270 + the 5 added here; no existing test changed)

$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!

$ python3 tools/validate_skill.py SKILL.md
✓ SKILL.md [Claude Code]: no Claude Code-breaking issues (1 warning(s))
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No UI; the user-visible change is the terminal output in the Before / after block above — the command stops reporting `No supported files found` for a directory that does contain matching files.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — `SKILL.md` is unchanged here; ran it anyway, output above
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

- Behaviour on Windows is unchanged in practice: `expanduser` there reads `USERPROFILE`, and `cmd`/PowerShell do not expand `~` at all, so this makes `~` work in one more place rather than changing an existing result.
- Deliberately out of scope, happy to send separately if you want them: `$VAR` expansion in paths (`os.path.expandvars`) — a different decision, since it has real injection-surface implications that `~` does not.

🤖 Drafted with [Claude Code](https://claude.com/claude-code); every command shown above was actually run, and the numbers are copied from that output.

Made with [Orca](https://github.com/stablyai/orca) 🐋
