### PR TITLE
fix(pdf): abort early on scanned PDFs with an OCR hint

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -64,6 +64,25 @@ def extract_with_pdftotext(pdf_path: str) -> str | None:
     return None
 
 
+def looks_image_only(pdf_path: str, pages: int = 5) -> bool:
+    """True when the first `pages` pages yield no extractable text — the signature
+    of a scanned/image-only PDF. Cheap pre-flight so a scan fails in a second
+    instead of after the whole extraction chain has run. Best-effort: without
+    pdftotext it reports False and the normal chain (plus the final empty-text
+    guard) still applies."""
+    if not shutil.which("pdftotext"):
+        return False
+    try:
+        result = subprocess.run(
+            ["pdftotext", "-f", "1", "-l", str(pages), os.path.abspath(pdf_path), "-"],
+            capture_output=True, text=True, timeout=30,
+            encoding="utf-8", errors="replace",
+        )
+        return result.returncode == 0 and not result.stdout.strip()
+    except Exception:
+        return False
+
+
 def extract_with_pypdf(pdf_path: str) -> str | None:
     try:
         import pypdf

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -38,6 +38,7 @@ from book_to_skill.parsers.pdf import (
     extract_with_pdftotext,
     extract_with_pypdf,
     extract_with_pdfminer,
+    looks_image_only,
     count_pages,
 )
 from book_to_skill.parsers.epub import (
@@ -533,10 +534,17 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
         pages_label = "spine_items"
     elif ext == ".pdf":
         print(f"Extracting PDF: {input_str}")
+        if looks_image_only(input_str):
+            raise ExtractionError(
+                f"{input_path.name} looks like a scanned (image-only) PDF: its first pages "
+                "contain no extractable text, only images.\n"
+                "Run OCR on it first, then retry:\n"
+                "  ocrmypdf input.pdf output.pdf"
+            )
         if extraction_mode == "technical":
             print("Mode: technical — using Docling (layout-aware)...", end=" ", flush=True)
             text = extract_with_docling(input_str)
-            if text:
+            if text and text.strip():
                 method = "docling"
                 print("OK")
             else:
@@ -547,22 +555,22 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
             print("Mode: text — using pdftotext...")
             print("Trying pdftotext...", end=" ", flush=True)
             text = extract_with_pdftotext(input_str)
-            
-            if text:
+
+            if text and text.strip():
                 method = "pdftotext"
                 print("OK")
             else:
                 print("not available")
                 print("Trying pypdf...", end=" ", flush=True)
                 text = extract_with_pypdf(input_str)
-                if text:
+                if text and text.strip():
                     method = "pypdf"
                     print("OK")
                 else:
                     print("not available")
                     print("Trying pdfminer.six...", end=" ", flush=True)
                     text = extract_with_pdfminer(input_str)
-                    if text:
+                    if text and text.strip():
                         method = "pdfminer"
                         print("OK")
                     else:

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1506,6 +1506,56 @@ class TestPdftotextEncoding:
         assert captured.get("errors") == "replace"
 
 
+class TestLooksImageOnly:
+    """Scanned PDFs are caught by probing the first pages, before the chain runs."""
+
+    def _probe(self, monkeypatch, stdout, *, has_pdftotext=True):
+        captured = {}
+
+        class _Result:
+            returncode = 0
+
+        _Result.stdout = stdout
+        monkeypatch.setattr(
+            pdf_parser.shutil, "which",
+            lambda name: "/usr/bin/pdftotext" if has_pdftotext else None,
+        )
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _Result()
+
+        monkeypatch.setattr(pdf_parser.subprocess, "run", fake_run)
+        return captured
+
+    def test_no_text_in_first_pages_is_image_only(self, monkeypatch):
+        captured = self._probe(monkeypatch, "\n\f\n  \f")
+        assert pdf_parser.looks_image_only("scan.pdf") is True
+        # Only the first pages are probed, not the whole book.
+        assert "-l" in captured["cmd"] and captured["cmd"][captured["cmd"].index("-l") + 1] == "5"
+
+    def test_text_in_first_pages_is_not_image_only(self, monkeypatch):
+        self._probe(monkeypatch, "Chapter 1\nOnce upon a time")
+        assert pdf_parser.looks_image_only("book.pdf") is False
+
+    def test_without_pdftotext_probe_is_skipped(self, monkeypatch):
+        self._probe(monkeypatch, "", has_pdftotext=False)
+        assert pdf_parser.looks_image_only("scan.pdf") is False
+
+    def test_extraction_fails_early_with_ocr_hint(self, monkeypatch, tmp_path):
+        from book_to_skill import utils
+
+        pdf = tmp_path / "scan.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+        monkeypatch.setattr(utils, "looks_image_only", lambda path: True)
+
+        with pytest.raises(ExtractionError) as exc:
+            utils.extract_single_file(pdf, "text", "no")
+
+        assert "scanned" in str(exc.value)
+        assert "ocrmypdf" in str(exc.value)
+
+
 class TestPdftotextCleanup:
     """clean_pdftotext strips repeated headers/footers/page numbers and dehyphenates."""
 


### PR DESCRIPTION
## Summary (Required)

A scanned (image-only) PDF used to fail only at the very end of the pipeline — after Docling had processed the entire book in technical mode — and the error blamed "Unicode sanitization" instead of saying "this is a scan, run OCR". This probes the first 5 pages up front and fails in ~0.01s with an actionable `ocrmypdf` hint.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** an image-only PDF ran the whole extraction chain (Docling on every page in `--mode technical`, then pdftotext → pypdf → pdfminer) before the final `if not text.strip()` guard in `extract_single_file` raised — with a message about Unicode sanitization that never mentions OCR. Root cause: there was no pre-flight check, and the guard sat at the end of the function.
- **Fixes:** the PDF chain tested `if text:` at four call sites. `extract_with_pypdf` joins per-page strings, so an image-only PDF yields `"\n\n\n…"` — truthy — and extraction was marked successful (`method="pypdf"`) with no real text. Now `if text and text.strip():`.
- **Improves:** time-to-error on a scanned PDF from a full Docling pass over the book down to a measured 0.01s, and the message now names the actual problem and the fix command.

## Motivation & context (Required)

Reported directly by a non-technical user who ran book-to-skill on a scanned PDF: it "spent ages trying to identify it and only then said it couldn't read it", burning agent time and tokens on a file that was never going to work. Her suggestion was exactly this — bail on the first pages.

Closes #n/a — reported in a live conversation, not via an issue.

## How it works (Required for anything non-trivial)

`looks_image_only()` shells out to `pdftotext -f 1 -l 5` and returns True when those pages produce no non-whitespace text. `extract_single_file` calls it as the first thing in the `.pdf` branch, before the extractor is chosen, so Docling never starts on a scan.

Deliberately conservative:
- **No OCR here.** Keeping OCR out of the tool is an existing product decision; this PR only makes the failure fast and legible, and points at `ocrmypdf`.
- **Degrades to a no-op.** Without `pdftotext` on PATH the probe returns False and the normal chain (plus the unchanged final empty-text guard) runs exactly as before. Same for a timeout or any subprocess error.
- **5 pages, not 1.** A single scanned cover page in an otherwise text PDF must not trip the guard.

Known limit, accepted: a book whose first 5 pages are images but whose body is real text would now be rejected. I could not construct a realistic instance of that, and the trade is a fast honest failure against minutes of work ending in a misleading message.

## Evidence (Required)
- **Tests:** new `TestLooksImageOnly` — 4 cases: whitespace-only first pages ⇒ True and the probe is capped at `-l 5`; real text ⇒ False; no `pdftotext` on PATH ⇒ False (probe skipped); and an end-to-end `extract_single_file` on a `.pdf` raising `ExtractionError` whose message contains both "scanned" and "ocrmypdf".
- **Before / after:** built two real PDFs with reportlab — `text.pdf` (8 pages of text) and `scan.pdf` (8 pages of drawn rectangles, zero text operators) — and ran the real extraction path on both.

```
$ python -c "... extract_single_file(scan.pdf) ..."
Extracting PDF: /tmp/.../scan.pdf
-> ExtractionError after 0.01s:
scan.pdf looks like a scanned (image-only) PDF: its first pages contain no extractable text, only images.
Run OCR on it first, then retry:
  ocrmypdf input.pdf output.pdf

$ python -c "... extract_single_file(text.pdf) ..."
Extracting PDF: /tmp/.../text.pdf
Mode: text — using pdftotext...
Trying pdftotext... OK
-> OK text.pdf: method=pdftotext chars=343 (0.03s)

$ pytest -q       ->  274 passed, 1 skipped
$ ruff check .    ->  All checks passed!
```

Before this change, the same `scan.pdf` reached the end of the chain and raised `Extracted text from scan.pdf contained no visible content after Unicode sanitization.` — and in `--mode technical` only after Docling had walked every page.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

The `text.strip()` tightening at the four call sites is strictly a second line of defense — with the probe in place it should be unreachable for scans — but `if text:` on a whitespace string was wrong on its own terms, so I fixed it rather than leaving a latent silent-success path for any future extractor that returns blank pages.
