### PR TITLE
fix(extract): report which method produced the chapter count

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -454,15 +454,26 @@ def detect_structure(text: str) -> dict:
     numeric_count = len(numbers)
     # Fall back to structural (Markdown/AsciiDoc) headings only when no numeric
     # "Chapter N" headings were found, so books with real chapters are unaffected.
-    chapters_detected = (
-        numeric_count if numeric_count > 0 else _structural_chapter_count(text)
-    )
+    #
+    # Which branch answered is reported alongside the count. The two disagree
+    # often, and a wrong count is not visible in the output it produces: it
+    # becomes the plan in Step 3 and the chapter files of the generated skill.
+    # Every parser in this project already announces which method it used
+    # ("Trying python-docx... OK"); this decision had the same shape and was
+    # the only silent one.
+    if numeric_count > 0:
+        chapters_detected = numeric_count
+        chapters_method = "numeric"
+    else:
+        chapters_detected = _structural_chapter_count(text)
+        chapters_method = "structural" if chapters_detected else "none"
 
     # Look for ToC indicators in the first ~30k chars (multilingual; see _TOC_PATTERN)
     has_toc = bool(_TOC_PATTERN.search(text[:30000]))
 
     return {
         "chapters_detected": chapters_detected,
+        "chapters_method": chapters_method,
         "chapter_headings_sample": headings[:10],
         "has_toc": has_toc,
     }
@@ -752,6 +763,10 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
 
     tokens = estimate_tokens(text)
     structure = detect_structure(text)
+    print(
+        f"  chapters: {structure['chapters_detected']} "
+        f"({structure['chapters_method']})"
+    )
     file_size_mb = os.path.getsize(input_str) / (1024 * 1024)
     
     return {
@@ -928,6 +943,7 @@ def main():
                 "words": src["words"],
                 "estimated_tokens": src["estimated_tokens"],
                 "chapters_detected": src["chapters_detected"],
+                "chapters_method": src["chapters_method"],
                 "has_toc": src["has_toc"]
             }
             for src in extracted_sources
@@ -951,7 +967,21 @@ def main():
     print(page_line)
     print(f"   Words   : {total_words:,}")
     print(f"   Tokens  : ~{total_tokens // 1000}K")
-    print(f"   Chapters: {consolidated_structure['chapters_detected']} detected overall")
+    print(
+        f"   Chapters: {consolidated_structure['chapters_detected']} detected overall "
+        f"({consolidated_structure['chapters_method']})"
+    )
+    if consolidated_structure["chapters_method"] == "structural" and (
+        consolidated_structure["chapters_detected"] <= 1 and total_words > 5000
+    ):
+        # Numeric "Chapter N" headings found nothing and the structural fallback
+        # came back with one section for a document of real length. That pairing
+        # is a detection failure far more often than it is a one-chapter book,
+        # and it is invisible in the output it produces.
+        print(
+            "   WARN    : only one section found in a document this long — chapter "
+            "detection likely failed; check the headings before generating."
+        )
     print(f"   ToC     : {'yes' if consolidated_structure['has_toc'] else 'not detected'}")
     if not consolidated_structure["has_toc"]:
         print(

--- a/tests/test_chapter_method_reported.py
+++ b/tests/test_chapter_method_reported.py
@@ -1,0 +1,58 @@
+"""The run must say which method produced `chapters_detected`.
+
+Chapter detection picks between counting numeric "Chapter N" headings and
+falling back to structural Markdown headings. The two disagree often, and a
+wrong count is invisible in the output it produces — it becomes Step 3's plan
+and the generated skill's chapter files.
+
+Every parser in this project already announces its method ("Trying
+python-docx... OK", "[warn] extract_with_pdftotext failed"). This decision has
+the same shape and was the only silent one.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import detect_structure
+
+CHAPTER_BODY = "prose carrying the section's actual content. " * 40
+
+
+class TestMethodIsReported:
+    def test_numeric_headings_report_numeric(self):
+        text = "\n\n".join(f"Chapter {n}: Title {n}\n{CHAPTER_BODY}" for n in (1, 2, 3))
+
+        result = detect_structure(text)
+
+        assert result["chapters_detected"] == 3
+        assert result["chapters_method"] == "numeric"
+
+    def test_markdown_headings_report_structural(self):
+        text = "# Book\n\n" + "\n\n".join(
+            f"## Section {n}\n{CHAPTER_BODY}" for n in (1, 2, 3)
+        )
+
+        result = detect_structure(text)
+
+        assert result["chapters_detected"] == 3
+        assert result["chapters_method"] == "structural"
+
+    def test_no_structure_reports_none(self):
+        result = detect_structure("just prose, no headings at all.\n" * 20)
+
+        assert result["chapters_detected"] == 0
+        assert result["chapters_method"] == "none"
+
+    def test_method_accompanies_every_count(self):
+        """Whatever the input, the pair is always present and consistent."""
+        for text in ("", "# Only\n\ntext\n", "Chapter 1: One\n" + CHAPTER_BODY):
+            result = detect_structure(text)
+
+            assert "chapters_method" in result
+            if result["chapters_detected"] == 0:
+                assert result["chapters_method"] == "none"
+            else:
+                assert result["chapters_method"] in {"numeric", "structural"}


### PR DESCRIPTION
## Summary (Required)

`detect_structure()` chooses between two ways of counting chapters and never said which one answered. The count now travels with its method — printed per source, printed in the summary, and recorded in `metadata.json`.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** the branch between numeric `Chapter N` counting and the structural Markdown fallback was invisible. When the count was wrong, nothing in the output suggested it.
- **Improves:** every run now states `chapters: 8 (structural)`, and a document over 5,000 words that comes back with a single section gets an explicit warning — the exact pairing that means detection failed rather than "this book has one chapter".
- **Adds:** `chapters_method` in `metadata.json`, so a batch of conversions can be audited after the fact instead of watched live.

## Motivation & context (Required)

Closes #148.

Every parser here already announces its method:

```
Trying python-docx... OK
Trying stdlib DOCX parser... OK
  [warn] extract_with_pdftotext failed: …
  [security] removed 3 invisible Unicode code point(s) from book.pdf
```

Chapter detection is the same shape of decision — method A, else method B — and was the one silent path. That silence is what made #143 expensive: a 26-page paper with 8 numbered sections reported 4, and the user only discovered it by reading the headings himself.

`chapters_detected` is not a cosmetic field. Step 3 plans from it and the generated skill's chapter files follow it, so a wrong count does not look wrong — it becomes the artifact.

## How it works (Required for anything non-trivial)

`detect_structure()` returns `chapters_method`: `numeric`, `structural`, or `none`. `extract_single_file()` prints it per source in the existing `  key: value` style, `main()` prints it in the summary, and it is stored alongside `chapters_detected` for each source and for the consolidated corpus (the latter comes free, since the summary dict is already spread into the metadata).

The extra warning fires only on `structural` + `<= 1 chapter` + `> 5,000 words`. A short document with one section is ordinary; a long one is a detection failure.

## Evidence (Required)

**Tests:** new `tests/test_chapter_method_reported.py`, 4 cases — numeric headings report `numeric`, Markdown headings report `structural`, no structure reports `none`, and the pair is always present and internally consistent whatever the input.

**Output, before / after:**

```
before:   Chapters: 4 detected overall
after:    Chapters: 4 detected overall (structural)

before:   (nothing)
after:    WARN    : only one section found in a document this long — chapter
                    detection likely failed; check the headings before generating.
```

```
$ pytest -q
435 passed, 1 skipped

$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, not touched
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

`metadata.json` gains a field rather than changing one, so anything reading the file today is unaffected.

The 5,000-word threshold for the warning is a judgement call, not a measurement — it is high enough that no short README trips it and low enough that any real book does. If it turns out noisy, it is one constant.
