### PR TITLE
fix(extractor): skip an unreadable source instead of aborting the batch

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -467,10 +467,21 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
     ext = input_path.suffix.lower()
     document_format = ext.lstrip(".")
     
-    # Sniff magic bytes if suffix is not supported
+    # Sniff magic bytes if suffix is not supported.
+    #
+    # Every failure in this function has to surface as ExtractionError: the
+    # batch loop in main() catches only that, and anything else aborts the whole
+    # run — including the sources that would have extracted fine. An unreadable
+    # or unopenable file is a per-source problem, so translate it here. (The
+    # ZipFile branch below already does this for OSError.)
     if ext not in SUPPORTED_EXTENSIONS:
-        with open(input_str, "rb") as f:
-            header = f.read(8)
+        try:
+            with open(input_str, "rb") as f:
+                header = f.read(8)
+        except OSError as exc:
+            raise ExtractionError(
+                f"Could not read {input_path.name}: {exc.strerror or exc}"
+            ) from exc
         if header[:4] == b"%PDF":
             ext = ".pdf"
             document_format = "pdf"

--- a/tests/test_batch_resilience_unreadable.py
+++ b/tests/test_batch_resilience_unreadable.py
@@ -1,0 +1,103 @@
+"""Regression tests: an unreadable source must be skipped, not abort the batch.
+
+`main()` catches only `ExtractionError`, so every failure inside
+`extract_single_file` has to arrive as one. The magic-byte sniff — reached when
+a file's suffix is not recognised — opened the file without translating
+`OSError`, so a single unreadable file aborted the entire run with a traceback
+and the remaining sources were never processed.
+
+The pre-existing batch tests do not cover this: they use recognised suffixes,
+which take the `read_text_file` path and never reach the sniff.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.exceptions import ExtractionError  # noqa: E402
+from book_to_skill.utils import extract_single_file, main  # noqa: E402
+
+
+def _make_unreadable(path: Path) -> Path:
+    """A file that exists, has an unrecognised suffix, and cannot be opened."""
+    path.write_bytes(b"junk")
+    path.chmod(0o000)
+    return path
+
+
+skip_if_readable_anyway = pytest.mark.skipif(
+    os.geteuid() == 0 if hasattr(os, "geteuid") else True,
+    reason="root (or a platform without POSIX permissions) can read mode-000 files",
+)
+
+
+@skip_if_readable_anyway
+def test_unreadable_unknown_suffix_raises_extraction_error(tmp_path):
+    """The sniff translates OSError instead of letting it escape."""
+    bad = _make_unreadable(tmp_path / "mystery.dat")
+    try:
+        with pytest.raises(ExtractionError) as excinfo:
+            extract_single_file(bad, "text", "no")
+        assert "mystery.dat" in str(excinfo.value)
+    finally:
+        bad.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+@skip_if_readable_anyway
+def test_batch_survives_unreadable_source(tmp_path, monkeypatch, capsys):
+    """The good source still extracts when an unreadable one comes first."""
+    bad = _make_unreadable(tmp_path / "mystery.dat")
+    good = tmp_path / "ok.md"
+    good.write_text("Chapter 1\nReal content.\n", encoding="utf-8")
+
+    workdir = tmp_path / "work"
+    monkeypatch.setenv("BOOK_SKILL_WORKDIR", str(workdir))
+    # config caches OUTPUT_* at import time; point the module constants at the
+    # temp workdir so the run does not touch the shared default.
+    import book_to_skill.config as config
+    import book_to_skill.utils as utils
+
+    for module in (config, utils):
+        monkeypatch.setattr(module, "OUTPUT_DIR", workdir, raising=False)
+        monkeypatch.setattr(module, "OUTPUT_TEXT", workdir / "full_text.txt", raising=False)
+        monkeypatch.setattr(module, "OUTPUT_META", workdir / "metadata.json", raising=False)
+
+    monkeypatch.setattr(
+        sys, "argv", ["extract.py", str(bad), str(good), "--mode", "text", "--install-missing", "no"]
+    )
+
+    try:
+        main()
+    finally:
+        bad.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    text = (workdir / "full_text.txt").read_text(encoding="utf-8")
+    assert "Real content." in text
+
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "mystery.dat" in combined
+    assert "Skipping" in combined or "skipped" in combined
+
+
+def test_missing_file_still_reports_not_found(tmp_path):
+    """The pre-existing not-found path is unchanged."""
+    with pytest.raises(ExtractionError) as excinfo:
+        extract_single_file(tmp_path / "nope.dat", "text", "no")
+    assert "File not found" in str(excinfo.value)
+
+
+def test_readable_unknown_suffix_still_rejected_by_format(tmp_path):
+    """A readable but unrecognised file still fails on format, not on IO."""
+    odd = tmp_path / "mystery.dat"
+    odd.write_bytes(b"not a pdf or a zip")
+
+    with pytest.raises(ExtractionError) as excinfo:
+        extract_single_file(odd, "text", "no")
+    assert "Unsupported format" in str(excinfo.value)


### PR DESCRIPTION
## Summary (Required)

One unreadable file ended the whole batch with a raw traceback, and the sources queued behind it were never processed — the opposite of what README and `docs/ARCHITECTURE.md` promise. The magic-byte sniff opened the file without translating `OSError`, so the failure escaped the per-source contract that `main()` relies on. One `try/except` restores it.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** a contract violation, not a logic error. `main()`'s batch loop catches only `ExtractionError`, so `extract_single_file` implicitly promises that every failure arrives as one. The bare `open(input_str, "rb")` in the magic-byte sniff — reached whenever a file's suffix is not in `SUPPORTED_EXTENSIONS` — was the single place that broke the promise. A file that exists but cannot be opened (permissions, a stale NFS handle, a broken symlink target, a device node) raised `PermissionError`/`OSError` straight through the loop.
- **Improves:** the documented guarantee now holds in this path too. `README.md` says "one bad source is skipped with a warning; the rest still process" and `docs/ARCHITECTURE.md` lists "one bad source is skipped, not fatal" as design principle 5.

## Motivation & context (Required)

Closes n/a — no existing issue; found while testing the batch path against a directory containing a file the user could not read. It matters most in exactly the case the batch mode exists for: point the converter at a folder of mixed sources, and one unreadable file throws away the work already done on every other file, with a traceback rather than a message. Ordering makes it worse — the unreadable file only has to sort first.

## How it works (Required for anything non-trivial)

Wrap the sniff's `open()` and re-raise as `ExtractionError` with the filename and `strerror`. This mirrors the `zipfile.ZipFile` branch a few lines below, which already catches `OSError` for the same reason — the surrounding code clearly knew the rule; this one call site was just missed.

`OSError` specifically, not bare `Exception`: a genuine bug in the sniff should still surface loudly rather than be reported to the user as an unreadable file.

Nothing else in the function needs the same treatment — the later `os.path.getsize` only runs after a successful read, and every parser already catches broadly.

## Evidence (Required)

- **Tests:** new `tests/test_batch_resilience_unreadable.py` (4 cases) — the sniff raises `ExtractionError` (not `OSError`) for an unreadable unknown-suffix file; a full `main()` batch run with the unreadable file **first** still writes `full_text.txt` containing the good source and warns about the skipped one; the pre-existing "File not found" path is unchanged; and a readable-but-unrecognised file still fails on *format* rather than on IO, so the fix does not swallow the real rejection. The permission-dependent cases skip under root and on platforms without POSIX modes.
- **Before / after:** `extract.py mystery.dat ok.md`, where `mystery.dat` is mode `000` and `ok.md` is a valid source.

```
### BEFORE (master b4b3733) ###
  File ".../book_to_skill/utils.py", line 710, in main
    res = extract_single_file(file_path, extraction_mode, install_mode)
  File ".../book_to_skill/utils.py", line 472, in extract_single_file
    with open(input_str, "rb") as f:
PermissionError: [Errno 13] Permission denied: '/tmp/.../mystery.dat'
  -> full_text.txt: NOT WRITTEN          <- ok.md was never even attempted

### AFTER (this branch) ###
   Text -> /tmp/.../out/full_text.txt
   Meta -> /tmp/.../out/metadata.json

   WARNING: 1 source(s) skipped due to errors:
     - mystery.dat: Could not read mystery.dat: Permission denied
  -> full_text.txt: written, contains Real content = yes
```

Reverting only the `utils.py` hunk turns 2 of the 4 new tests red, so they pin the fix:

```
$ git stash push book_to_skill/utils.py && pytest tests/test_batch_resilience_unreadable.py -q
FAILED ...::test_unreadable_unknown_suffix_raises_extraction_error
FAILED ...::test_batch_survives_unreadable_source
2 failed, 2 passed in 0.10s
```

Full suite and lint on a clean checkout:

```
$ pytest -q
274 passed, 1 skipped in 0.33s        (270 + the 4 added here; no existing test changed)

$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No UI. The user-visible change is the terminal output above: a traceback and a lost run become one `WARNING:` line and a complete `full_text.txt`.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — `SKILL.md` is unchanged here
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

- The new test monkeypatches `OUTPUT_DIR`/`OUTPUT_TEXT`/`OUTPUT_META` on both `config` and `utils` because `utils` binds them at import time, so setting `BOOK_SKILL_WORKDIR` alone would not redirect an already-imported module. Happy to switch to whichever pattern you prefer if there is a house style for this.
- A thought rather than a request: the class of bug here is "a call site that escapes the `ExtractionError` contract", and it is invisible to review. If you want, a follow-up could make the batch loop catch `OSError` as well, so a future miss degrades to a skipped source instead of a lost run. I kept this PR to the actual call site.

🤖 Drafted with [Claude Code](https://claude.com/claude-code); every command shown above was actually run, and the numbers are copied from that output.

Made with [Orca](https://github.com/stablyai/orca) 🐋
