### PR TITLE
docs(contributing): use --prepend for the release changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,26 @@ from Conventional Commit messages — do not hand-edit it:
 
 ```bash
 # 1. bump version in pyproject.toml
-# 2. regenerate CHANGELOG.md from commits (needs git-cliff installed locally)
-git-cliff --tag vX.Y.Z -o CHANGELOG.md
+# 2. prepend the new section to CHANGELOG.md (needs git-cliff locally,
+#    or run it without installing: uvx git-cliff …)
+git-cliff --tag vX.Y.Z --unreleased --prepend CHANGELOG.md
 # 3. commit, tag, push
 git commit -am "chore(release): vX.Y.Z"
 git tag vX.Y.Z && git push origin master vX.Y.Z
 # 4. publish a GitHub Release using the new CHANGELOG section as notes
 ```
+
+**Use `--unreleased --prepend`, not `-o CHANGELOG.md`.** The `-o` form
+rewrites the whole file from commit subjects, which discards the hand-written
+release notes for v1.0–v1.3 — the ones carrying measurements (`precision
+0.999 / recall 1.000`, the `~1000×` CJK undercount, the Gutenberg benchmark)
+that no commit subject contains. `--prepend` adds only the new section and
+leaves everything below it untouched.
+
+One edge case: if you also change `[changelog] header` in `cliff.toml`, that
+release's prepend writes the new header above the old one still sitting in the
+file — delete the stale copy by hand that once. Subsequent releases are clean,
+because the file then already matches the configured header.
 
 git-cliff is a dev-only tool (a single static binary; not a runtime dependency
 of book-to-skill). See `cliff.toml` for the type→section mapping.


### PR DESCRIPTION
## Summary (Required)

The release recipe in `CONTRIBUTING.md` told maintainers to run `git-cliff --tag vX.Y.Z -o CHANGELOG.md`, which regenerates the whole changelog from commit subjects and destroys the hand-written release notes for v1.0–v1.3. Replaces it with the `--unreleased --prepend` form.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** the documented command rewrites `CHANGELOG.md` end to end. The v1.0–v1.3 sections are hand-written and carry measurements that exist nowhere else — the Korean heading corpus result (`precision 0.999 / recall 1.000`), the `~1000×` CJK undercount, the Gutenberg #132 benchmark. A commit subject cannot reconstruct any of it.
- **Adds:** a note about the one-time header duplication to expect when `[changelog] header` in `cliff.toml` changes during the same release, so the next maintainer doesn't think the tool is broken.

## Motivation & context (Required)

Found while cutting v1.4.0. Following the documented command produced a **−205 line** diff on `CHANGELOG.md`. The release was cut with `--prepend` instead (**+50 lines, zero removals**), so the shipped file is correct — but the instructions still pointed at the destructive form.

Closes #n/a — found during release prep.

## How it works (Required for anything non-trivial)

`--unreleased --prepend CHANGELOG.md` generates only the section for commits since the last tag and inserts it below the header, leaving everything already in the file untouched. Also mentions `uvx git-cliff`, since git-cliff is a dev-only binary and needn't be installed to cut a release.

## Evidence (Required)
- **Tests:** none — documentation only. `pytest -q` (349 passed) and `ruff check .` run to confirm nothing else moved.
- **Before / after:** both commands run against the real repository at v1.4.0.

```
DOCUMENTED COMMAND (-o)
 CHANGELOG.md | 322 +++++-------------------------------
 1 file changed, 127 insertions(+), 205 deletions(-)
   → v1.0–v1.3 hand-written notes replaced by commit-subject bullets

NEW COMMAND (--unreleased --prepend)
 CHANGELOG.md | 50 ++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 50 insertions(+)
   → history untouched
```

Header duplication was verified as one-time, not recurring: re-running `--prepend` against the shipped v1.4.0 file yields exactly one `# Changelog`.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, untouched
- [x] PR title follows Conventional Commits
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
