### PR TITLE
test(security): skip POSIX permission assertions on Windows

### DIFF
--- a/tests/test_output_dir_security.py
+++ b/tests/test_output_dir_security.py
@@ -6,7 +6,17 @@ import pytest
 from book_to_skill.exceptions import ExtractionError
 from book_to_skill.utils import prepare_output_dir
 
+# Permission bits are a POSIX concept. On Windows os.chmod only toggles the
+# read-only flag and st_mode always reports 0o666/0o777, so asserting 0o700
+# fails there even though prepare_output_dir() behaves correctly — it guards
+# the symlink and non-directory cases on every platform and only tightens the
+# mode where the mode means something.
+posix_permissions = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX-only permission bits"
+)
 
+
+@posix_permissions
 def test_prepare_output_dir_creates_dir_with_restrictive_permissions(tmp_path):
     target = tmp_path / "work"
 
@@ -34,6 +44,7 @@ def test_prepare_output_dir_rejects_non_directory(tmp_path):
         prepare_output_dir(target)
 
 
+@posix_permissions
 def test_prepare_output_dir_tightens_permissions_on_existing_own_dir(tmp_path):
     target = tmp_path / "work"
     target.mkdir()
@@ -44,7 +55,7 @@ def test_prepare_output_dir_tightens_permissions_on_existing_own_dir(tmp_path):
     assert stat.S_IMODE(target.stat().st_mode) == 0o700
 
 
-@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only ownership check")
+@posix_permissions
 def test_prepare_output_dir_rejects_directory_owned_by_another_user(tmp_path, monkeypatch):
     target = tmp_path / "work"
     target.mkdir()


### PR DESCRIPTION
## Summary (Required)

The work-directory tests from #141 assert POSIX permission bits, which fail on Windows even though the code under test is correct there. They now skip, like the ownership test already did.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `stat.S_IMODE(target.stat().st_mode) == 0o700` fails on Windows/NTFS, where `os.chmod` only toggles the read-only flag and `st_mode` always reports 0o666/0o777. Three tests failed for every Windows contributor since #141 merged.

## Motivation & context (Required)
Closes n/a.

Reported by @albatrossflyon-coder while working on #142: three failures in `tests/test_output_dir_security.py`, a file that branch never touches. Our CI is `ubuntu-latest` only, so it could not have caught this.

The code itself is fine on Windows — `prepare_output_dir()` refuses a symlink and a non-directory everywhere, and only tightens the mode inside the POSIX branch. It is the assertions that are platform-specific, not the behaviour.

## How it works (Required for anything non-trivial)
One named marker, `posix_permissions`, applied to the three tests that assert mode bits. The ownership test already had the identical condition inline and now shares the marker.

## Evidence (Required)
- **Tests:** with `os.getuid` removed to emulate Windows, the three permission tests skip instead of failing.
- Full suite on Linux unchanged: 476 passed, 1 skipped.
- `ruff check .` clean.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

The real gap this exposes is that the test matrix is five Python versions on one OS. A `windows-latest` job would have caught it, and would also cover the `pdftotext` encoding work in #117 and the symlink question in #125 — both Windows-specific and both currently unverifiable by CI. Worth its own issue rather than riding along here.