### PR TITLE
fix(pdf): use reading order for multi-column PDFs instead of -layout

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -10,6 +10,41 @@ from collections import Counter
 _PDF_PAGE_NUM = re.compile(r"^\s*(\d{1,4}|[ivxlcdm]{1,7})\s*$", re.IGNORECASE)
 _PDF_HYPHEN_WRAP = re.compile(r"(\w)-\n(\w)")
 
+# A wide run of spaces *inside* a line of text is the gutter between columns.
+# Four is above the widest inter-word justification pdftotext emits and below
+# the narrowest real gutter.
+_PDF_GUTTER = re.compile(r"\S {4,}\S")
+
+# Fraction of substantive lines that must show a gutter before the document is
+# treated as multi-column. A single-column PDF scores near zero; a
+# three-column government publication scores ~0.85.
+_MULTICOLUMN_THRESHOLD = 0.35
+
+# Short lines are headings, page furniture and list stubs; they pick up wide
+# gaps by accident. Only lines long enough to span a column are evidence.
+_MIN_GUTTER_LINE = 40
+_GUTTER_SAMPLE = 4000
+
+
+def looks_multicolumn(layout_text: str) -> bool:
+    """Does ``pdftotext -layout`` output come from a multi-column document?
+
+    ``-layout`` preserves horizontal position, which is what keeps table
+    columns aligned — and is exactly what makes a multi-column page unusable:
+    every emitted line spans all columns, so consecutive sentences from
+    different columns interleave.
+
+    This is a structural signal, not layout analysis: two runs of real text
+    separated by a wide space run means two blocks sat side by side.
+    """
+    lines = [ln for ln in layout_text.splitlines()
+             if len(ln.strip()) > _MIN_GUTTER_LINE]
+    if not lines:
+        return False
+    sample = lines[:_GUTTER_SAMPLE]
+    hits = sum(1 for ln in sample if _PDF_GUTTER.search(ln))
+    return hits / len(sample) >= _MULTICOLUMN_THRESHOLD
+
 
 def clean_pdftotext(text: str) -> str:
     """Clean pdftotext '-layout' output (pages are form-feed delimited): drop
@@ -47,18 +82,58 @@ def clean_pdftotext(text: str) -> str:
     return _PDF_HYPHEN_WRAP.sub(r"\1\2", text)
 
 
+def _pdftotext(pdf_path: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["pdftotext", *args, pdf_path, "-"],
+        capture_output=True, text=True, timeout=120,
+        encoding="utf-8", errors="replace",
+    )
+
+
 def extract_with_pdftotext(pdf_path: str) -> str | None:
+    """Extract a PDF, choosing ``-layout`` only when it will not scramble text.
+
+    ``-layout`` is the right default for a single-column document: it keeps
+    table columns aligned. On a multi-column document it destroys reading
+    order, because each emitted line spans every column. Measured on IRS
+    Publication 17 (142 pages, three columns), searching both outputs for the
+    same phrase:
+
+        -layout        'standard deduction or if you    (QOF). Taxpayers who made a'
+        reading order  'Standard deduction amount increased. For 2025, the
+                        standard deduction amount has been increased for all filers'
+
+    The first is three columns welded together, and it is what every later
+    step reads. ``-layout`` also pads each line to preserve position, which on
+    that document produced 25,266,249 characters at 96.8% whitespace against
+    957,757 in reading order — 26x larger for text that is also wrong.
+
+    So: run ``-layout`` first (unchanged for the single-column majority), and
+    only re-run without it when the output looks multi-column. The second
+    subprocess is paid solely by documents that need it.
+    """
     if not shutil.which("pdftotext"):
         return None
     try:
         pdf_path = os.path.abspath(pdf_path)
-        result = subprocess.run(
-            ["pdftotext", "-layout", pdf_path, "-"],
-            capture_output=True, text=True, timeout=120,
-            encoding="utf-8", errors="replace",
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return clean_pdftotext(result.stdout)
+        result = _pdftotext(pdf_path, "-layout")
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        if looks_multicolumn(result.stdout):
+            reading_order = _pdftotext(pdf_path)
+            if reading_order.returncode == 0 and reading_order.stdout.strip():
+                # ASCII only: this goes to stderr from the parser, which does
+                # not get cli.py's UTF-8 reconfigure on a legacy Windows console.
+                print("  [info] multi-column layout detected - using reading "
+                      "order instead of -layout", file=sys.stderr)
+                return clean_pdftotext(reading_order.stdout)
+            # Falling back to -layout output is still better than nothing;
+            # say so rather than silently returning scrambled text.
+            print("  [warn] multi-column layout detected but the reading-order "
+                  "pass failed; text may be interleaved", file=sys.stderr)
+
+        return clean_pdftotext(result.stdout)
     except Exception as e:
         print(f"  [warn] extract_with_pdftotext failed: {type(e).__name__}: {e}", file=sys.stderr)
     return None

--- a/tests/test_pdf_multicolumn.py
+++ b/tests/test_pdf_multicolumn.py
@@ -1,0 +1,140 @@
+"""`pdftotext -layout` must not be used on multi-column documents.
+
+`-layout` preserves horizontal position, which keeps table columns aligned on a
+single-column page and destroys reading order on a multi-column one: every
+emitted line spans all columns, so consecutive sentences from different columns
+interleave.
+
+Measured on IRS Publication 17 (142 pages, three columns per page), searching
+both extractions for the same phrase:
+
+    -layout        'standard deduction or if you    (QOF). Taxpayers who made a'
+    reading order  'Standard deduction amount increased. For 2025, the standard
+                    deduction amount has been increased for all filers'
+
+The first is three columns welded together. A skill distilled from it can
+contain sentences that never existed in the book.
+
+The size difference on the same document — 25,266,249 chars at 96.8%
+whitespace versus 957,757 — is the visible symptom, but it is the ordering
+that makes the output wrong rather than merely large.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.parsers import pdf as pdf_parser
+from book_to_skill.parsers.pdf import extract_with_pdftotext, looks_multicolumn
+
+
+def _single_column(lines: int = 60) -> str:
+    body = ("The quick brown fox jumps over the lazy dog and keeps running "
+            "until it reaches the far side of the field.")
+    return "\n".join(body for _ in range(lines))
+
+
+def _two_column(lines: int = 60) -> str:
+    """What -layout emits for side-by-side text: one line spanning both."""
+    left = "The quick brown fox jumps over the lazy dog and keeps"
+    right = "Separately typeset material that belongs to another column"
+    return "\n".join(f"{left}        {right}" for _ in range(lines))
+
+
+# ── detection ────────────────────────────────────────────────────────────
+
+def test_single_column_is_not_flagged():
+    assert not looks_multicolumn(_single_column())
+
+
+def test_two_column_is_flagged():
+    assert looks_multicolumn(_two_column())
+
+
+def test_empty_and_whitespace_only_input_are_safe():
+    assert not looks_multicolumn("")
+    assert not looks_multicolumn("\n\n   \n")
+
+
+def test_short_lines_alone_do_not_trigger_detection():
+    """Headings, page numbers and list stubs pick up wide gaps by accident.
+    Only lines long enough to span a column count as evidence."""
+    assert not looks_multicolumn("\n".join("Ch 1        7" for _ in range(50)))
+
+
+def test_a_few_wide_gaps_do_not_flag_a_single_column_document():
+    """A table or two inside an otherwise single-column book must not flip the
+    whole document into reading-order mode."""
+    text = _single_column(50) + "\n" + _two_column(5)
+    assert not looks_multicolumn(text)
+
+
+# ── extraction ───────────────────────────────────────────────────────────
+
+class _FakeRun:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _patch(monkeypatch, layout_out, plain_out, plain_rc=0):
+    """Record which pdftotext invocations happen and with what flags."""
+    calls = []
+
+    def fake(pdf_path, *args):
+        calls.append(args)
+        if "-layout" in args:
+            return _FakeRun(layout_out)
+        return _FakeRun(plain_out, plain_rc)
+
+    monkeypatch.setattr(pdf_parser, "_pdftotext", fake)
+    monkeypatch.setattr(pdf_parser.shutil, "which", lambda _: "/usr/bin/pdftotext")
+    return calls
+
+
+def test_single_column_still_uses_layout_and_runs_once(monkeypatch, tmp_path):
+    """The common case must not pay for a second subprocess, and must keep the
+    -layout behaviour that aligns tables."""
+    calls = _patch(monkeypatch, _single_column(), "READING ORDER")
+    out = extract_with_pdftotext(str(tmp_path / "book.pdf"))
+    assert calls == [("-layout",)]
+    assert "quick brown fox" in out
+    assert "READING ORDER" not in out
+
+
+def test_multicolumn_reruns_without_layout(monkeypatch, tmp_path):
+    calls = _patch(monkeypatch, _two_column(), "READING ORDER TEXT")
+    out = extract_with_pdftotext(str(tmp_path / "book.pdf"))
+    assert calls == [("-layout",), ()]
+    assert "READING ORDER TEXT" in out
+
+
+def test_failed_reading_order_pass_warns_and_keeps_layout(monkeypatch, tmp_path, capsys):
+    """Interleaved text still beats no text — but it must not be silent."""
+    _patch(monkeypatch, _two_column(), "", plain_rc=1)
+    out = extract_with_pdftotext(str(tmp_path / "book.pdf"))
+    assert out is not None and "quick brown fox" in out
+    assert "may be interleaved" in capsys.readouterr().err
+
+
+def test_missing_binary_still_returns_none(monkeypatch, tmp_path):
+    """The fallback chain contract: return None so the next extractor runs."""
+    monkeypatch.setattr(pdf_parser.shutil, "which", lambda _: None)
+    assert extract_with_pdftotext(str(tmp_path / "book.pdf")) is None
+
+
+def test_empty_layout_output_returns_none(monkeypatch, tmp_path):
+    _patch(monkeypatch, "   \n", "READING ORDER")
+    assert extract_with_pdftotext(str(tmp_path / "book.pdf")) is None
+
+
+# ── the real thing, when poppler is present ──────────────────────────────
+
+def test_gutter_regex_matches_a_real_layout_line():
+    """Guards the constant: a genuine -layout line from Publication 17."""
+    line = ("standard deduction or if you        (QOF). Taxpayers who made a")
+    assert pdf_parser._PDF_GUTTER.search(line)
+    assert not pdf_parser._PDF_GUTTER.search(
+        "Standard deduction amount increased. For 2025, the amounts are:")


### PR DESCRIPTION
Fixes #128.

## Problem

`extract_with_pdftotext()` runs `pdftotext -layout` unconditionally. That is the right default for a single-column document — it keeps table columns aligned. On a **multi-column** document every emitted line spans all columns, so consecutive sentences from different columns interleave.

Measured on **IRS Publication 17** (142 pages, three columns, public domain, <https://www.irs.gov/pub/irs-pdf/p17.pdf>), searching both extractions for the same phrase:

```
-layout        'standard deduction or if you        (QOF). Taxpayers who made a'

reading order  'Standard deduction amount increased. For 2025, the standard
                deduction amount has been increased for all filers'
```

The first is three columns welded together — and it is what chapter detection, ToC detection and the Step 3 distillation all read. A skill built from it can contain sentences that never existed in the book.

`-layout` also pads every line to preserve horizontal position, and `clean_pdftotext()` never collapses it:

| | chars | whitespace |
|---|---:|---:|
| `-layout` | 25,266,249 | 96.8% |
| reading order | 957,007 | 15.8% |

26× larger, for text that is also wrong. That blowup is invisible today because `estimate_tokens()` counts words, and padding does not change word count — so `metadata.json` reports `~220K` tokens for a file that costs ~6.3M to read.

## Change

Detect the layout and pick the mode.

Detection is a structural signal rather than layout analysis: under `-layout`, a wide run of spaces between two runs of real text means two blocks sat side by side.

```python
_PDF_GUTTER = re.compile(r"\S {4,}\S")
_MULTICOLUMN_THRESHOLD = 0.35
_MIN_GUTTER_LINE = 40      # headings and page furniture are not evidence
_GUTTER_SAMPLE = 4000
```

Publication 17 scores **0.85**. A single-column document scores near zero.

**`-layout` still runs first**, so the single-column majority is completely unchanged and pays no extra subprocess. The reading-order pass runs only when detection fires.

If that second pass fails, the `-layout` text is still returned — interleaved text beats no text — but with a warning rather than silently. That follows the reasoning in #47 about surfacing rather than swallowing.

Stdlib only; no new dependencies.

## Verification

End to end on Publication 17: detection fires, output drops to 957,007 chars, and the phrase above comes back intact.

```
  [info] multi-column layout detected - using reading order instead of -layout
  chars=957,007  whitespace=15.8%  ~tokens=239,251
  phrase: Standard deduction amount increased. For 2025, the standard deduction
          amount has been increased for all filers. The amounts are:
```

**11 new tests** in `tests/test_pdf_multicolumn.py`:

- detection on single-column vs two-column text
- empty and whitespace-only input
- short-lines-only input (headings and page numbers must not trigger it)
- a table inside an otherwise single-column book must not flip the whole document
- the single-column path still runs **exactly one** subprocess, with `-layout`
- the multi-column path re-runs without it
- a failed second pass warns and keeps the `-layout` text
- a missing `pdftotext` binary still returns `None`, so the fallback chain continues
- the gutter regex matches a real Publication 17 line and not ordinary prose

`pytest -q`: **282 passed**. `ruff check`: clean.

## Notes

- The same run reported `Chapters: 3 detected` on a publication with dozens. I suspect that is downstream of the interleaving, but I have not proven it and this PR does not claim to fix it.
- `estimate_tokens()` counting words rather than characters is the reason neither failure is visible in `metadata.json`. Left alone here to keep this PR to one change — happy to open a separate one if you want it.
- Not addressed: collapsing `-layout` padding for documents where `-layout` remains the correct choice. Collapsing runs of 2+ spaces took Publication 17 from 25,264,555 to 970,243 chars with all 165,049 words intact, but that makes interleaved text *smaller*, not *correct*, so it is a separate concern from this fix.