### PR TITLE
feat: progressive disclosure — lightweight SKILL.md + HOW_TO_USE.md (opt-in NAV=progressive)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -289,6 +289,15 @@ Use the answer to weight what gets highlighted in the SKILL.md Core section.
 
 `DEPTH` and `BOOK_TYPE` together set the per-chapter token budget in Step 7. Do **not** ask a separate "study vs reference" question — it is inferred here. (In Modes 2/3, where Step 4 is skipped, default `DEPTH=study`.)
 
+**Ask about navigation tier (one extra prompt):**
+
+> "How should the skill's navigation be organized?
+>
+> 1. **Flat** (default) — How to Use, Topic Index, Supporting Files, and Scope & Limits all live in SKILL.md. Best for short / simple books.
+> 2. **Progressive** — SKILL.md stays lean (~1,800 tokens: core frameworks + chapter index + quick-reference table); the full topic index, source mapping, usage guide, and scope move to a separate `HOW_TO_USE.md`, loaded on demand when the user says "expand framework". Best for large, frequently-triggered books."
+
+Set `NAV=flat` or `NAV=progressive` based on the answer. Default to `flat` if the user is unsure. (In Modes 2/3, where Step 4 is skipped, default `NAV=flat`.)
+
 ---
 
 ## Step 5 — Determine skill name
@@ -447,14 +456,67 @@ Avoid: bare term→definition rows (that's the glossary), and prose paragraphs (
 - Format mostly as compact tables and decision rules; the content you'd want on a single printed page kept beside you while working.
 - Max 1,200 tokens.
 
+### HOW_TO_USE.md *(only if `NAV=progressive`)*
+
+Create `$SKILLS_HOME/<skill_name>/HOW_TO_USE.md`:
+
+This is the **deep-navigation layer** — loaded only when the user says "expand framework" or needs full orientation. It holds everything that would bloat SKILL.md but is essential for thorough use.
+
+Structure:
+```markdown
+# <Full Title> — Extended Framework
+
+> Load this file on demand: say "expand framework" to open it.
+
+## How to Use This Skill
+
+- **No arguments** — load SKILL.md core frameworks
+- **By chapter** — ask for `ch03`; I load that specific chapter
+- **By topic / method** — ask about `<framework>`; I find the relevant chapter
+- **By source mapping** (if applicable) — ask "which chapter maps to <textbook section>?"
+- **By depth tier** (if applicable) — add `beginner` / `intermediate` / `advanced` (or your own tiers) for the matching level
+
+## Source / Textbook Mapping (if applicable)
+
+| Skill chapter | Source / standard textbook |
+|---|---|
+| ... | ... |
+
+## Tiered Depth System (if applicable)
+
+| Mark | Tier | Use when |
+|---|---|---|
+| 🟢 `[B]` | Beginner | ... |
+| 🟡 `[I]` | Intermediate | ... |
+| 🔴 `[A]` | Advanced | ... |
+
+## Full Topic Index
+
+<!-- Complete term/framework → chapter mapping, extracted from all Step 7 chapters -->
+- **<Term/Framework>** → ch<N>[, ch<N>]
+- ...
+
+## Scope & Limits
+
+This skill covers <what it covers>. It does not cover <what it doesn't>. Pair with: <brief note>.
+```
+
+**Skeleton rules:**
+- Sections marked "(if applicable)" are **conditional** — skip them if the book has no source mapping or no tiered depth system.
+- The Topic Index must be comprehensive (extracted from all chapters generated in Step 7).
+- Keep the total under 2,000 tokens.
+- The "expand framework" trigger phrase must appear in the first blockquote so the agent knows how to load it.
+
 ---
 
 ## Step 9 — Generate the master SKILL.md
 
-**CRITICAL TOKEN BUDGET: Keep SKILL.md body under 4,000 tokens.**
+**CRITICAL TOKEN BUDGET:** `NAV=flat` → keep SKILL.md body under 4,000 tokens; `NAV=progressive` → keep it under 1,800 tokens (deep navigation moves to HOW_TO_USE.md).
 Compaction truncates from the END — put the most important content FIRST.
 
 Create `$SKILLS_HOME/<skill_name>/SKILL.md`:
+
+### If `NAV=flat` (default)
 
 ```markdown
 ---
@@ -517,6 +579,50 @@ combine with project-specific tools. For topics beyond this book, check related 
 or ask the agent directly.
 ```
 
+### If `NAV=progressive`
+
+```markdown
+---
+name: <skill_name>
+description: "Knowledge base from \"<Full Title>\" by <Author(s)>. Use when applying <author>'s frameworks for <key topics, 3–6 terms>, studying the book, or referencing its concepts."
+---
+
+<!-- argument-hint: [topic, framework name, or chapter number] -->
+
+# <Full Title>
+**Author**: <Author(s)> | **Pages**: ~<N> | **Chapters**: <N> | **Generated**: <YYYY-MM-DD>
+
+## Core Frameworks & Mental Models
+<!-- ~1,500 tokens: the author's most important named frameworks and principles.
+     Preserve exact names. Write as "Use X when Y", "Prefer X over Y because Z".
+     This is a toolkit, not a summary. -->
+
+<generate ~1,500 tokens of the most critical frameworks and insights here>
+
+---
+
+## Chapter Index
+
+| # | Title | Key Frameworks |
+|---|-------|----------------|
+| [ch01](chapters/ch01-<slug>.md) | <Title> | <framework1>, <framework2> |
+| [ch02](chapters/ch02-<slug>.md) | <Title> | <framework1>, <framework2> |
+...
+
+---
+
+## Quick Reference
+
+| File | Purpose |
+|------|---------|
+| [cheatsheet.md](cheatsheet.md) | Decision rules, trade-off tables, thresholds |
+| [glossary.md](glossary.md) | Key terms with definitions |
+| [patterns.md](patterns.md) | Techniques, patterns, anti-patterns |
+| [HOW_TO_USE.md](HOW_TO_USE.md) | 📖 Full topic index, source mapping, usage guide — say "expand framework" to load |
+```
+
+**Discovery hint (required):** keep the `HOW_TO_USE.md` row above — it is the pointer that lets an agent find the deep-navigation layer even when it never receives a follow-up question. The "expand framework" phrase must also appear in the first blockquote of HOW_TO_USE.md (Step 8).
+
 ---
 
 ## Step 9.5 — Scan the generated skill
@@ -566,6 +672,7 @@ Files generated:
   glossary.md      — key terms                 (~X tokens)
   patterns.md      — techniques & patterns     (~X tokens)
   cheatsheet.md    — quick reference           (~X tokens)
+  HOW_TO_USE.md    — full navigation (on-demand; NAV=progressive only) (~X tokens)
   ─────────────────────────────────────────────────────
   Total skill size: ~X tokens (loaded on-demand, not all at once)
 
@@ -676,6 +783,12 @@ For each new or revised chapter:
   - Read existing `$SKILLS_HOME/<skill_name>/cheatsheet.md`.
   - Extract new comparison rules, decision tables, or parameter guides.
   - Integrate them cleanly into the cheatsheet structure.
+- **Merge HOW_TO_USE.md** *(only if the skill has one — `NAV=progressive`)*:
+  - Read existing `$SKILLS_HOME/<skill_name>/HOW_TO_USE.md`.
+  - Update the topic index with new terms from the new chapters/sections.
+  - If new source mappings or depth tiers are introduced, add them.
+  - Update scope & limits if the new content expands coverage.
+  - Keep the total under 2,500 tokens (fold-in may grow the index past the initial 2,000-token budget).
 
 ### 5. Re-generate the Master SKILL.md
 Update the master skill file `$SKILLS_HOME/<skill_name>/SKILL.md`:
@@ -698,4 +811,5 @@ Once the files are successfully written and merged, run **Step 9.5**, then proce
 5. **Front-load SKILL.md** — compaction keeps the first 5,000 tokens; most important content comes first
 6. **Chapter files are on-demand** — they don't count against skill budget until loaded
 7. **Never copy raw book text** — always synthesize, summarize, extract signal
-8. **Topic index is critical** — it's how the agent navigates to the right chapter file
+8. **Topic index is critical** — it's how the agent navigates to the right chapter file (in `NAV=progressive`, it lives in HOW_TO_USE.md)
+9. **Progressive disclosure (`NAV=progressive`)** — SKILL.md is the lightweight entry (~1,800 tokens); deep navigation (topic index, source mapping, scope, usage guide) lives in HOW_TO_USE.md and loads only when the user says "expand framework" or needs full orientation. Never bloat SKILL.md with content the agent can load on demand.

--- a/tests/test_skill_progressive_disclosure.py
+++ b/tests/test_skill_progressive_disclosure.py
@@ -1,0 +1,105 @@
+"""Regression tests for the progressive-disclosure (NAV) split in SKILL.md.
+
+Steps 4, 8, and 9 define an opt-in `NAV=progressive` mode where a generated
+book skill keeps its SKILL.md lean (~1,800 tokens) and defers deep navigation
+(topic index, source mapping, usage guide, scope) to a lazily-loaded
+HOW_TO_USE.md. The default (`NAV=flat`) keeps everything in a single ~4,000
+token SKILL.md.
+
+These sections are LLM instructions, not executable code - nothing in this
+project runs them. The tests pin the *prose* so a future edit that silently
+removes the split, the "expand framework" trigger, or the distinct token
+budgets fails loudly instead of drifting in review.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_MD = REPO_ROOT / "SKILL.md"
+
+
+def _section(marker: str) -> str:
+    """The SKILL.md section beginning at `marker`, up to the next `## Step ` heading."""
+    if not SKILL_MD.is_file():
+        pytest.skip("SKILL.md not present (e.g. installed sdist)")
+    text = SKILL_MD.read_text(encoding="utf-8")
+    start = text.find(marker)
+    assert start != -1, f"SKILL.md no longer has a section beginning with {marker!r}"
+    # Cut at the next top-level "## Step " heading, not any "## " - Steps 8/9
+    # embed fenced markdown templates whose own "## " headings (e.g. "## How to
+    # Use This Skill") would otherwise truncate the section early.
+    end = text.find("\n## Step ", start + len(marker))
+    return text[start:] if end == -1 else text[start:end]
+
+
+def test_step_4_asks_navigation_tier_and_defaults_to_flat():
+    """Step 4 must offer the navigation choice and default to flat.
+
+    `NAV=flat` is the safe default - progressive is opt-in, so a model that
+    skips the question still produces the plain single-file skill.
+    """
+    section = _section("## Step 4")
+    assert "Ask about navigation tier" in section, (
+        "Step 4 no longer asks the navigation-tier question"
+    )
+    assert "NAV=flat" in section, "Step 4 no longer names the flat default"
+    assert "NAV=progressive" in section, "Step 4 no longer offers progressive mode"
+    folded = section.casefold()
+    assert "default to `flat`" in folded, (
+        "Step 4 no longer states that flat is the default"
+    )
+    assert "default `nav=flat`" in folded, (
+        "Step 4 no longer defaults NAV=flat when the step is skipped (Modes 2/3)"
+    )
+
+
+def test_step_8_generates_how_to_use_only_for_progressive():
+    """Step 8 must emit HOW_TO_USE.md only under NAV=progressive, with its trigger."""
+    section = _section("## Step 8")
+    assert "HOW_TO_USE.md" in section, "Step 8 no longer generates HOW_TO_USE.md"
+    assert "NAV=progressive" in section, (
+        "Step 8 no longer gates HOW_TO_USE.md on NAV=progressive"
+    )
+    folded = section.casefold()
+    assert "expand framework" in folded, (
+        "Step 8 no longer names the 'expand framework' on-demand trigger"
+    )
+    assert "(if applicable)" in folded, (
+        "Step 8 no longer marks source-mapping / depth-tier sections as conditional"
+    )
+    assert "under 2,000 tokens" in folded, (
+        "Step 8 no longer caps the HOW_TO_USE.md deep-navigation layer"
+    )
+
+
+def test_step_9_branches_on_nav_with_distinct_token_budgets():
+    """Step 9 must branch: flat stays under 4,000, progressive under 1,800 tokens."""
+    section = _section("## Step 9")
+    assert "NAV=flat" in section and "under 4,000 tokens" in section, (
+        "Step 9 no longer keeps NAV=flat under the 4,000-token budget"
+    )
+    assert "NAV=progressive" in section and "under 1,800 tokens" in section, (
+        "Step 9 no longer keeps NAV=progressive under the 1,800-token budget"
+    )
+    assert "If `NAV=flat`" in section, "Step 9 no longer has a NAV=flat template branch"
+    assert "If `NAV=progressive`" in section, (
+        "Step 9 no longer has a NAV=progressive template branch"
+    )
+
+
+def test_quality_rules_name_progressive_disclosure():
+    """The quality rules must keep a progressive-disclosure rule (rule 9)."""
+    section = _section("## Quality Rules")
+    folded = section.casefold()
+    assert "progressive disclosure" in folded, (
+        "Quality Rules no longer name progressive disclosure"
+    )
+    assert "nav=progressive" in folded, (
+        "Quality Rule 9 no longer ties progressive disclosure to NAV=progressive"
+    )
+    assert "expand framework" in folded, (
+        "Quality Rule 9 no longer names the 'expand framework' trigger"
+    )


### PR DESCRIPTION
## Summary (Required)

Adds an opt-in two-tier navigation for generated book skills: a lightweight `SKILL.md` loaded on every trigger, with deep navigation in a separate `HOW_TO_USE.md` loaded on demand. The default stays the current single-layer layout; the new mode is opt-in via `NAV=progressive`.

## Type of change (Required)

- [x] ✨ Feature (non-breaking change that adds capability)

## What it does (Required)

- **Adds:** an opt-in `NAV=progressive` mode for generated book skills. When enabled, Step 8 also generates `HOW_TO_USE.md` (full topic index, source mapping, usage guide, scope), and Step 9 produces a slimmed `SKILL.md` (~1,800 tokens: core frameworks + chapter index + quick-reference table) with a discovery hint pointing to `HOW_TO_USE.md`. `NAV=flat` (default) is unchanged.
- **Improves:** `SKILL.md` size for large, frequently-triggered skills drops by 40–75% depending on the book's topic density (see Evidence), with zero navigation loss — the topic index and scope move to `HOW_TO_USE.md`, not away.
- **Fixes:** #67 (the two-tier progressive-disclosure proposal).

## Motivation & context (Required)

Closes #67 (two-tier proposal; World Knowledge First split to #156).

Progressive disclosure is the pattern the ecosystem already uses for large skills. A skill that bundles its whole topic index into `SKILL.md` pays that cost on every trigger; moving deep navigation to an on-demand file keeps the always-loaded entry light while preserving full orientation when the user asks for it.

## How it works (Required)

- `NAV` is a separate internal variable (set by a one-prompt question in Step 4), not a third `DEPTH` value — `DEPTH` is now used for `study`/`reference` chapter depth, and navigation tier is an orthogonal dimension.
- Step 9 branches on `NAV`: `flat` keeps the existing 4,000-token template verbatim; `progressive` uses a 1,800-token template whose "How to Use / Topic Index / Supporting Files / Scope & Limits" move to `HOW_TO_USE.md` (generated in Step 8).
- The Update/Fold-in workflow merges `HOW_TO_USE.md` alongside glossary/patterns/cheatsheet rather than regenerating it.
- Rebased on the latest `master` (this branch is a fresh transplant onto `903d102`, not a rebase of the stale 6-week-old fork branch).

## Evidence (Required)

- **Tests:** the change is confined to `SKILL.md` (a prompt/spec); it has no Python code, so no unit tests apply. The `SKILL.md` validation in CI (`validate SKILL.md (Claude Code rules)`) passes.
- **Before / after** — `SKILL.md` token size (measured with book-to-skill's own `estimate_tokens`, CJK-aware):

| Book | Type | `NAV=flat` | `NAV=progressive` | Saving |
|------|------|:--:|:--:|:--:|
| Math Analysis Vol.1 (11 ch) | math | ~4,000 | ~1,000 | -75% |
| Math Analysis Vol.2 (12 ch) | math | ~4,000 | ~1,000 | -75% |
| 王道数据结构 (8 ch) | CS (考研 408 讲义, term-dense) | 1,612 | 732 | -55% |
| 量价分析 (12 ch) | non-technical | 1,544 | 926 | -40% |

These are synthetic SKILL.md samples — the chapter structure and topic terms are real (extracted from the actual content: 王道 via PaddleOCR of the scanned PDF, 量价分析 via the EPUB text), but the Core Frameworks prose is hand-authored and the token counts are not from a full end-to-end book-to-skill run. Included to show the structural saving scales outside math. The math rows are from #67.

王道数据结构 is a Chinese postgraduate (考研 408) textbook — term-dense and index-heavy. If you'd prefer a classic CS textbook in the SICP style instead, I can swap it in and re-measure.

## Screenshots / output (Required if behavior or output changes)

`NAV=progressive` moves the Topic Index / How to Use / Scope / Supporting Files out of `SKILL.md` and into a Quick Reference table + `HOW_TO_USE.md`:

```
# 量价分析
## Core Frameworks & Mental Models        (~600 tokens)
## Chapter Index                           (12 rows)
## Quick Reference                         (4 rows, incl. HOW_TO_USE.md pointer)
```

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes — no Python code changed; `SKILL.md` is covered by `tools/validate_skill.py` (CI green)
- [x] `pytest -q` is green on a clean checkout — CI `test (py3.9…py3.13)` all green
- [x] `ruff check .` is clean — CI `lint (ruff)` green
- [x] `python3 tools/validate_skill.py SKILL.md` passes — CI `validate SKILL.md` green
- [x] PR title follows Conventional Commits — CI `PR title` green
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification — the `SKILL.md` growth is the two-tier template itself

## Notes for reviewers (Optional)

- **Naming:** you suggested `DEPTH=progressive` in #67; since `DEPTH` now means `study`/`reference`, I used a separate `NAV` variable. Happy to rename.
- **World Knowledge First** was split out per your review into #156, not bundled here.
- **Discovery hint:** the Quick Reference table carries a `HOW_TO_USE.md` row, and Step 9 requires the "expand framework" phrase in `HOW_TO_USE.md`'s first blockquote.
