### PR TITLE
fix(extractor): request UTF-8 output from pdftotext

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -53,7 +53,7 @@ def extract_with_pdftotext(pdf_path: str) -> str | None:
     try:
         pdf_path = os.path.abspath(pdf_path)
         result = subprocess.run(
-            ["pdftotext", "-layout", pdf_path, "-"],
+            ["pdftotext", "-layout", "-enc", "UTF-8", pdf_path, "-"],
             capture_output=True, text=True, timeout=120,
             encoding="utf-8", errors="replace",
         )

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1484,7 +1484,7 @@ class TestTextEncodingDetection:
 
 
 class TestPdftotextEncoding:
-    """pdftotext output (UTF-8) is decoded as UTF-8, not the locale encoding."""
+    """pdftotext is asked for UTF-8 output, and that output is decoded as UTF-8."""
 
     def test_pdftotext_decodes_as_utf8(self, monkeypatch):
         captured = {}
@@ -1504,6 +1504,28 @@ class TestPdftotextEncoding:
         assert pdf_parser.extract_with_pdftotext("x.pdf") == "Café — naïve"
         assert captured.get("encoding") == "utf-8"
         assert captured.get("errors") == "replace"
+
+    def test_pdftotext_requests_utf8_output(self, monkeypatch):
+        """pdftotext defaults to Latin-1 output; without -enc UTF-8 all CJK is dropped."""
+        captured = {}
+
+        class _Result:
+            returncode = 0
+            stdout = "제1장 서론"
+
+        monkeypatch.setattr(pdf_parser.shutil, "which", lambda name: "/usr/bin/pdftotext")
+
+        def fake_run(cmd, **kwargs):
+            captured["argv"] = list(cmd)
+            return _Result()
+
+        monkeypatch.setattr(pdf_parser.subprocess, "run", fake_run)
+
+        assert pdf_parser.extract_with_pdftotext("x.pdf") == "제1장 서론"
+
+        argv = captured["argv"]
+        assert "-enc" in argv, f"pdftotext invoked without -enc: {argv}"
+        assert argv[argv.index("-enc") + 1] == "UTF-8"
 
 
 class TestPdftotextCleanup:


### PR DESCRIPTION
## Problem

`pdftotext` writes **Latin-1** by default. `extract_with_pdftotext()` decodes the subprocess as UTF-8, but by then the damage is done — every non-Latin-1 codepoint was already dropped by `pdftotext` itself. Hangul, Kana, Han and Cyrillic silently disappear.

The failure is quiet rather than loud: the run succeeds, `chapters_detected` looks sane, and the word count is merely *small* rather than zero. `pdftotext` is tried first and its output is accepted because it is non-empty, so the healthier `pypdf` fallback never runs.

## Fix

Pass `-enc UTF-8`.

```diff
-["pdftotext", "-layout", pdf_path, "-"],
+["pdftotext", "-layout", "-enc", "UTF-8", pdf_path, "-"],
```

## Measurement

A 2,530-page corpus of seven Korean qualitative-methods books, `--mode text`:

| | words | words/page |
|---|---|---|
| before | 141,787 | ~56 |
| after | **539,750** | ~213 |

3.8×. These are not scanned-only PDFs — `pypdf` extracts the same pages fine, which is exactly why the loss is easy to miss.

Sample of the same three pages, before and after:

```
before:  ' ...  '`.I  r  `.`  ,`  Hb  '  140
after:   140 질적 연구 이해 논문 초보자를 위한 가이드
         과정을 거쳐 진행되었는지를 들어야 할 때가 있다. …
```

## Test

`TestPdftotextEncoding` already existed but asserted only the Python-side decode kwargs (`encoding`, `errors`) — never the argv — so it passed both before and after. Added `test_pdftotext_requests_utf8_output`, which captures the argv and asserts `-enc UTF-8` is present.

Verified it actually discriminates:

```
# with the old argv
E  AssertionError: pdftotext invoked without -enc:
   ['pdftotext', '-layout', 'x.pdf', '-']
1 failed

# with the fix
8 passed
```

Full suite: `272 passed`, `ruff check .` clean.

## Notes

- Affects every non-Latin-1 script, not just Korean; Korean is simply where I hit it.
- Independent of #111 (CJK ToC headers with inserted whitespace) — that one is about heading detection *after* text is extracted, this is about the text never arriving.
