### PR TITLE
fix(extractor): treat bracketed paths as literals

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -534,7 +534,9 @@ def resolve_input_files(paths: list[str]) -> list[Path]:
         # the file/directory branch below see a real path.
         path_str = os.path.expanduser(raw_path)
         # Check if it has glob wildcards
-        if any(char in path_str for char in ("*", "?", "[")):
+        if not Path(path_str).exists() and any(
+            char in path_str for char in ("*", "?", "[")
+        ):
             glob_matches = glob.glob(path_str, recursive=True)
             # Sort expanded glob results deterministically
             expanded = []

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1206,6 +1206,13 @@ class TestDocxExtraction:
 class TestResolveInputFiles:
     """Additional edge-case tests for resolve_input_files."""
 
+    def test_existing_file_with_glob_metacharacters_is_literal(self, tmp_path):
+        target = _make_text_file(tmp_path / "book [2013].pdf")
+
+        result = resolve_input_files([str(target)])
+
+        assert result == [target.resolve()]
+
     def test_nonexistent_file_kept_for_error_reporting(self, tmp_path):
         """A nonexistent explicit path is kept so extract_single_file can report it."""
         fake = tmp_path / "nonexistent.pdf"


### PR DESCRIPTION
## Summary

Treat an existing input path as a literal before checking it for glob metacharacters. This lets files such as `book [2013].pdf` resolve normally without changing actual glob expansion.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## What it does

- **Fixes:** existing filenames containing square brackets being interpreted as glob patterns and resolving to no files.

## Motivation & context

Closes #158.

## How it works

The resolver enters the glob branch only when the literal path does not exist. Existing files continue through the explicit file path branch, while real patterns keep the same expansion, filtering, sorting, and deduplication behavior.

## Evidence

- **Tests:** added a regression test for a literal `book [2013].pdf`; the focused path/glob/tilde group passes 17 tests.
- **Before / after:** the new test returned `[]` before the fix and the resolved file path after it.

```
before: 1 failed (result: [])
after:  1 passed (result: [book [2013].pdf])
full:   470 passed, 7 skipped
ruff:   All checks passed
```

The only additional local result is the existing Windows symlink-creation test, which needs the OS symlink privilege and fails with WinError 1314 before reaching project code.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
