### PR TITLE
fix(security): harden extraction work directory against symlink and ownership attacks

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -679,6 +679,32 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
     }
 
 
+def prepare_output_dir(path: Path) -> None:
+    """Create the work directory, guarding against two shared-tmp risks:
+    a pre-planted symlink at a predictable path, and reusing a directory
+    another user already owns (either could expose or tamper with the
+    extracted document text, which may be sensitive).
+    """
+    if path.is_symlink():
+        raise ExtractionError(
+            f"Refusing to use {path}: it is a symbolic link, not a real "
+            "directory. Remove it or set BOOK_SKILL_WORKDIR to a private path."
+        )
+    if path.exists():
+        if not path.is_dir():
+            raise ExtractionError(f"Refusing to use {path}: it exists and is not a directory.")
+        if hasattr(os, "getuid"):
+            owner_uid = path.stat().st_uid
+            if owner_uid != os.getuid():
+                raise ExtractionError(
+                    f"Refusing to use {path}: it is owned by a different user "
+                    f"(uid {owner_uid}). Set BOOK_SKILL_WORKDIR to a private directory."
+                )
+            os.chmod(path, 0o700)
+    else:
+        path.mkdir(parents=True, mode=0o700)
+
+
 def print_banner() -> None:
     """Print the attribution banner. Done here (not only in SKILL.md) so it
     shows on every run regardless of how the agent invokes extraction."""
@@ -729,7 +755,7 @@ def main():
         print(f"ERROR: No supported files found matching: {', '.join(raw_input_paths)}", file=sys.stderr)
         sys.exit(1)
         
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    prepare_output_dir(OUTPUT_DIR)
     
     extracted_sources = []
     combined_texts = []

--- a/tests/test_output_dir_security.py
+++ b/tests/test_output_dir_security.py
@@ -1,0 +1,56 @@
+import os
+import stat
+
+import pytest
+
+from book_to_skill.exceptions import ExtractionError
+from book_to_skill.utils import prepare_output_dir
+
+
+def test_prepare_output_dir_creates_dir_with_restrictive_permissions(tmp_path):
+    target = tmp_path / "work"
+
+    prepare_output_dir(target)
+
+    assert target.is_dir()
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+def test_prepare_output_dir_rejects_symlink(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link = tmp_path / "work"
+    link.symlink_to(real_dir)
+
+    with pytest.raises(ExtractionError, match="symbolic link"):
+        prepare_output_dir(link)
+
+
+def test_prepare_output_dir_rejects_non_directory(tmp_path):
+    target = tmp_path / "work"
+    target.write_text("not a directory")
+
+    with pytest.raises(ExtractionError, match="not a directory"):
+        prepare_output_dir(target)
+
+
+def test_prepare_output_dir_tightens_permissions_on_existing_own_dir(tmp_path):
+    target = tmp_path / "work"
+    target.mkdir()
+    os.chmod(target, 0o777)  # simulate a pre-existing, overly-permissive dir
+
+    prepare_output_dir(target)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only ownership check")
+def test_prepare_output_dir_rejects_directory_owned_by_another_user(tmp_path, monkeypatch):
+    target = tmp_path / "work"
+    target.mkdir()
+
+    real_getuid = os.getuid
+    monkeypatch.setattr(os, "getuid", lambda: real_getuid() + 1)
+
+    with pytest.raises(ExtractionError, match="owned by a different user"):
+        prepare_output_dir(target)


### PR DESCRIPTION
## Summary (Required)
Replaces the bare `OUTPUT_DIR.mkdir(parents=True, exist_ok=True)` with `prepare_output_dir()`, which rejects a pre-planted symlink, a non-directory, or (on POSIX) a directory owned by another user at the predictable shared-`/tmp` extraction path, and tightens the directory to mode `0o700`.

## Type of change (Required)
- [x] 🔒 Security

## What it does (Required)
- **Fixes:** the extraction work directory was created with `mkdir(exist_ok=True)` against a predictable path under `/tmp`. Any local user could pre-plant a symlink, a non-directory, or a directory they own there ahead of the run, letting them read or tamper with extracted document text via a shared-tmp race/ownership attack.
- **Improves:** `prepare_output_dir()` now refuses all three cases with a clear `ExtractionError`, and creates/tightens the directory to mode `0o700` so it isn't group/world readable even if it does need reuse.

## Motivation & context (Required)
Closes n/a — found while reviewing the extraction pipeline's use of a fixed, predictable output path in shared temp space.

## How it works (Required for anything non-trivial)
`prepare_output_dir(path)`: if `path` exists, `os.path.islink()` and `os.path.isdir()` gate against symlinks and non-directories; on POSIX, `os.stat().st_uid` is compared to `os.getuid()` to reject a directory owned by another user. On the accepted path it calls `os.chmod(path, 0o700)` (creating the directory first via `mkdir(parents=True)` if it doesn't exist yet), so both a fresh directory and a pre-existing directory the caller owns end up at the same restrictive mode.

## Evidence (Required)
- **Tests:** `tests/test_output_dir_security.py` (new) — asserts a fresh directory is created at mode `0o700`; a symlink at the target path raises `ExtractionError` matching "symbolic link"; a non-directory raises matching "not a directory"; a pre-existing world-writable (`0o777`) directory the caller owns gets tightened back to `0o700`; and (POSIX-only) a directory owned by a different uid raises matching "owned by a different user".
- **Before / after:** before, `OUTPUT_DIR.mkdir(parents=True, exist_ok=True)` would silently follow a pre-planted symlink or reuse a directory with any permissions/ownership. After, `prepare_output_dir()` raises `ExtractionError` on the symlink/non-directory/wrong-owner cases and the directory it hands back is always mode `0o700`.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` not touched
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
This branch originally also patched `sanitize.py` to strip U+2060 (word joiner) from extracted text. That's dropped from this PR — `master`'s invisible-codepoint sweep (since this branch was first opened) already covers U+2060 and considerably more, so it was superseded upstream.

CodeQL flags `tests/test_output_dir_security.py:40` (`os.chmod(target, 0o777)`) as "overly permissive file permissions." That line intentionally simulates a pre-existing world-writable directory, inside pytest's isolated `tmp_path`, specifically to assert `prepare_output_dir()` tightens it back to `0o700` — i.e. it's exercising the fix, not introducing the vulnerability. Flagging for a maintainer to dismiss the alert or point me at this repo's preferred suppression convention, since I didn't see an existing one to follow.