### PR TITLE
fix(pdf): stop edge-of-page cleanup deleting real one-word lines

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -7,7 +7,23 @@ import subprocess
 import sys
 from collections import Counter
 
-_PDF_PAGE_NUM = re.compile(r"^\s*(\d{1,4}|[ivxlcdm]{1,7})\s*$", re.IGNORECASE)
+# A bare page number sitting alone on a line: Arabic, or a Roman numeral of the
+# kind used to number front matter.
+#
+# The Roman branch spells out the SHAPE of a canonical numeral instead of
+# listing the letters one may contain. `[ivxlcdm]{1,7}` matched any short word
+# built from those letters, so "MIX", "CIVIL", "DIM", "MILD" and "VIVID" were
+# all silently deleted whenever they landed on a page's first or last non-blank
+# line — a one-word line is exactly what a part title or a display heading looks
+# like. Deleting real text is a worse failure than leaving a stray numeral, so
+# the pattern is now exact.
+#
+# The range is 1-99, which is what front matter uses; "c"/"d"/"m" therefore no
+# longer match on their own, so a lone "C" or "M" line is now kept as text.
+# `(?=[ivxl])` is the non-empty guard: both groups are individually optional, so
+# without it the pattern would match a blank line.
+_ROMAN_1_99 = r"(?=[ivxl])(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})"
+_PDF_PAGE_NUM = re.compile(rf"^\s*(?:\d{{1,4}}|{_ROMAN_1_99})\s*$", re.IGNORECASE)
 _PDF_HYPHEN_WRAP = re.compile(r"(\w)-\n(\w)")
 
 

--- a/tests/test_pdf_page_number_detection.py
+++ b/tests/test_pdf_page_number_detection.py
@@ -1,0 +1,103 @@
+"""Regression tests: edge-of-page cleanup must not delete real one-word lines.
+
+`clean_pdftotext` drops a bare page number when it is a page's first or last
+non-blank line. The Roman branch of that pattern used to be `[ivxlcdm]{1,7}`
+with `re.IGNORECASE`, which matches any short word built from those letters, so
+"MIX", "CIVIL", "DIM", "MILD" and "VIVID" were deleted without a trace whenever
+they were the only word on such a line — the shape of a part title or a display
+heading.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.parsers.pdf import _PDF_PAGE_NUM, clean_pdftotext  # noqa: E402
+
+
+# Words made only of Roman-numeral letters that are not canonical numerals.
+NOT_NUMERALS = ["MIX", "CIVIL", "DIM", "MILD", "VIVID", "LIVID", "DID", "ILL"]
+
+# Numerals that really are used to paginate front matter. Every canonical value
+# in 1-99 must still be stripped — the fix must not trade false positives for
+# false negatives.
+REAL_NUMERALS = [
+    "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix", "x",
+    "xi", "xiv", "xix", "xx", "xxxix", "xl", "xlii", "xlix",
+    "l", "li", "lxxxviii", "xc", "xcix",
+]
+
+
+@pytest.mark.parametrize("word", NOT_NUMERALS)
+def test_roman_letter_words_are_not_page_numbers(word):
+    assert _PDF_PAGE_NUM.match(word) is None
+    assert _PDF_PAGE_NUM.match(word.lower()) is None
+
+
+@pytest.mark.parametrize("numeral", REAL_NUMERALS)
+def test_real_roman_numerals_still_match(numeral):
+    assert _PDF_PAGE_NUM.match(numeral) is not None
+    assert _PDF_PAGE_NUM.match(numeral.upper()) is not None
+
+
+@pytest.mark.parametrize("digits", ["1", "42", "999", "1234"])
+def test_arabic_page_numbers_still_match(digits):
+    assert _PDF_PAGE_NUM.match(digits) is not None
+
+
+def test_every_canonical_numeral_1_to_99_matches():
+    """Exhaustive: no value in the supported range regressed into a miss."""
+    ones = ["", "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix"]
+    tens = ["", "x", "xx", "xxx", "xl", "l", "lx", "lxx", "lxxx", "xc"]
+    for value in range(1, 100):
+        numeral = tens[value // 10] + ones[value % 10]
+        assert _PDF_PAGE_NUM.match(numeral) is not None, f"{value} -> {numeral}"
+
+
+def test_letters_outside_the_1_to_99_range_are_kept():
+    """"C"/"D"/"M" alone are not page numbers in the supported range."""
+    for letter in ("c", "d", "m", "C", "D", "M"):
+        assert _PDF_PAGE_NUM.match(letter) is None
+
+
+def test_blank_line_is_not_a_page_number():
+    """The pattern must not match emptily now that a branch is optional."""
+    assert _PDF_PAGE_NUM.match("") is None
+    assert _PDF_PAGE_NUM.match("   ") is None
+
+
+def test_non_numeral_words_still_rejected():
+    for word in ("Chapter", "Introduction", "the", "42a"):
+        assert _PDF_PAGE_NUM.match(word) is None
+
+
+def _pages(*pages):
+    return "\f".join(pages)
+
+
+def test_part_title_at_page_edge_survives():
+    """End to end: a one-word display line is no longer eaten by the cleaner."""
+    raw = _pages(
+        "MIX\nReal content on page 1.\n1",
+        "CIVIL\nReal content on page 2.\n2",
+        "VIVID\nReal content on page 3.\n3",
+    )
+    out = clean_pdftotext(raw)
+
+    assert "MIX" in out
+    assert "CIVIL" in out
+    assert "VIVID" in out
+    # The actual page numbers are still stripped.
+    assert not any(line.strip() in {"1", "2", "3"} for line in out.splitlines())
+
+
+def test_front_matter_roman_numbers_still_stripped():
+    raw = _pages(*(f"Preface text on page {n}.\n{n}" for n in ("ii", "iii", "iv")))
+    out = clean_pdftotext(raw)
+
+    assert not any(line.strip() in {"ii", "iii", "iv"} for line in out.splitlines())
+    assert "Preface text on page ii." in out


### PR DESCRIPTION
## Summary (Required)

`clean_pdftotext` silently deleted real one-word lines. Its bare-page-number pattern listed the *letters* a Roman numeral may contain instead of the *shape* one has, so `MIX`, `CIVIL`, `DIM`, `MILD`, `VIVID`, `LIVID`, `DID` and `ILL` were removed whenever they were a page's first or last non-blank line. Spelling out the canonical numeral fixes all eight while still stripping every real numeral.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** silent content loss in PDF text-mode extraction. Root cause: `_PDF_PAGE_NUM` used `[ivxlcdm]{1,7}` with `re.IGNORECASE`, which matches any short word built from those letters — not only numerals. A one-word line at a page edge is exactly the shape of a part title, a display heading or a figure caption, so those were dropped before the text ever reached chapter detection or the agent. Nothing is logged when it happens, so the loss is invisible in the output and in `metadata.json`.
- **Improves:** false positives on the word list above go **8 → 0**, with **0** loss in stripping power: every canonical numeral in 1–99 (all 99 checked exhaustively by a new test) is still removed.

## Motivation & context (Required)

Closes n/a — no existing issue; found by fuzzing the cleanup pass against ordinary English words while reviewing the extractor. This one is worth more than its size: it is the failure mode the project can least afford, because a dropped heading is invisible. Everything downstream — `detect_structure`, the Step 3 chapter map, the generated `SKILL.md` topic index — trusts `full_text.txt` to be complete, and there is no signal anywhere that a line went missing.

## How it works (Required for anything non-trivial)

Describe the numeral rather than enumerate its alphabet:

```
(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})
```

Tens: `x{0,3}` for 10–30, `xl` for 40, `l?x{0,3}` for 50–80, `xc` for 90. Units: `i{0,3}` for 1–3, `iv`, `v?i{0,3}` for 5–8, `ix`. That is exactly the canonical set for 1–99, so a non-numeral like `MIX` or `CIVIL` cannot match no matter which letters it is made of.

Rejected alternative: parse the numeral and round-trip it through an int (`_roman_to_int` / `_int_to_roman` already exist in `utils.py`). Two problems. First, `utils` imports `parsers.pdf`, so importing back is a cycle — it would need a new shared module, which is more churn than this bug warrants. Second, it would not actually work on its own: `MIX` **is** canonical Roman for 1009, so a round-trip check passes it and you would still need a range bound on top. The regex needs neither.

Two deliberate range effects, both toward keeping text rather than deleting it:

- A lone `c`/`d`/`m` line is now kept. Those letters only carry values above 99, which is outside the front-matter range this branch exists to serve.
- `(?=[ivxl])` is the non-empty guard. Both numeral groups are individually optional, so without it the pattern would match a blank line; a test pins that.

## Evidence (Required)

- **Tests:** new `tests/test_pdf_page_number_detection.py` (41 cases) — the eight real words are rejected in both cases; all 99 canonical numerals 1–99 are generated and asserted to still match; Arabic 1–4 digits still match; `c`/`d`/`m` alone are kept; blank and whitespace-only lines do not match; and two end-to-end `clean_pdftotext` cases assert a part title at a page edge survives while genuine page numbers are still stripped. The five existing `TestPdftotextCleanup` tests are untouched and still pass.
- **Before / after:** same probe run against `master` (b4b3733) and this branch.

```
### BEFORE (master b4b3733) ###
  words deleted as "page numbers": ['MIX','CIVIL','DIM','MILD','VIVID','LIVID','DID','ILL']
  real numerals still stripped   : ['i','ii','iv','v','x','xiv','xl','l','xc','xcix','42']
  end to end                     : 'content 1\ncontent 2\ncontent 3'

### AFTER (this branch) ###
  words deleted as "page numbers": []
  real numerals still stripped   : ['i','ii','iv','v','x','xiv','xl','l','xc','xcix','42']
  end to end                     : 'MIX\ncontent 1\nCIVIL\ncontent 2\nVIVID\ncontent 3'
```

The middle line is the one that matters: the fix removes false positives without giving up a single true positive.

Full suite and lint on a clean checkout:

```
$ pytest -q
311 passed, 1 skipped in 0.28s        (270 + 41 added here; no existing test changed)

$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No UI. The user-visible change is the end-to-end line above: `MIX`, `CIVIL` and `VIVID` now appear in `full_text.txt` instead of vanishing.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — `SKILL.md` is unchanged here
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

- Happy to change the two range calls if you would rather have them the other way: extending the pattern past 99 (so `c`/`d`/`m` keep being stripped) is a one-line edit, and I chose 1–99 because that is the range front matter actually uses.
- Out of scope, but noticed next door and I can send it separately: the dehyphenation on the last line of this function joins genuinely hyphenated compounds — `"well-\nknown"` becomes `"wellknown"`. The existing comment already flags it; I left it alone to keep this PR to one change.

🤖 Drafted with [Claude Code](https://claude.com/claude-code); every command shown above was actually run, and the numbers are copied from that output.

Made with [Orca](https://github.com/stablyai/orca) 🐋
