### PR TITLE
fix: detect Markdown ToC headings, Unit-style chapters, stray-Roman suppression (#126)

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -96,14 +96,14 @@ def estimate_tokens(text: str) -> int:
 # the longer words match in full. Captures the number (bounded to 1..99 — drops
 # years like "2025.") and whatever follows it on the line, so we can reject prose.
 _EXPLICIT_CHAPTER = re.compile(
-    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(?:(\d{1,2})|(?P<roman>[IVXLCDMivxlcdm]{1,7}))\b(?P<rest>.*)$",
+    r"^\s*(?:chapter|unit|lesson|module|lecture|part|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(?:(\d{1,2})|(?P<roman>[IVXLCDMivxlcdm]{1,7}))\b(?P<rest>.*)$",
     re.IGNORECASE,
 )
 # A heading's number is followed by end-of-line, punctuation (“. : - —“), or a
 # Capitalized title word. A lowercase continuation (“Chapter 6 explores...”,
 # “Chapter 8 are relevant...”) is prose / a cross-reference, not a heading.
 # The uppercase class is À-Þ so titles starting with Ü/Û (common in German, e.g. “Überblick”) are recognized.
-_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+[A-ZÀ-Þ0-9\"“(]")
+_HEADING_TAIL = re.compile(r"^\s*$|^\s*[.:\-—–]|^\s+(?![a-z])")
 
 # Roman-numeral chapter heading: "I: Loomings", "II. The Carpet-Bag".
 # Uppercase alone at line start is safe — no common English word is a valid
@@ -179,7 +179,7 @@ _TOC_HEADERS = (
 )
 _TOC_CJK_PATTERN = r"目[ \t\u3000]*(?:录|錄|次)"
 _TOC_PATTERN = re.compile(
-    r"^\s*(?:"
+    r"^\s*(?:#{1,6}\s*)?(?:"
     + "|".join([*(re.escape(h) for h in _TOC_HEADERS), _TOC_CJK_PATTERN])
     + r")\s*$",
     re.IGNORECASE | re.MULTILINE,
@@ -461,12 +461,21 @@ def detect_structure(text: str) -> dict:
     # Every parser in this project already announces which method it used
     # ("Trying python-docx... OK"); this decision had the same shape and was
     # the only silent one.
-    if numeric_count > 0:
+    if numeric_count >= 2:
         chapters_detected = numeric_count
         chapters_method = "numeric"
     else:
-        chapters_detected = _structural_chapter_count(text)
-        chapters_method = "structural" if chapters_detected else "none"
+        # A single stray number (e.g. a Roman numeral inside an example paper
+        # reproduced in the book, or a lone "Part 1") is not enough to suppress
+        # the structural (Markdown/AsciiDoc) heading count, so course-style
+        # books with "### Unit N" headings still get counted via max().
+        structural_count = _structural_chapter_count(text)
+        chapters_detected = max(numeric_count, structural_count)
+        chapters_method = (
+            "structural" if structural_count > numeric_count
+            else "numeric" if numeric_count
+            else "none"
+        )
 
     # Look for ToC indicators in the first ~30k chars (multilingual; see _TOC_PATTERN)
     has_toc = bool(_TOC_PATTERN.search(text[:30000]))

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -731,6 +731,52 @@ class TestDetectStructure:
         text = "The contents of this chapter are varied and the index is long.\n"
         assert detect_structure(text)["has_toc"] is False
 
+
+    def test_toc_markdown_atx_heading(self):
+        # issue #126: a Markdown export writes the ToC as "## Table of Contents"
+        text = """## Table of Contents
+1. Intro
+2. Body
+"""
+        assert detect_structure(text)["has_toc"] is True
+
+    def test_toc_markdown_headers_other_languages(self):
+        text = """## 目录
+第一章 开始
+第二章 进阶
+"""
+        assert detect_structure(text)["has_toc"] is True
+
+    def test_unit_style_chapter_headings(self):
+        # course-style books: "### Unit 1 ✏ ..." must be detected as chapters
+        text = """### Unit 1 ✏ How to Write an Introduction
+body
+### Unit 2 ✏ Writing about Methodology
+body
+"""
+        assert detect_structure(text)["chapters_detected"] >= 2
+
+    def test_stray_roman_numeral_does_not_suppress_structural_count(self):
+        # a single Roman numeral inside a reproduced example paper must not
+        # outvote the structural heading count of the surrounding book
+        text = """### Introduction
+VIII. CONCLUSIONS
+### Methodology
+"""
+        result = detect_structure(text)
+        assert result["chapters_detected"] >= 2
+        assert result["chapters_method"] == "structural"
+
+    def test_unit_style_headings_count_as_numeric(self):
+        # "Unit N" headings are explicit chapters once the markdown prefix is
+        # stripped, so they take the numeric branch
+        text = """### Unit 1 ✏ How to Write an Introduction
+VIII. CONCLUSIONS
+### Unit 2 ✏ Writing about Methodology
+"""
+        result = detect_structure(text)
+        assert result["chapters_detected"] >= 2
+        assert result["chapters_method"] == "numeric"
     def test_numbered_list_items_are_not_chapters(self):
         # The AI-Engineering failure: numbered list items were counted as chapters.
         text = (


### PR DESCRIPTION
Three related chapter/ToC detection fixes surfaced while converting a Markdown book through the pipeline. Closes the Markdown half of #126.

## What changed

1. **`_TOC_PATTERN` accepts an optional ATX prefix** — Markdown exports write the ToC as `## Table of Contents` / `## 目录`, which never matched the bare-line pattern, so every Markdown source reported `ToC: not detected` and emitted the "chapter mapping may miss or duplicate sections" warning (issue #126).

2. **`_EXPLICIT_CHAPTER` + `_HEADING_TAIL` support course-style headings** — added `unit|lesson|module|lecture|part` to the chapter words (preserving the existing Roman-numeral branch), and relaxed the heading tail from "uppercase-only" to "any non-lowercase continuation" so `Unit 1 ✏ How to Write an Introduction` (emoji/CJK glyph after the number) is recognized. Prose cross-references like `Chapter 6 explores...` are still rejected.

3. **`detect_structure` no longer lets a single stray number suppress the structural count** — one Roman numeral inside a reproduced example paper (`VIII. CONCLUSIONS`) used to outvote all Markdown headings (`numeric_count > 0`). Now numeric is authoritative only at `>= 2` distinct headings; otherwise the count is `max(numeric, structural)` and `chapters_method` reports which branch answered.

## Tests

5 new regression tests (Markdown ToC EN/CJK, Unit-style headings, stray-Roman suppression, Unit-style as numeric). Full suite: **475 passed** — the single failure (`test_prepare_output_dir_rejects_symlink`) is a pre-existing Windows-only environment issue, unrelated to this change (fails on `upstream/master` too).

Also posted a [showcase](https://github.com/Justinjchen-Cornell/Science-Research-Writing-Skill) repo generated by book-to-skill — happy to adjust any of these changes per review feedback.