### PR TITLE
fix(deps): diagnose a module installed in an isolated environment

### DIFF
--- a/book_to_skill/dependencies.py
+++ b/book_to_skill/dependencies.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
+
 from book_to_skill.config import PYTHON_DEPENDENCIES, HTML_EXTENSIONS
 
 
@@ -70,6 +72,32 @@ DEPENDENCY_GROUPS = [
 
 def python_module_available(module_name: str) -> bool:
     return importlib.util.find_spec(module_name) is not None
+
+
+def isolated_install_hint(module_name: str) -> str | None:
+    """Explain a module that is installed as a tool but not importable here.
+
+    pipx — the way Docling's own docs suggest installing it — puts the package
+    in its own virtualenv and only the executable on PATH. The module is then
+    genuinely not importable from this interpreter, so "✗ python: docling" is
+    correct and useless: the user installed it, and we say it is missing.
+
+    Returns a line naming the executable and the interpreter that can import
+    it, or None when there is no such executable. Never claims the module is
+    available — the parsers import it, so a binary on PATH does not make the
+    import work; it only tells us where a working environment is.
+    """
+    executable = shutil.which(module_name)
+    if not executable:
+        return None
+    # pipx layout: <venv>/bin/<tool> — its sibling `python` can import the module.
+    venv_python = Path(executable).resolve().parent / "python"
+    where = f"\n        {venv_python} scripts/extract.py …" if venv_python.exists() else ""
+    return (
+        f"a `{module_name}` command exists at {executable}, so it is installed in an "
+        f"isolated environment (pipx?).\n        Run the extractor with that "
+        f"environment's Python, or install it into this one:{where}"
+    )
 
 
 def missing_python_packages(module_names: list[str]) -> list[str]:
@@ -239,6 +267,9 @@ def run_dependency_check() -> int:
             print(f"      {'✓' if ok else '✗'} python: {pip_name}")
             if not ok:
                 missing_pip_packages.append(pip_name)
+                hint = isolated_install_hint(module_name)
+                if hint:
+                    print(f"        ↳ {hint}")
 
         for cmd, pretty, hint in group["system"]:
             ok = cmd in system_present

--- a/tests/test_isolated_install_hint.py
+++ b/tests/test_isolated_install_hint.py
@@ -1,0 +1,78 @@
+"""A module installed as a tool (pipx) is not importable, and saying only
+"missing" sends the user to reinstall something they already have.
+
+The hint must never claim the module is available: the parsers import Docling,
+so an executable on PATH does not make the import work. It only tells us where
+an environment that can import it lives.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill import dependencies
+
+
+class TestNoExecutable:
+    def test_returns_none_when_nothing_on_path(self, monkeypatch):
+        monkeypatch.setattr(dependencies.shutil, "which", lambda _: None)
+
+        assert dependencies.isolated_install_hint("docling") is None
+
+
+class TestExecutableFound:
+    def test_names_the_executable(self, monkeypatch):
+        monkeypatch.setattr(
+            dependencies.shutil, "which", lambda _: "/home/u/.local/bin/docling"
+        )
+
+        hint = dependencies.isolated_install_hint("docling")
+
+        assert hint is not None
+        assert "/home/u/.local/bin/docling" in hint
+        assert "isolated environment" in hint
+
+    def test_points_at_the_venv_python_when_it_exists(self, monkeypatch, tmp_path):
+        venv_bin = tmp_path / "venvs" / "docling" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").write_text("")
+        (venv_bin / "docling").write_text("")
+        monkeypatch.setattr(
+            dependencies.shutil, "which", lambda _: str(venv_bin / "docling")
+        )
+
+        hint = dependencies.isolated_install_hint("docling")
+
+        assert str(venv_bin / "python") in hint
+        assert "scripts/extract.py" in hint
+
+    def test_omits_the_interpreter_line_when_there_is_no_sibling_python(
+        self, monkeypatch, tmp_path
+    ):
+        lone = tmp_path / "docling"
+        lone.write_text("")
+        monkeypatch.setattr(dependencies.shutil, "which", lambda _: str(lone))
+
+        hint = dependencies.isolated_install_hint("docling")
+
+        assert hint is not None
+        assert "scripts/extract.py" not in hint
+
+    def test_still_treats_the_module_as_missing(self, monkeypatch, capsys):
+        """The parsers import it; a binary on PATH does not make that work.
+
+        The report must keep the ✗ and keep offering to install — the hint adds
+        a diagnosis, it does not reclassify the dependency as satisfied.
+        """
+        monkeypatch.setattr(dependencies.shutil, "which", lambda cmd: (
+            "/home/u/.local/bin/docling" if cmd == "docling" else None
+        ))
+        monkeypatch.setattr(dependencies, "python_module_available", lambda _: False)
+
+        dependencies.run_dependency_check()
+
+        out = capsys.readouterr().out
+        assert "✗ python: docling" in out
+        assert "isolated environment" in out


### PR DESCRIPTION
## Summary (Required)

When an optional module is not importable but a same-named executable is on `PATH`, `--check` now says so and points at the interpreter that can import it, instead of reporting a bare absence. The dependency is still counted as missing.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `--check` reported `✗ python: docling` on machines where Docling is installed with pipx — which is how its own documentation suggests installing it. The statement is true (the module is not importable from this interpreter) and useless (the user installed it, and we told them it is missing).
- **Improves:** the report now names the executable and the Python that can import it, so the fix is one copy-paste instead of a session of reinstalling.

## Motivation & context (Required)

Closes #145.

From a real session: `--check` said Docling was missing, `--install-missing yes` then failed with `/usr/bin/python3: No module named pip`, and the working answer — running the extractor with the pipx venv's own interpreter — was only found after several attempts.

## How it works (Required for anything non-trivial)

`isolated_install_hint(module)` returns a line when `shutil.which(module)` finds an executable, and `None` otherwise. `run_dependency_check()` prints it under the `✗`.

**It does not reclassify the dependency.** `parsers/pdf.py` imports Docling as a library and never invokes a CLI, so a binary on `PATH` does not make the import work — treating `which()` as proof of installation would flip a true "missing" into a false "present" and move the failure from a cheap preflight message to a crash mid-extraction. The `✗` stays, the missing-package list is unchanged, and only a diagnosis is added.

The venv interpreter is best-effort: pipx's `<venv>/bin/<tool>` layout puts a usable `python` next to the executable, so that path is offered when it exists and the line is omitted when it does not.

## Evidence (Required)

**Real output on a machine with Docling installed via pipx:**

```
  PDF (technical: tables, code, formulas)
      ✗ python: docling
        ↳ a `docling` command exists at /home/u/.local/bin/docling, so it is installed
          in an isolated environment (pipx?).
          Run the extractor with that environment's Python, or install it into this one:
          /home/u/.local/share/pipx/venvs/docling/bin/python scripts/extract.py …
      → fallback available (install for best quality)
```

Modules with no executable (`ebooklib`, `beautifulsoup4`) print exactly what they printed before.

**Tests:** new `tests/test_isolated_install_hint.py`, 5 cases — no executable returns `None`; the executable is named; the sibling interpreter is offered when present and omitted when absent; and the report still prints `✗` and still treats the module as missing when the hint fires.

```
$ pytest -q
436 passed, 1 skipped

$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, not touched
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

The hint is generic rather than Docling-specific, but Docling is the only optional dependency here that ships a CLI entry point, so in practice it is the only one that can trigger it today.

Not included, and worth a FAQ entry rather than code: Docling 2.119.0 defaults to `compile_torch_models = True`, which needs the Python development headers and otherwise dies on `fatal error: Python.h: No such file or directory`. `DOCLING_INFERENCE_COMPILE_TORCH_MODELS=false` avoids it with no loss of the layout model.
