### PR TITLE
test(security): skip symlink assertion when unsupported

### DIFF
--- a/tests/test_output_dir_security.py
+++ b/tests/test_output_dir_security.py
@@ -30,7 +30,10 @@ def test_prepare_output_dir_rejects_symlink(tmp_path):
     real_dir = tmp_path / "real"
     real_dir.mkdir()
     link = tmp_path / "work"
-    link.symlink_to(real_dir)
+    try:
+        link.symlink_to(real_dir, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"directory symlinks are unavailable on this host: {exc}")
 
     with pytest.raises(ExtractionError, match="symbolic link"):
         prepare_output_dir(link)


### PR DESCRIPTION
## Summary (Required)

Keep the output-directory security test portable on hosts that cannot create directory symlinks. The security assertion still runs everywhere directory symlinks are available.

## Type of change (Required)

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [x] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `test_prepare_output_dir_rejects_symlink` failed during setup on Windows installations without Developer Mode or symlink privileges, before `prepare_output_dir()` was exercised.
- **Improves:** the Windows suite result from 1 failed / 470 passed / 6 skipped to 470 passed / 7 skipped on such hosts.
- **Adds:** an explicit directory-symlink capability check while preserving the security assertion on capable hosts.

## Motivation & context (Required)

The permission-bit assertions in this test module were made POSIX-only in #155, but the remaining symlink test still assumes every host may create a symlink. On Windows that operation commonly raises `WinError 1314`, making an otherwise green local suite fail for an environmental limitation.

Closes: n/a — discovered while verifying current `master` on Windows; no matching open issue or PR was found.

## How it works (Required for anything non-trivial)

The test requests a directory symlink explicitly with `target_is_directory=True`. If the platform does not implement symlinks or the host refuses their creation, the test reports a capability-based skip. When creation succeeds, the existing assertion that `prepare_output_dir()` raises `ExtractionError` remains unchanged.

## Evidence (Required)

- **Tests:** `tests/test_output_dir_security.py` still asserts that a successfully created symlink is rejected; the full suite was rerun from a clean detached worktree.
- **Before / after:** reproduced on Windows 11 with Python 3.12.

```text
Before: 1 failed, 470 passed, 6 skipped
FAILED tests/test_output_dir_security.py::test_prepare_output_dir_rejects_symlink
OSError: [WinError 1314] A required privilege is not held by the client

After: 470 passed, 7 skipped
SKIPPED tests/test_output_dir_security.py: directory symlinks are unavailable on this host: [WinError 1314]

python -m ruff check .
All checks passed!

python tools/validate_skill.py SKILL.md
no Claude Code-breaking issues (1 pre-existing line-count warning)
```

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Suggested PR title: `test(security): skip symlink assertion when unsupported`

This changes test setup only; production symlink rejection behavior is untouched.
