### PR TITLE
fix: ToC detection misses Markdown headings; concurrent runs share one workdir

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -156,6 +156,13 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
 
+# Give this run its own extraction workdir. The default is shared across runs,
+# so two conversions in flight at once overwrite each other's full_text.txt —
+# and the loser still writes a metadata.json describing text it did not produce.
+# The extractor now refuses to start on a workdir another live run holds; this
+# keeps you from hitting that at all. Reuse this same value in Step 10.
+export BOOK_SKILL_WORKDIR="${BOOK_SKILL_WORKDIR:-$(mktemp -d -t book_skill_work-XXXXXX)}"
+
 "$PYTHON_BIN" "$SCRIPT_PATH" $INPUT_PATHS --mode <BOOK_TYPE> --install-missing ask
 ```
 
@@ -163,17 +170,17 @@ Before extraction, the script checks optional Python packages needed for the det
 
 **Tip — preflight the environment:** run `"$PYTHON_BIN" "$SCRIPT_PATH" --check` to print a per-format report of which extractors are installed and the exact command to install whatever is missing, without processing any file. Useful when a user reports a setup or quality problem.
 
-This creates:
-- `<tempdir>/book_skill_work/full_text.txt` — combined extracted text of all sources with clear visually demarcated boundaries.
-- `<tempdir>/book_skill_work/metadata.json` — overall combined size, words, pages, token counts, and a detailed list of individual processed `sources`.
+This creates, inside `$BOOK_SKILL_WORKDIR` (the run prints `Workdir ->`, `Text ->` and `Meta ->` so you can confirm where they landed):
+- `full_text.txt` — combined extracted text of all sources with clear visually demarcated boundaries.
+- `metadata.json` — overall combined size, words, pages, token counts, and a detailed list of individual processed `sources`.
 
-Read `<tempdir>/book_skill_work/metadata.json` to inspect the results.
+Read `$BOOK_SKILL_WORKDIR/metadata.json` to inspect the results.
 
 ---
 
 ## Step 2.5 — Pre-flight cost estimate
 
-Read `<tempdir>/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
+Read `$BOOK_SKILL_WORKDIR/metadata.json` and present the user with an estimate **before doing any generation**:
 
 ```
 📖 Sources detected: <total_sources> source(s)
@@ -196,6 +203,14 @@ Read `<tempdir>/book_skill_work/metadata.json` and present the user with an esti
 
 ➡  Proceed with Full Conversion / Update? (or type "analyze only" to preview first)
 ```
+
+**First, sanity-check the chapter count — the estimate is only as good as this number.**
+
+`chapters_detected` comes from a heading scan that looks for "Chapter N" and for Markdown/AsciiDoc headings. A book that numbers its sections `1.`, `2.`, `3.`, or a PDF flattened by `pdftotext` (which carries no Markdown syntax), yields **0** while being perfectly well structured.
+
+Zero is not a small error here, it is a structural one: the output formula multiplies by this count, so a 0 deletes the entire chapter-generation term and the estimate collapses to a flat ~8,500 tokens for a book of any size. The user then approves a number that can be off by half or more, and nothing in the output looks wrong.
+
+So when `chapters_detected` is 0 or obviously disagrees with the source, do the Step 3 structure analysis **now**, before presenting the estimate, and use the count you derive from the table of contents. Say which number you used and where it came from: "the script detected 0 chapters because this book numbers its sections rather than titling them 'Chapter N'; I mapped 6 from the table of contents and estimated on that."
 
 **How to estimate:**
 - Input tokens ≈ `estimated_tokens` from metadata × 1.3 (prompts overhead per chapter pass)
@@ -245,6 +260,12 @@ Read the first 8,000 characters of the extracted `full_text.txt` to identify:
 - Approximate number of chapters
 
 Then read the Table of Contents section if present to map all chapters.
+
+**Treat the ToC as a claim about the book, not as the book.** Two things routinely go wrong, and both are silent:
+
+- **An entry may resolve to nothing.** A ToC row is just a line of text with a page number; extraction can drop the section it points at (a front/back-matter page the extractor skipped, an image-only spread, a PDF whose final pages linearize into boilerplate). Before you commit to a chapter list, confirm each entry actually has body text — `grep -n -i "<entry title>"` and check for a hit *outside* the ToC block. If an entry appears only in the ToC, it does not exist as far as you are concerned. Do not write a chapter for it and do not reconstruct one from the title, which is fabrication dressed as extraction (Quality Rule 7). Record the gap in the generated SKILL.md's Scope & Limits so the reader knows the book has a section your skill does not cover.
+
+- **Not every top-level entry is a chapter.** Front and back matter (Introduction, Preface, Foreword, Conclusion, Afterword, Appendix) often sit at the same indent level as numbered sections. Chapters should be the numbered or clearly parallel body sections. When unnumbered matter carries real content — an Introduction that states the book's core principles, say — fold that content into SKILL.md's Core Frameworks rather than minting a `ch00`, because a reader looking for those principles will look in the front matter of your skill too. When it carries only throat-clearing, drop it.
 
 **If mode is "Analyze Only":** produce the extraction report now and stop. Structure:
 ```
@@ -309,10 +330,22 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
 
 Selection rules:
-1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
+1. If **exactly one** of the host's candidate roots exists on disk, propose it — then confirm before writing (see the destination gate below).
 2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
 3. If the user explicitly asked for project-local output, prefer the project-local row.
 4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, or Claude Code?"
+
+**Destination gate — state the full path and get agreement before any file is written.**
+
+A personal skill root is not an output folder; it is the directory the host **auto-loads every session**. Whatever lands there is live immediately, competing for triggering with everything else installed, under a `name:` you chose rather than one the user picked. If the conversion misfires, the user does not get a bad file to delete — they get a bad skill that starts firing on their prompts. That asymmetry is why this is worth one sentence of friction, even though the rest of the workflow leans toward proceeding.
+
+So before Step 6 creates anything, say plainly where it is going and what it will be called:
+
+> "This will write a new skill to `<SKILLS_HOME>/<skill_name>/` (7 files). That is your live skills directory, so it becomes active as soon as it lands. Good to go, or would you rather I stage it somewhere else first?"
+
+Honour a staging request by writing the whole skill to the path they name and reporting how to move it in later. Do not treat an earlier "yes, convert this book" as agreement about the destination — the user was answering a different question, and most people have no idea the output is auto-loaded until told.
+
+This gate is about *where the files land*, so it applies once per run and does not reopen when Step 5 offers the Update / Overwrite / Rename choice below.
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:
@@ -539,15 +572,19 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
 
+# Removes exactly the workdir Step 2 exported. If BOOK_SKILL_WORKDIR is unset
+# here, Step 2's export was lost — do NOT fall back to the shared default path,
+# which may belong to another run in flight. Skip the cleanup and say so.
 "$PYTHON_BIN" - <<'PY'
 import os
 import shutil
-import tempfile
-from pathlib import Path
-shutil.rmtree(
-    os.environ.get("BOOK_SKILL_WORKDIR", Path(tempfile.gettempdir()) / "book_skill_work"),
-    ignore_errors=True,
-)
+
+workdir = os.environ.get("BOOK_SKILL_WORKDIR")
+if not workdir:
+    print("SKIPPED: BOOK_SKILL_WORKDIR unset; not guessing a path to delete.")
+else:
+    shutil.rmtree(workdir, ignore_errors=True)
+    print(f"Removed extraction workdir: {workdir}")
 PY
 ```
 
@@ -597,7 +634,7 @@ Read and parse the existing skill's files:
 - Read `$SKILLS_HOME/<skill_name>/glossary.md`, `$SKILLS_HOME/<skill_name>/patterns.md`, and `$SKILLS_HOME/<skill_name>/cheatsheet.md` to see what terms and frameworks are already indexed.
 
 ### 2. Match Content & Identify Revisions vs. Additions
-Analyze the new extracted text in `<tempdir>/book_skill_work/full_text.txt` to identify if the new content represents:
+Analyze the new extracted text in `$BOOK_SKILL_WORKDIR/full_text.txt` to identify if the new content represents:
 - **Updates/Revisions to existing chapters**: If a section of the new content directly updates or expands an existing chapter's topic, read the existing chapter file, merge the new details into it, and rewrite the file.
 - **New additions**: If the content introduces new chapters, papers, or separate sections, create **new chapter summary files** under `chapters/`. Start numbering these files after the highest existing chapter number (e.g. if the existing chapters stop at `ch12`, create `ch13-*.md`, `ch14-*.md`, etc.).
 

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -153,8 +153,13 @@ _KO_CHAPTER = re.compile(
     r"^\s*(?:#{1,6}\s+)?제\s*([0-9]+)\s*[장편절관](?:\s*의\s*[0-9]+)?(?:\s*$|[.:\-]|\s+\S)"
 )
 
-# Table-of-contents header lines across common languages. Anchored to a whole
-# line (^\s*X\s*$) so an inline "the contents of this chapter" never matches.
+# Table-of-contents header lines across common languages. Still anchored to a
+# whole line so an inline "the contents of this chapter" never matches, but the
+# header may carry markup: an ATX/AsciiDoc heading marker ("## Contents",
+# "== Contents"), emphasis wrappers ("**Contents**"), and a trailing colon.
+# A bare "^\s*X\s*$" missed every Markdown document, since Markdown writes its
+# ToC heading as "## Table of Contents" — the same blind spot that #91/#92 fixed
+# for chapter headings, which left this sibling pattern behind.
 _TOC_HEADERS = (
     "table of contents", "contents", "índice", "sumário",   # EN / ES / PT
     "目录", "目錄", "目次",                                   # Chinese / Japanese
@@ -164,7 +169,12 @@ _TOC_HEADERS = (
     "inhoudsopgave",                                        # Dutch
 )
 _TOC_PATTERN = re.compile(
-    r"^\s*(?:" + "|".join(re.escape(h) for h in _TOC_HEADERS) + r")\s*$",
+    r"^[ \t]*"                                                  # leading indent
+    r"(?:[#=]{1,6}[ \t]*)?"                                     # "## " / "== "
+    r"(?:\*\*|__|\*|_)?[ \t]*"                                  # opening emphasis
+    r"(?:" + "|".join(re.escape(h) for h in _TOC_HEADERS) + r")"
+    r"[ \t]*(?:\*\*|__|\*|_)?"                                  # closing emphasis
+    r"[ \t]*[:：]?[ \t]*$",                                      # optional colon
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -673,6 +683,68 @@ def print_usage() -> None:
     print(f"Supported formats: {supported_formats_message()}", file=sys.stderr)
 
 
+_WORKDIR_LOCK_NAME = ".extract.lock"
+
+
+def _lock_holder_pid(lock: Path):
+    """PID currently holding the workdir, or None if free/stale/unreadable."""
+    try:
+        pid = int(lock.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    if pid == os.getpid():
+        return None
+    try:
+        os.kill(pid, 0)          # signal 0 = liveness probe, no signal delivered
+    except ProcessLookupError:
+        return None              # ESRCH: process is gone, the lock is stale
+    except PermissionError:
+        return pid               # EPERM: it exists, we simply may not signal it
+    except (OSError, AttributeError):
+        return None              # unknown / platform without os.kill: don't block
+    return pid
+
+
+def claim_workdir(workdir: Path = None) -> Path:
+    """Take exclusive ownership of the extraction workdir.
+
+    Every run defaults to the same <tempdir>/book_skill_work, so two concurrent
+    extractions overwrite each other's full_text.txt in silence: the second
+    writer wins, and the first run then reports its own metadata against text it
+    did not produce. That is worse than failing, because nothing in the output
+    says the text is wrong. Refuse to start instead, and name the way out.
+
+    Stale locks (holder process gone) are reclaimed automatically, so a crashed
+    run does not wedge the next one.
+    """
+    workdir = OUTPUT_DIR if workdir is None else workdir
+    workdir.mkdir(parents=True, exist_ok=True)
+    lock = workdir / _WORKDIR_LOCK_NAME
+
+    holder = _lock_holder_pid(lock)
+    if holder is not None:
+        raise ExtractionError(
+            f"Extraction workdir {workdir} is already in use by PID {holder}. "
+            f"Concurrent runs would overwrite each other's full_text.txt. "
+            f"Give this run its own directory: "
+            f"BOOK_SKILL_WORKDIR=/tmp/book_skill_work-<name> <command>"
+        )
+
+    lock.write_text(str(os.getpid()), encoding="utf-8")
+    return workdir
+
+
+def release_workdir(workdir: Path = None) -> None:
+    """Drop our claim. Safe to call when the lock is absent or not ours."""
+    workdir = OUTPUT_DIR if workdir is None else workdir
+    lock = workdir / _WORKDIR_LOCK_NAME
+    try:
+        if int(lock.read_text(encoding="utf-8").strip()) == os.getpid():
+            lock.unlink()
+    except (OSError, ValueError):
+        pass
+
+
 def main():
     print_banner()
 
@@ -699,8 +771,12 @@ def main():
         print(f"ERROR: No supported files found matching: {', '.join(raw_input_paths)}", file=sys.stderr)
         sys.exit(1)
         
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    
+    try:
+        claim_workdir()
+    except ExtractionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     extracted_sources = []
     combined_texts = []
     errors = []
@@ -800,8 +876,10 @@ def main():
             "   WARN    : No table of contents detected — chapter mapping in Step 3 "
             "will rely on heading scan only, which may miss or duplicate sections."
         )
-    print(f"\n   Text -> {OUTPUT_TEXT}")
+    print(f"\n   Workdir -> {OUTPUT_DIR}")
+    print(f"   Text -> {OUTPUT_TEXT}")
     print(f"   Meta -> {OUTPUT_META}")
+    release_workdir()
     if errors:
         print(f"\n   WARNING: {len(errors)} source(s) skipped due to errors:")
         for path, err in errors:

--- a/tests/test_toc_markdown_headings.py
+++ b/tests/test_toc_markdown_headings.py
@@ -1,0 +1,72 @@
+"""ToC detection must survive Markdown/AsciiDoc heading markup.
+
+Kept in its own file so it does not collide with upstream edits to
+test_book_to_skill.py on a future pull.
+
+Before this fix, _TOC_PATTERN was ^\\s*(table of contents|contents|...)\\s*$,
+which requires the header alone on its line. Every Markdown document writes it
+as "## Table of Contents", so has_toc was False for the entire Markdown corpus
+and detect_structure emitted a spurious "chapter mapping may miss or duplicate
+sections" warning. This is the same blind spot #91/#92 fixed for chapter
+headings; the sibling ToC pattern was left behind.
+"""
+import pytest
+
+from book_to_skill.utils import _TOC_PATTERN, detect_structure
+
+
+@pytest.mark.parametrize("line", [
+    "Table of Contents",            # bare (the only form that worked before)
+    "  Contents",                   # indented
+    "# Contents",                   # ATX level 1
+    "## Table of Contents",         # ATX level 2 — the common Markdown form
+    "###### Contents",              # ATX level 6
+    "== Table of Contents",         # AsciiDoc
+    "**Contents**",                 # bold
+    "__Table of Contents__",        # bold, underscore form
+    "*Contents*",                   # italic
+    "## **Table of Contents**",     # heading + bold
+    "Contents:",                    # trailing colon
+    "## Table of Contents  ",       # trailing whitespace
+    "## SUMÁRIO",                   # non-English, uppercase
+    "## 目录",                       # CJK
+    "目次：",                        # CJK with fullwidth colon
+    "## Inhaltsverzeichnis",
+    "## Table des matières",
+])
+def test_toc_header_forms_are_detected(line):
+    assert _TOC_PATTERN.search(line), f"should match: {line!r}"
+
+
+@pytest.mark.parametrize("line", [
+    "the contents of this chapter are",   # inline prose
+    "Contents of the box",                # line does not end at the header
+    "Table of Contents for Part II",      # qualified, not a bare header
+    "No table of contents was provided",
+    "discontents",                        # substring, not a header
+])
+def test_prose_mentions_are_not_detected(line):
+    assert not _TOC_PATTERN.search(line), f"should NOT match: {line!r}"
+
+
+def test_markdown_document_reports_has_toc():
+    """End-to-end: the regression this fix targets."""
+    doc = (
+        "# The Decision Ledger\n\n"
+        "## Table of Contents\n\n"
+        "- Chapter 1 - The Reversibility Gate\n"
+        "- Chapter 2 - The Cost-of-Delay Triangle\n\n"
+        "## Chapter 1 - The Reversibility Gate\n\nBody text.\n\n"
+        "## Chapter 2 - The Cost-of-Delay Triangle\n\nMore body text.\n"
+    )
+    result = detect_structure(doc)
+    assert result["has_toc"] is True
+    assert result["chapters_detected"] == 2
+
+
+def test_document_without_toc_still_reports_false():
+    doc = (
+        "# Some Book\n\n"
+        "## Chapter 1 - Opening\n\nBody text mentioning the contents of the room.\n"
+    )
+    assert detect_structure(doc)["has_toc"] is False

--- a/tests/test_workdir_lock.py
+++ b/tests/test_workdir_lock.py
@@ -1,0 +1,88 @@
+"""Concurrent extractions must not silently share one workdir.
+
+Kept in its own file so it does not collide with upstream edits to
+test_book_to_skill.py on a future pull.
+
+BOOK_SKILL_WORKDIR defaults to a single <tempdir>/book_skill_work for every
+run, so two extractions running at once overwrite each other's full_text.txt.
+The damage is silent: the losing run still writes its own metadata.json, which
+then describes text it did not produce. claim_workdir() makes the second run
+refuse to start instead.
+"""
+import os
+
+import pytest
+
+from book_to_skill.exceptions import ExtractionError
+from book_to_skill.utils import claim_workdir, release_workdir, _WORKDIR_LOCK_NAME
+
+
+def test_claim_creates_workdir_and_lock(tmp_path):
+    wd = tmp_path / "work"
+    claim_workdir(wd)
+    assert wd.is_dir()
+    assert (wd / _WORKDIR_LOCK_NAME).read_text().strip() == str(os.getpid())
+
+
+def test_same_process_can_reclaim(tmp_path):
+    """Re-entry within one run is not a collision."""
+    wd = tmp_path / "work"
+    claim_workdir(wd)
+    claim_workdir(wd)  # must not raise
+
+
+def test_live_holder_blocks_second_run(tmp_path):
+    """A different, living PID means a concurrent run: refuse."""
+    wd = tmp_path / "work"
+    wd.mkdir()
+    # PID 1 always exists and is never this process.
+    (wd / _WORKDIR_LOCK_NAME).write_text("1")
+
+    with pytest.raises(ExtractionError) as exc:
+        claim_workdir(wd)
+    msg = str(exc.value)
+    assert "already in use" in msg
+    assert "BOOK_SKILL_WORKDIR" in msg, "the error must name the way out"
+
+
+def test_stale_lock_is_reclaimed(tmp_path):
+    """A crashed run must not wedge the next one."""
+    wd = tmp_path / "work"
+    wd.mkdir()
+    dead = _find_unused_pid()
+    (wd / _WORKDIR_LOCK_NAME).write_text(str(dead))
+
+    claim_workdir(wd)  # must not raise
+    assert (wd / _WORKDIR_LOCK_NAME).read_text().strip() == str(os.getpid())
+
+
+@pytest.mark.parametrize("junk", ["", "   ", "not-a-pid", "\x00"])
+def test_unreadable_lock_is_treated_as_free(tmp_path, junk):
+    wd = tmp_path / "work"
+    wd.mkdir()
+    (wd / _WORKDIR_LOCK_NAME).write_text(junk)
+    claim_workdir(wd)  # must not raise
+
+
+def test_release_removes_only_our_lock(tmp_path):
+    wd = tmp_path / "work"
+    claim_workdir(wd)
+    release_workdir(wd)
+    assert not (wd / _WORKDIR_LOCK_NAME).exists()
+
+    (wd / _WORKDIR_LOCK_NAME).write_text("1")
+    release_workdir(wd)
+    assert (wd / _WORKDIR_LOCK_NAME).exists(), "must not steal another run's lock"
+
+
+def test_release_is_safe_when_absent(tmp_path):
+    release_workdir(tmp_path / "never-created")  # must not raise
+
+
+def _find_unused_pid() -> int:
+    for pid in range(320000, 400000):
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return pid
+    pytest.skip("no free PID found to simulate a stale lock")


### PR DESCRIPTION
Two independent defects found while benchmarking the converter, plus the workflow changes that follow from them. Happy to split into separate PRs if you'd prefer to take them one at a time.

## 1. ToC detection never fires on Markdown

`_TOC_PATTERN` is `^\s*(table of contents|contents|...)\s*$`, which requires the header alone on its line. Markdown writes it as `## Table of Contents`, so **every** Markdown document reports `ToC: not detected` and emits the "chapter mapping may miss or duplicate sections" warning.

This is the same blind spot #91/#92 fixed for chapter headings — the chapter regex was patched, its ToC sibling was left behind.

The pattern now allows ATX/AsciiDoc markers, emphasis wrappers and a trailing colon (ASCII or fullwidth), while keeping the end-of-line anchor so an inline "the contents of this chapter" still does not match.

Reproducer, before the fix (`book.md` contains a `## Table of Contents` section):

```
$ python3 scripts/extract.py book.md --mode text
   Chapters: 7 detected overall
   ToC     : not detected
   WARN    : No table of contents detected ...
```

## 2. Concurrent runs silently corrupt each other

Every extraction defaults to one shared `<tempdir>/book_skill_work`, so two runs in flight overwrite each other's `full_text.txt`. The failure is silent and worse than a crash: the losing run still writes its own `metadata.json`, which then describes text it did not produce, and nothing in the output indicates the text is wrong.

`claim_workdir()` takes a PID lock and refuses to start on a workdir a live run holds, naming `BOOK_SKILL_WORKDIR` as the way out. Stale locks are reclaimed so a crashed run cannot wedge the next one, and `EPERM` is treated as alive rather than gone so a lock held by another user's process is never stolen.

## 3. SKILL.md workflow changes

These are more opinionated than the two code fixes, so they are the most likely part to want discussion:

- **Destination gate (Step 5).** Step 5 resolved `SKILLS_HOME` to the personal skills root and used it "without asking". That root is auto-loaded every session, so a misfired conversion does not leave a file the user can delete — it leaves a skill that starts firing on their prompts. The gate states the full path and gets agreement before Step 6 creates anything.
- **Chapter count (Step 2.5).** The estimate multiplies a per-chapter budget by `chapters_detected`. A book numbering its sections `1.`/`2.`/`3.` through `pdftotext` yields `0`, which deletes the entire chapter term and collapses the estimate to a flat ~8,500 output tokens for a book of any size. Observed off by roughly 2x on a real 27-page PDF.
- **ToC entries may not resolve (Step 3).** In that same book the ToC listed a `Conclusion` whose only occurrence in the extracted text was the ToC line itself. Step 3 now says to grep-confirm each entry outside the ToC block and never reconstruct a chapter from its title.

## Tests

33 new tests across two new files, kept out of `test_book_to_skill.py` to stay merge-friendly. Suite goes 270 → 304 passing, 1 skipped, no regressions.

One of those tests caught a real bug in my own first attempt: I had written `except OSError` as "process is gone", but `EPERM` means the process exists and merely cannot be signalled, so a root-owned lock would have been wrongly reclaimed.

## Not addressed

`pdftotext` renders `ff`/`ffi` ligatures as `!` (`di!erent`, and `di!` for `diff`). Auto-repair looks unsafe — you cannot distinguish a mangled ligature from a real `!` without a dictionary — so a warning when the signature appears may be the better fix. Left alone here.
