### PR TITLE
docs: name Codex as a supported host

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -67,7 +67,7 @@ Four paths available. Route based on what the user asks:
 This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
 
 1. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
-2. Cross-agent personal skills (Copilot + Amp): `~/.agents/skills/`
+2. Cross-agent personal skills (Copilot, Amp, Codex): `~/.agents/skills/`
 3. Claude Code personal skills: `~/.claude/skills/`
 4. Project-local Copilot skills: `.github/skills/`
 5. Project-local Claude skills: `.claude/skills/`
@@ -307,12 +307,13 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 | **GitHub Copilot CLI** | `~/.copilot/skills` → `~/.agents/skills` | `.github/skills` → `.claude/skills` → `.agents/skills` |
 | **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
+| **OpenAI Codex** | `~/.agents/skills` (discovered natively; follows symlinks) | `.agents/skills` |
 
 Selection rules:
 1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
 2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
 3. If the user explicitly asked for project-local output, prefer the project-local row.
-4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, or Claude Code?"
+4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, Codex, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,12 @@
 ---
-description: "Install book-to-skill as an agent skill for Claude Code, GitHub Copilot CLI and Amp, or as a standalone pip CLI. Every host path and optional extractor covered."
+description: "Install book-to-skill as an agent skill for Claude Code, GitHub Copilot CLI, Amp and Codex, or as a standalone pip CLI. Every host path and optional extractor covered."
 seo_title: "Install book-to-skill - Claude Code, Copilot CLI, Amp, or pip"
 ---
 
 ## 📥 Install
 
 > **Two ways to use it, do not confuse them:**
-> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, or Amp) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
+> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, Amp, or Codex) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
 > - **As a standalone CLI** (just the text extractor) → `pip install book-to-skill`, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
@@ -28,10 +28,16 @@ git clone https://github.com/virgiliojr94/book-to-skill.git ~/.copilot/skills/bo
 /skills info book-to-skill
 ```
 
-Or the cross-agent path that Copilot CLI and Amp both discover:
+Or the cross-agent path that Copilot CLI, Amp and Codex all discover:
 
 ```bash
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/book-to-skill
+```
+
+**OpenAI Codex** reads `~/.agents/skills` and follows symlinks, so the clone above is all it needs. A local checkout works too, linked in rather than copied:
+
+```bash
+ln -s /path/to/book-to-skill ~/.agents/skills/book-to-skill
 ```
 
 **Claude Code**:


### PR DESCRIPTION
## Summary (Required)

Codex already works end to end — it reads `~/.agents/skills` and follows symlinks — but no document said so. This adds it to the four places every other host is named.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** Codex to the Skill Locations list, the Step 5 destination table, the 'which agent are you running in' question, and `docs/install.md` (including the symlink form used in the reported session).

## Motivation & context (Required)
Closes n/a — no issue; comes from a real session report.

A user installed book-to-skill in Codex, converted a 26-page PDF with Docling, generated and installed the skill, and Codex listed it in the same session. Zero code changes were needed. The Step 5 table names every other host explicitly, so leaving Codex out read as 'unsupported' rather than 'unmentioned'.

Worth noting alongside: PR #79 proposed Codex support as a code change bundled with a validator lens, CI and docs, and was closed for being unreviewable as a unit. This is the part that was actually missing.

## How it works (Required for anything non-trivial)
Documentation only. Codex discovers the cross-agent root the project already writes to.

## Evidence (Required)
- **Tests:** none added — no behavior changed. Suite green: 476 passed, 1 skipped.
- `python3 tools/validate_skill.py SKILL.md` passes (pre-existing body-length soft warning).
- Session report: install via symlink into `~/.agents/skills`, extraction with Docling, generation, scan, install, and the skill appearing in Codex's catalogue without restarting.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes — n/a, docs only
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification — +3 lines, one of them a table row