### PR TITLE
docs: state that scanned PDFs need OCR first

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ The extractor tries tools in order per format and uses the first available. If n
 
 > Before extraction begins, the skill asks you whether the book is **technical** or **text-heavy** and picks the right tool automatically. Docling preserves markdown tables and code blocks; pdftotext is faster for prose-only books.
 
+> **Scanned PDFs need OCR first.** A PDF that is page images with no text layer — a photographed or scanned book — has nothing for these tools to extract. The extractor checks the first pages and stops immediately with an explanation, rather than working through the whole book to produce an empty skill. Run OCR yourself, then convert the result:
+>
+> ```bash
+> ocrmypdf input.pdf output.pdf
+> ```
+
 **EPUB:**
 
 | Tool | Install | Quality |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,6 +63,22 @@ book-to-skill is built for a different job: you want to go deep on a specific to
 
 ---
 
+**"My PDF is a scan and extraction stops right away. Why?"**
+
+Because a scanned PDF is a stack of page images — there is no text in it to extract. Every tool in the PDF chain reads a text layer, so a scan yields nothing no matter which one runs.
+
+The extractor checks the first pages and stops there with that explanation. That check exists so the failure costs you a second instead of a full pass over a 400-page book that ends in an empty skill.
+
+Run OCR first, then convert the output:
+
+```bash
+ocrmypdf input.pdf output.pdf
+```
+
+book-to-skill does not run OCR itself, and that is deliberate: it would mean a heavy dependency and a slow, lossy step for every user, to serve a case that a dedicated tool already handles better. The same applies to figures — text baked into diagrams and charts is not extracted from any format.
+
+---
+
 
 ---
 


### PR DESCRIPTION
## Summary (Required)

`grep -riE "scanned|image-only|ocr"` across `README.md`, `SKILL.md` and `docs/` returned nothing. The one input that cannot work — a scanned, image-only PDF — was the one input with no documentation. This adds a note under the PDF extractor table and an FAQ entry, both pointing at `ocrmypdf`.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** a blockquote under the PDF extractor table in `README.md` saying scanned PDFs have no text layer, that extraction stops on the first pages, and the `ocrmypdf` command to fix it.
- **Adds:** an FAQ entry — *"My PDF is a scan and extraction stops right away. Why?"* — which also states that **not** shipping OCR is a deliberate choice, not an oversight, and notes the same limit applies to text inside figures.

## Motivation & context (Required)

A non-technical user converted a scanned PDF, waited through a long extraction, and got an unhelpful message at the end. #130 fixed the behavior — it now stops in ~0.01s with an actionable error. But an error message is a bad place to learn a product limit, and the docs never stated it anywhere.

The FAQ wording also pre-answers #127 (figure-borne content is not extracted), which is the same boundary seen from a different format.

Closes #n/a — user-reported in conversation.

## How it works (Required for anything non-trivial)

See diff. Two additions, no restructuring: the README note sits with the other extractor guidance where someone choosing a tool will meet it, and the FAQ entry serves the person who already hit the error and is searching for why.

## Evidence (Required)
- **Tests:** none — documentation only, no behavior change. `pytest -q` (349 passed) and `ruff check .` run to confirm nothing else moved, and `tools/validate_skill.py SKILL.md` still passes (`SKILL.md` untouched).
- **Before / after:**

```
BEFORE
$ grep -riE "scanned|image-only|ocr" README.md SKILL.md docs/*.md
(no output)

AFTER
README.md:  **Scanned PDFs need OCR first.** …  ocrmypdf input.pdf output.pdf
docs/faq.md:  "My PDF is a scan and extraction stops right away. Why?" …
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No behavior change — documentation only. The rendered addition is the blockquote below the PDF table and one new FAQ entry.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, untouched
- [x] PR title follows Conventional Commits
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Deliberately kept out: a general "Known limits" section. #127 argues for one, and it should be designed as a section rather than accreted one bullet per bug report.
