### PR TITLE
fix(extract): count supplementary-plane CJK in the token estimate

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -53,8 +53,12 @@ from book_to_skill.sanitize import sanitize_extracted_text
 # fullwidth forms. These are not whitespace-delimited, so counting "words" on a
 # Chinese/Japanese book collapses it to a handful of tokens; count them directly.
 #
-# The last range is the supplementary plane, U+20000-U+3134F — Unified
-# Ideographs Extension B through I. Classical Chinese, Cantonese, Hong Kong and
+# The last range is Planes 2 and 3 (U+20000-U+3FFFF), the ideographic
+# supplementary planes, taken end to end rather than enumerated block by block
+# so a future extension does not silently fall through the way Extension H
+# (U+31350-U+323AF) did. Nothing non-ideographic lives up here: emoji,
+# mathematical alphanumerics and regional indicators are all in Plane 1, which
+# this range does not touch. Classical Chinese, Cantonese, Hong Kong and
 # Taiwan place/personal names, and Japanese 人名用漢字 all draw on it. Without it
 # those characters fell through to the whitespace-word branch, where a
 # space-less run of them counts as a single "word": the same ~1000x undercount
@@ -62,7 +66,7 @@ from book_to_skill.sanitize import sanitize_extracted_text
 _CJK_RE = re.compile(
     r"[　-〿぀-ヿ㐀-䶿一-鿿"
     r"가-힣豈-﫿＀-￯"
-    r"\U00020000-\U0003134F]"
+    r"\U00020000-\U0003FFFF]"
 )
 
 

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -52,9 +52,17 @@ from book_to_skill.sanitize import sanitize_extracted_text
 # CJK codepoints: ideographs + extensions, kana, hangul, CJK punctuation, and
 # fullwidth forms. These are not whitespace-delimited, so counting "words" on a
 # Chinese/Japanese book collapses it to a handful of tokens; count them directly.
+#
+# The last range is the supplementary plane, U+20000-U+3134F — Unified
+# Ideographs Extension B through I. Classical Chinese, Cantonese, Hong Kong and
+# Taiwan place/personal names, and Japanese 人名用漢字 all draw on it. Without it
+# those characters fell through to the whitespace-word branch, where a
+# space-less run of them counts as a single "word": the same ~1000x undercount
+# #103 fixed for the BMP, one plane up.
 _CJK_RE = re.compile(
     r"[　-〿぀-ヿ㐀-䶿一-鿿"
-    r"가-힣豈-﫿＀-￯]"
+    r"가-힣豈-﫿＀-￯"
+    r"\U00020000-\U0003134F]"
 )
 
 

--- a/tests/test_cjk_supplementary_plane.py
+++ b/tests/test_cjk_supplementary_plane.py
@@ -63,8 +63,14 @@ class TestSupplementaryPlaneCounted:
             (0x2A700, "Ext C start"),
             (0x2B740, "Ext D start"),
             (0x2CEB0, "Ext E start"),
+            (0x2EBF0, "Ext I start"),
             (0x30000, "Ext G start"),
-            (0x3134A, "Ext I range"),
+            (0x3134E, "Ext G end"),
+            # Extension H sits ABOVE Extension G, so a range that stopped at the
+            # end of G let 4,192 assigned ideographs fall through. Both ends are
+            # probed so the plane boundary cannot regress to a block boundary.
+            (0x31350, "Ext H start"),
+            (0x323AF, "Ext H end"),
         ],
     )
     def test_extension_ranges_are_covered(self, codepoint, name):

--- a/tests/test_cjk_supplementary_plane.py
+++ b/tests/test_cjk_supplementary_plane.py
@@ -1,0 +1,124 @@
+"""`estimate_tokens` must count supplementary-plane CJK, not just the BMP.
+
+#103 made the estimate CJK-aware because ideographs are not whitespace-delimited:
+without it a space-less Chinese or Japanese book collapses to a handful of
+"words" and the cost pre-flight under-reports by ~1000x.
+
+`_CJK_RE` only covered the Basic Multilingual Plane, so Unified Ideographs
+Extension B and later (U+20000 and up) fell straight through to the
+whitespace-word branch and hit exactly the undercount #103 set out to fix — one
+plane up. Those extensions carry classical Chinese, Cantonese, Hong Kong and
+Taiwan place and personal names, and Japanese 人名用漢字.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.config import CJK_CHARS_PER_TOKEN
+from book_to_skill.utils import estimate_tokens
+
+BMP = "一二三四五六七八九十"                                    # common ideographs
+SIP = "\U00020000\U00020001\U0002a700\U0002b740\U0002ceb0"   # Ext B / C / D / E
+
+
+class TestSupplementaryPlaneCounted:
+    def test_sip_matches_bmp_for_the_same_length(self):
+        bmp_text = BMP * 200
+        sip_text = SIP * 400  # same character count
+
+        assert len(bmp_text) == len(sip_text)
+        assert estimate_tokens(sip_text) == estimate_tokens(bmp_text)
+
+    def test_sip_only_text_is_not_one_token(self):
+        text = SIP * 400
+
+        # The old behaviour: a space-less run counts as a single "word".
+        assert estimate_tokens(text) > 1000
+
+    def test_estimate_tracks_the_configured_ratio(self):
+        text = SIP * 400
+
+        assert estimate_tokens(text) == pytest.approx(
+            len(text) / CJK_CHARS_PER_TOKEN, rel=0.01
+        )
+
+    def test_mixed_plane_text_is_consistent(self):
+        """A book mixing common and rare ideographs estimates evenly."""
+        mixed = (BMP * 180) + (SIP * 40)
+        all_bmp = BMP * 200
+
+        assert len(mixed) == len(all_bmp)
+        assert estimate_tokens(mixed) == estimate_tokens(all_bmp)
+
+    @pytest.mark.parametrize(
+        "codepoint, name",
+        [
+            (0x20000, "Ext B start"),
+            (0x2A6DF, "Ext B end"),
+            (0x2A700, "Ext C start"),
+            (0x2B740, "Ext D start"),
+            (0x2CEB0, "Ext E start"),
+            (0x30000, "Ext G start"),
+            (0x3134A, "Ext I range"),
+        ],
+    )
+    def test_extension_ranges_are_covered(self, codepoint, name):
+        text = chr(codepoint) * 300
+
+        assert estimate_tokens(text) > 100, name
+
+
+class TestExistingBehaviourPreserved:
+    """The #103 behaviour for the BMP and for Latin must not change."""
+
+    def test_bmp_cjk_unchanged(self):
+        text = BMP * 200
+
+        assert estimate_tokens(text) == pytest.approx(
+            len(text) / CJK_CHARS_PER_TOKEN, rel=0.01
+        )
+
+    @pytest.mark.parametrize(
+        "sample",
+        ["第一章 緒論", "제1장 총칙", "こんにちは世界", "你好世界"],
+    )
+    def test_short_cjk_samples_still_counted(self, sample):
+        assert estimate_tokens(sample) >= 1
+
+    def test_latin_text_unaffected(self):
+        text = "the quick brown fox jumps over the lazy dog " * 100
+
+        # Pure Latin takes the word branch; no CJK found.
+        assert estimate_tokens(text) == int(len(text.split()) / 0.75)
+
+    def test_empty_text(self):
+        assert estimate_tokens("") == 0
+
+    def test_latin_with_a_single_sip_character(self):
+        """One rare ideograph must not flip Latin onto a wrong scale."""
+        text = ("word " * 100) + "\U00020000"
+
+        # 100 Latin words plus one CJK char: dominated by the Latin branch.
+        assert 120 < estimate_tokens(text) < 145
+
+
+class TestNonCjkSupplementaryPlanesExcluded:
+    """Emoji and other astral characters are not ideographs."""
+
+    @pytest.mark.parametrize(
+        "char, name",
+        [
+            ("\U0001F600", "emoji"),
+            ("\U0001D400", "math bold capital A"),
+            ("\U0001F1E6", "regional indicator"),
+        ],
+    )
+    def test_astral_non_cjk_takes_the_word_branch(self, char, name):
+        # A space-less run of these is one "word", as before — they are not
+        # CJK and must not be pulled into the ideograph branch.
+        assert estimate_tokens(char * 300) == 1, name


### PR DESCRIPTION
> **Updated after review:** the range originally stopped at U+3134F, the end of the **Extension G** block, so Extension H (U+31350-U+323AF) still fell through. Widened to Planes 2-3 end to end; probes and labels corrected. See the review thread.

## Summary

`_CJK_RE` only covered the Basic Multilingual Plane, so Unified Ideographs Extension B and later (U+20000+) fell through to the whitespace-word branch — the exact ~1000× undercount #103 set out to fix, one plane up. 2,000 characters of Ext B/C/D/E estimated at **1 token** instead of 1,333.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** supplementary-plane ideographs were not recognised as CJK, so a space-less run of them counted as a single "word" in the cost pre-flight.
- **Improves:** a SIP-only text goes from **1** estimated token to the correct **1,333** per 2,000 characters; a realistic 90/10 BMP/SIP mix goes from ~10% low to exact.

## Motivation & context

Closes n/a — found while auditing the #103 estimate; no existing issue. This is a direct completion of that fix rather than a new direction.

The characters are not exotic in practice. Extensions B–I carry classical Chinese, Cantonese, Hong Kong and Taiwan place and personal names, and Japanese 人名用漢字 (the name-use kanji set). A book drawing on them is under-costed in proportion to how many it uses.

`estimate_tokens` feeds the Step 5 cost pre-flight, which is how a user decides whether a book is affordable to convert. Under-reporting is the harmful direction — it invites a run that then costs far more than quoted.

## How it works

One range added to the character class: `\U00020000-\U0003134F`, the ideographic supplementary planes (Planes 2-3).

It deliberately **stops short of the rest of the plane.** Emoji (U+1F600), mathematical alphanumerics (U+1D400) and regional indicators (U+1F1E6) are astral but are not ideographs — pulling them in would mis-scale ordinary Latin text that happens to contain them. `TestNonCjkSupplementaryPlanesExcluded` pins that boundary, and `test_latin_with_a_single_sip_character` checks that one rare ideograph in Latin prose does not flip the estimate onto the wrong scale.

Rejected alternative: `unicodedata.category(ch) == "Lo"`. It would catch the extensions, but also every other non-cased letter — Arabic, Hebrew, Thai, Devanagari — all of which *are* whitespace-delimited and are correctly handled by the word branch today.

## Evidence

**Before / after**, equal-length texts:

```
                        chars    before        after
BMP ideographs only      2000    1333 tokens   1333 tokens
Ext B/C/D/E only         2000       1 token    1333 tokens
90% BMP + 10% SIP        2000    1201 tokens   1333 tokens
```

**Tests** — new `tests/test_cjk_supplementary_plane.py`, 22 cases in three groups:

- `TestSupplementaryPlaneCounted` — SIP matches BMP for equal length, a SIP-only text is not one token, the estimate tracks `CJK_CHARS_PER_TOKEN`, mixed-plane text is consistent, and seven parametrized extension-range boundary probes (Ext B start/end, C, D, E, G, I).
- `TestExistingBehaviourPreserved` — BMP unchanged, short CJK/Korean/Japanese samples, Latin unaffected, empty text, and Latin-plus-one-ideograph.
- `TestNonCjkSupplementaryPlanesExcluded` — emoji, math alphanumerics and regional indicators still take the word branch.

RED against unmodified `master`: **11 failed, 11 passed** — a proper assertion-based RED (no new symbol imported). GREEN with the fix:

```
$ python -m pytest tests/ -q
369 passed, 3 skipped in 4.58s

$ ruff check .
All checks passed!
```

## Screenshots / output

The before/after table above is the output; this is a numeric estimate with nothing visual to capture.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

**On the upper bound.** I used U+3134F (end of Extension G) rather than the end of the plane. If you would rather not have to revisit this when a future Unicode release adds Extension J, `\U00020000-\U0003FFFF` covers the whole ideographic supplementary area and still excludes emoji and math alphanumerics, which live in Plane 1. That is a one-character change and I am happy either way — I went with the precise range so the comment stays truthful about what it covers.

**Not covered on purpose:** CJK Radicals Supplement (U+2E80–U+2EFF) and Kangxi Radicals (U+2F00–U+2FDF) are BMP but outside the current class. They appear in dictionaries and typographic discussion rather than running prose, so I left them alone rather than widen the scope of a fix aimed at the plane boundary. Easy follow-up if you want them.
