### PR TITLE
docs: add Hermes Agent as a supported host

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through Hermes Agent, GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 ---
 
 <!--
 Cross-agent notes (informational; ignored by host agents):
-  - Compatible skill roots: GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills,
-    .github/skills, .claude/skills, .agents/skills), Amp (.agents/skills,
+  - Compatible skill roots: Hermes Agent ($HERMES_HOME/skills, default ~/.hermes/skills),
+    GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills, .github/skills,
+    .claude/skills, .agents/skills), Amp (.agents/skills,
     ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills).
   - `allowed-tools` is intentionally omitted to stay agent-neutral: Copilot CLI uses
     `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`, Amp
@@ -66,14 +67,15 @@ Four paths available. Route based on what the user asks:
 
 This converter can run from multiple skill systems. When looking for this converter's helper script or writing the generated book skill, prefer these locations in order:
 
-1. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
-2. Cross-agent personal skills (Copilot, Amp, Codex): `~/.agents/skills/`
-3. Claude Code personal skills: `~/.claude/skills/`
-4. Project-local Copilot skills: `.github/skills/`
-5. Project-local Claude skills: `.claude/skills/`
-6. Project-local Amp / Copilot skills: `.agents/skills/`
-7. Amp global skills: `~/.config/agents/skills/`
-8. Amp legacy global skills: `~/.config/amp/skills/`
+1. Hermes Agent skills: `$HERMES_HOME/skills/` (default `~/.hermes/skills/`)
+2. GitHub Copilot CLI personal skills: `~/.copilot/skills/`
+3. Cross-agent personal skills (Copilot, Amp, Codex): `~/.agents/skills/`
+4. Claude Code personal skills: `~/.claude/skills/`
+5. Project-local Copilot skills: `.github/skills/`
+6. Project-local Claude skills: `.claude/skills/`
+7. Project-local Amp / Copilot skills: `.agents/skills/`
+8. Amp global skills: `~/.config/agents/skills/`
+9. Amp legacy global skills: `~/.config/amp/skills/`
 
 For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
 
@@ -131,6 +133,7 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 for candidate in \
+  "${HERMES_HOME:-$HOME/.hermes}/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
@@ -304,6 +307,7 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 
 | Host agent | Personal skill root (probe in order) | Project-local root |
 |---|---|---|
+| **Hermes Agent** | `$HERMES_HOME/skills` (default `~/.hermes/skills`) | `.claude/skills` → `.agents/skills` |
 | **GitHub Copilot CLI** | `~/.copilot/skills` → `~/.agents/skills` | `.github/skills` → `.claude/skills` → `.agents/skills` |
 | **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
@@ -313,7 +317,7 @@ Selection rules:
 1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
 2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
 3. If the user explicitly asked for project-local output, prefer the project-local row.
-4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, Codex, or Claude Code?"
+4. If you cannot identify the host, ask: "Which agent are you running this in — Hermes Agent, GitHub Copilot CLI, Amp, Codex, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:


### PR DESCRIPTION
## Summary (Required)

Adds Hermes Agent (`$HERMES_HOME/skills`, default `~/.hermes/skills`) as a supported host alongside Copilot CLI, Amp, Claude Code, and Codex. Docs-only change to `SKILL.md` (+16/−12): the converter's script lookup, skill-location ranking, and generated-skill destination table now recognize Hermes so a conversion run inside it works end-to-end instead of guessing at another host's root.

## Type of change (Required)

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [x] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Adds:** Hermes Agent as a first-class host in `SKILL.md`: frontmatter description + cross-agent notes, Skill Locations list (ranked #1), Step 2 `extract.py` lookup (`${HERMES_HOME:-$HOME/.hermes}/skills/book-to-skill/scripts/extract.py`, env-var aware so non-default profiles resolve too), and a Hermes row in the Step 5 `SKILLS_HOME` table + host-detection prompt.
- **Improves:** running the converter inside Hermes now writes generated book skills to the running host's skill root (`~/.hermes/skills/<name>/`) instead of probing only Copilot/Amp/Claude roots and potentially asking the user or picking a root their agent can't discover.

## Motivation & context (Required)

Closes #n/a — no issue filed; Hermes Agent is an Agent Skills-compatible host that was missing from the host lists, so its users had to hand-edit `SKILL.md` after installing (this PR's own install required exactly those edits).

## How it works (Required for anything non-trivial)

No new steps added — only existing lists/tables extended with one host row each. The lookup path uses `${HERMES_HOME:-$HOME/.hermes}` so both default and profile-based installs resolve correctly, matching how Hermes resolves its home directory.

## Evidence (Required)

- **Tests:** no code files touched; full suite still green on the changed tree (`pytest -q` → 477 passed).
- **Before / after:** local preflight of the exact commands CI runs:

```
$ python3 tools/validate_skill.py SKILL.md
WARN  body: 705 lines > 500 (soft guideline for optimal performance)   # pre-existing, unchanged by this PR
✓ SKILL.md [Claude Code]: no Claude Code-breaking issues (1 warning(s))

$ pytest -q
477 passed in 0.45s

# ruff: docs-only diff, no code files changed
```

Also verified in practice on a Hermes install (symlinked checkout into `~/.hermes/skills/`): skill loads, and an end-to-end markdown extraction run completed successfully with the Step 2 lookup resolving to the Hermes path.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes *(none needed — docs-only, no code behavior change)*
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification *(+4 lines net, all host-list entries required for correct routing in Hermes)*

## Notes for reviewers (Optional)

The Hermes row is placed first in the Skill Locations list and lookup loop because this PR targets a Hermes install; other hosts fall through to their existing paths unchanged. Happy to reorder or gate it differently if you'd rather keep alphabetical/host-precedence conventions.
