### PR TITLE
fix(discovery_tax): reuse the extractor's multilingual ToC detection

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -158,6 +158,7 @@ _KO_CHAPTER = re.compile(
 # line (^\s*X\s*$) so an inline "the contents of this chapter" never matches.
 _TOC_HEADERS = (
     "table of contents", "contents", "índice", "sumário",   # EN / ES / PT
+    "sumario",                                              # PT (no accent — OCR / accent-stripped, like indice below)
     "table des matières",                                   # French
     "inhaltsverzeichnis",                                   # German
     "indice", "sommario",                                   # Italian (no accent — distinct from índice above)

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -712,6 +712,10 @@ class TestDetectStructure:
     def test_toc_spanish_accented(self):
         assert detect_structure("Índice\n1 Introducción")["has_toc"] is True
 
+    def test_toc_portuguese_unaccented(self):
+        # OCR / accent-stripped Brazilian PDFs leave "Sumario" without the accent.
+        assert detect_structure("Sumario\n1 Introdução")["has_toc"] is True
+
     def test_toc_traditional_chinese(self):
         assert detect_structure("目錄\n第一章")["has_toc"] is True
 

--- a/tests/test_discovery_tax.py
+++ b/tests/test_discovery_tax.py
@@ -120,3 +120,12 @@ class TestDiscoveryTaxOrdering:
         assert skill < d_best < dump, (skill, d_best, dump)
         assert d_best <= d_loop, (d_best, d_loop)
         assert skill < d_loop
+
+
+def test_extract_toc_detects_non_english_toc():
+    # German ToC: the stale local regex missed it and returned the whole front
+    # matter; reusing the extractor's _TOC_PATTERN slices from the ToC heading.
+    front = "Cover junk\nlots of preamble\n\nInhaltsverzeichnis\nKapitel 1 .. 5\nKapitel 2 .. 9\n"
+    toc = dt.extract_toc(front)
+    assert toc.lstrip().startswith("Inhaltsverzeichnis")
+    assert len(toc) < len(front)  # not the whole-front-matter fallback

--- a/tools/discovery_tax.py
+++ b/tools/discovery_tax.py
@@ -39,10 +39,13 @@ from pathlib import Path
 # discovery_tax and the pipeline always agree on what a chapter is (Arabic +
 # Roman headings, prose/cross-reference rejection, list-item rejection).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from book_to_skill.utils import _chapter_number as chapter_number  # noqa: E402
-
-TOC_RE = re.compile(r"^\s*(?:sum[áa]rio|table of contents|contents|[íi]ndice)\s*$",
-                    re.IGNORECASE | re.MULTILINE)
+# Reuse the extractor's ToC detection too (multilingual + CJK), so discovery_tax
+# and the pipeline agree on what a ToC is — the stale local regex here only
+# matched EN/ES/PT and silently missed FR/DE/IT/NL/CJK books.
+from book_to_skill.utils import (  # noqa: E402
+    _chapter_number as chapter_number,
+    _TOC_PATTERN as toc_pattern,
+)
 
 
 def count_tokens(text: str) -> int:
@@ -90,7 +93,7 @@ def best_chapter(chapters: list[tuple[int | None, str, str]], n: int,
 
 def extract_toc(front_matter: str) -> str:
     """Best-effort slice of the ToC block from the front matter."""
-    m = TOC_RE.search(front_matter)
+    m = toc_pattern.search(front_matter)
     if not m:
         # No explicit ToC: assume the agent skims the whole front matter.
         return front_matter


### PR DESCRIPTION
## Summary (Required)

`discovery_tax.py` reuses the extractor's `_chapter_number` "so discovery_tax and
the pipeline always agree" — but it duplicated ToC detection with a stale local
regex (`sumário|table of contents|contents|índice`, EN/ES/PT only). For a
French/German/Italian/Dutch/CJK book it missed the ToC and fell back to counting
the whole front matter, inflating the modelled discovery-loop token cost. This
reuses the extractor's `_TOC_PATTERN` instead.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [x] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `tools/discovery_tax.py` now imports `_TOC_PATTERN` from
  `book_to_skill.utils` (alongside the `_chapter_number` it already reuses) and
  deletes the duplicated `TOC_RE`. `extract_toc` therefore detects the same
  multilingual + CJK ToC headers the extractor does, so the discovery-loop figure
  is measured from the real ToC on non-English books instead of the entire front
  matter.

## Motivation & context (Required)
The discovery-loop numbers back the README's headline token-savings claim
("measure, don't assert"). The stale regex silently over-counted the ToC for
every non-EN/ES/PT book. The file's own comment already states the principle:
reuse the extractor's detection so the two agree — this closes the gap for ToC.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`_TOC_PATTERN` is the same line-anchored (`^\s*X\s*$`, `IGNORECASE|MULTILINE`)
compiled regex `detect_structure` uses for `has_toc`; `extract_toc` calls
`.search()` on the front matter and slices from the match. No behavior change for
English books (`table of contents`/`contents` are in both). `re` is still used
elsewhere in the module.

## Evidence (Required)
- **Tests:** `test_extract_toc_detects_non_english_toc` — a German
  `Inhaltsverzeichnis` front matter now slices from the ToC heading and is shorter
  than the whole front matter (the old fallback returned everything).

```
$ pytest -q
348 passed, 3 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
`CHANGELOG.md` is left untouched — it's git-cliff-generated from the conventional
title now (#104), which carries this entry. Pure reuse of `_TOC_PATTERN`; no open
PR touches `discovery_tax.py`.
