### PR TITLE
fix(changelog): stop duplicating the PR number in generated entries

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -2,6 +2,12 @@
 # messages so PRs never edit the changelog by hand (no more merge-conflict churn
 # on a shared [Unreleased] section). Keep a Changelog style; grouped by type.
 # Regenerate at release time:  git-cliff --tag vX.Y.Z -o CHANGELOG.md
+#
+# The entry line does NOT append commit.remote.pr_number: PRs land here by
+# squash merge, and GitHub already puts "(#N)" at the end of the squashed
+# commit subject. Appending it again produced "… (#101) (#101)", and only for
+# the commits whose PR git-cliff could resolve — so the generated file differed
+# depending on whether the person cutting the release had GitHub API access.
 
 [changelog]
 header = """
@@ -23,7 +29,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}\
-- {{ commit.message | upper_first }}{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}
+- {{ commit.message | upper_first }}
 {% endfor %}\
 {% endfor %}\n
 """


### PR DESCRIPTION
## Summary (Required)

The changelog generator appended the PR number to entries that already ended with one, so the pending v1.4.0 notes read `Apply pdftotext cleanup … (#101) (#101)`. One line in `cliff.toml`.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** the entry template appended `commit.remote.pr_number` on top of a commit subject that already carries `(#N)` — GitHub puts it there on squash merge, which is how every PR lands here. Root cause is the template assuming the subject is bare.
- **Fixes:** a subtler consequence — `commit.remote.pr_number` only resolves when git-cliff can reach the GitHub API, so the *same commits* generated *different* changelogs depending on who cut the release and whether they had API access. The output is now a pure function of the commit history.

## Motivation & context (Required)

Found while previewing the v1.4.0 notes before cutting the release. `CHANGELOG.md` is committed, so releasing without this bakes the duplication in permanently.

Closes #n/a — found during release prep, no issue filed.

## How it works (Required for anything non-trivial)

Drops the `{% if commit.remote.pr_number %}…{% endif %}` suffix. The number still appears, because it is already in the subject the squash merge produced. Commits pushed straight to `master` have no number in their subject and get none — same as today, since `remote.pr_number` was empty for those anyway.

Rejected alternative: strip a trailing `(#N)` from the subject and keep the template suffix. Same output, more moving parts, and it would still be API-dependent.

## Evidence (Required)
- **Tests:** none added — this is a generator template with no test surface. Verified by generating the pending release notes before and after.
- **Before / after:** `git-cliff --tag v1.4.0 --unreleased` over the 27 commits since v1.3.0.

```
BEFORE
- Apply pdftotext cleanup to pypdf and pdfminer paths too (#101) (#101)
- Abort early on scanned PDFs with an OCR hint (#130) (#130)
- Detect Markdown-prefixed chapter headings (#91) (#92) (#92)

AFTER
- Apply pdftotext cleanup to pypdf and pdfminer paths too (#101)
- Abort early on scanned PDFs with an OCR hint (#130)
- Detect Markdown-prefixed chapter headings (#91) (#92)
```

The last line is correct as-is: `#91` is the issue and `#92` its PR, both already part of the commit subject. Doubled-number entries in the range: 3 before, 0 after.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, untouched
- [x] PR title follows Conventional Commits
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Separate heads-up for whoever cuts v1.4.0: `git-cliff -o CHANGELOG.md` rewrites the whole file, which will drop the hand-written "Do not edit this file by hand" note currently at the top of `CHANGELOG.md`. That note is worth re-adding to the `[changelog] header` in `cliff.toml` if you want it to survive — deliberately out of scope here.
