### PR TITLE
docs(install): install the CLI from the repo — book-to-skill is not on PyPI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,8 @@ git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/boo
 **As a standalone CLI** (just the text extractor, optional):
 
 ```bash
-pip install "book-to-skill[pdf,epub,docx]"
+# not on PyPI yet — pip takes it from the repository
+pip install "book-to-skill[pdf,epub,docx] @ git+https://github.com/virgiliojr94/book-to-skill.git"
 book-to-skill /path/to/book.pdf --mode text
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ seo_title: "Install book-to-skill - Claude Code, Copilot CLI, Amp, or pip"
 
 > **Two ways to use it, do not confuse them:**
 > - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, Amp, or Codex) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
-> - **As a standalone CLI** (just the text extractor) → `pip install book-to-skill`, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
+> - **As a standalone CLI** (just the text extractor) → `pip install` it from the repository, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
 
@@ -64,13 +64,16 @@ Then in any agent session:
 
 ### Standalone CLI (pip)
 
-`pip install book-to-skill` is a **separate, optional** path. It installs only the
+Installing the CLI with `pip` is a **separate, optional** path. It installs only the
 text-extraction engine as a CLI, for scripting or to grab the optional extractors;
 it does **not** register the `/book-to-skill` agent skill (use the `git clone` above
 for that).
 
+`book-to-skill` is not on PyPI yet, so `pip` takes the package straight from the
+repository:
+
 ```bash
-pip install "book-to-skill[pdf,epub,docx]"   # engine + optional extractors
+pip install "book-to-skill[pdf,epub,docx] @ git+https://github.com/virgiliojr94/book-to-skill.git"
 book-to-skill ~/path/to/book.pdf --mode text  # or: python -m book_to_skill ...
 book-to-skill --check                          # report which extractors are installed
 ```


### PR DESCRIPTION
Hi — quick disclosure first, because you should know who typed this: I am an AI agent (Claude) working with @tonydzi, who reviews what I send. Everything below was run on a real machine; the terminal output is pasted, not summarised.

## Summary (Required)

The docs advertise a standalone CLI you can install with `pip install "book-to-skill[pdf,epub,docx]"`, but `book-to-skill` has never been published to PyPI, so that command fails for every reader who tries it. This PR points the same `pip` command at the repository, which installs the identical package, extras and console script today.

## Type of change (Required)

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** the documented standalone-CLI install. `docs/install.md` (the callout at the top and the “Standalone CLI (pip)” section) and `docs/index.md` tell the reader to run `pip install "book-to-skill[pdf,epub,docx]"`. Root cause: the packaging work from #42 landed (`book_to_skill/`, the `book-to-skill` console script, the extras), but nothing was ever uploaded to PyPI — `https://pypi.org/pypi/book-to-skill/json` and `https://pypi.org/simple/book-to-skill/` both return **404**, and there is no publish workflow in `.github/workflows/`. So the command cannot succeed, on any machine.
- **Improves:** the section now works as written: 4 lines changed, `pip` resolves the project from git, and `book-to-skill --check` / a real extraction run both work afterwards (output below).

## Motivation & context (Required)

Closes n/a — no issue open for this; the pip lines went live in `bd8a522` (2026-08-10) and the docs site publishes them at https://booktoskill.is-a.dev/install/, so anyone following the “standalone CLI” path today hits a hard stop on the first command.

## How it works (Required for anything non-trivial)

`pip install "book-to-skill[pdf,epub,docx] @ git+https://github.com/virgiliojr94/book-to-skill.git"` — PEP 508 direct reference, so the extras still apply and the console script is still registered; nothing about the package changes. The `#standalone-cli-pip` heading (and the anchor the callout links to) is untouched.

**The alternative I did not take, because it is your call, not mine:** publish `book-to-skill` to PyPI and leave the docs as they are. If that is already in flight, close this — the docs will be right again the moment you upload, and a one-line revert puts the short command back.

## Evidence (Required)

- **Tests:** none added — docs-only change, no code touched. The existing suite is green on this branch (below).
- **Before / after:** clean `python3 -m venv`, Python 3.12.13, no cache of the project.

```
### BEFORE — the command as documented today
$ pip install "book-to-skill[pdf,epub,docx]"
ERROR: Could not find a version that satisfies the requirement book-to-skill[docx,epub,pdf] (from versions: none)
ERROR: No matching distribution found for book-to-skill[docx,epub,pdf]

### AFTER — the command in this PR
$ pip install "book-to-skill[pdf,epub,docx] @ git+https://github.com/virgiliojr94/book-to-skill.git"
(exit 0)

$ book-to-skill --check
book-to-skill — dependency check

  PDF (text-heavy)
      ✓ python: pypdf
      ✓ python: pdfminer.six
      ✗ system: pdftotext (poppler-utils)
      → ready — any one of pdftotext / pypdf / pdfminer is enough

$ book-to-skill /tmp/b2s-demo/note.md --mode text --install-missing no
   Text -> /tmp/b2s-demo/work/full_text.txt
   Meta -> /tmp/b2s-demo/work/metadata.json

### the 404 behind all of it
$ curl -s -o /dev/null -w "%{http_code}\n" https://pypi.org/pypi/book-to-skill/json
404
$ curl -s -o /dev/null -w "%{http_code}\n" https://pypi.org/simple/book-to-skill/
404

### repo gates, clean checkout of this branch
$ pytest tests/ -q
477 passed in 3.10s
$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!
$ python3 tools/validate_skill.py SKILL.md
✓ SKILL.md [Claude Code]: no Claude Code-breaking issues (1 warning(s))   # pre-existing 701-line body warning, untouched
```

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes — n/a, docs only, no behavior change
- [x] `pytest -q` is green on a clean checkout (477 passed)
- [x] `ruff check .` is clean (CI's `--select E9,F` gate; output above)
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — `SKILL.md` not changed; ran it anyway, passes
- [x] PR title follows Conventional Commits (`docs(install): …`); `CHANGELOG.md` not touched
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Deliberately out of scope: the `npx skills add …` and `git clone` paths (both work as written — I checked), and the README, which does not carry a pip line. If you would rather the docs say “not installable via pip yet, clone it” instead of carrying a git URL, say the word and I will re-send it that way.
