### PR TITLE
fix(extractor): extract multi-column PDFs in reading order instead of -layout (#128)

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -26,6 +26,30 @@ _ROMAN_1_99 = r"(?=[ivxl])(?:xc|xl|l?x{0,3})(?:ix|iv|v?i{0,3})"
 _PDF_PAGE_NUM = re.compile(rf"^\s*(?:\d{{1,4}}|{_ROMAN_1_99})\s*$", re.IGNORECASE)
 _PDF_HYPHEN_WRAP = re.compile(r"(\w)-\n(\w)")
 
+# A wide internal run of spaces — the column gutter. Multi-column `-layout`
+# output pads each physical line across all columns, so a substantive line
+# contains 4+ spaces between two non-space characters; single-column reading
+# order never does (#128).
+GUTTER = re.compile(r"\S[ ]{4,}\S")
+
+
+def looks_multicolumn(layout_text: str, threshold: float = 0.35) -> bool:
+    """True when `-layout` output looks like a multi-column page: under -layout
+    each physical line spans all columns, so a large fraction of substantive
+    lines carry a wide internal run of spaces (the gutter). Reading order has no
+    gutters, so the fraction is near zero on single-column documents.
+
+    Only substantive lines (40+ chars after stripping) are sampled, capped at
+    the first 4000 lines for a bounded cost on huge documents. Returns False on
+    empty or all-short input — a book with no long lines is not multi-column.
+    """
+    lines = [ln for ln in layout_text.splitlines() if len(ln.strip()) > 40]
+    if not lines:
+        return False
+    sample = lines[:4000]
+    gutter_lines = sum(1 for ln in sample if GUTTER.search(ln))
+    return gutter_lines / len(sample) >= threshold
+
 
 def clean_pdftotext(text: str) -> str:
     """Clean pdftotext '-layout' output (pages are form-feed delimited): drop
@@ -73,20 +97,48 @@ def clean_pdftotext(text: str) -> str:
     return _PDF_HYPHEN_WRAP.sub(r"\1\2", text)
 
 
-def extract_with_pdftotext(pdf_path: str) -> str | None:
+def _run_pdftotext(
+    pdf_path: str, extra_args: list[str], timeout: int
+) -> subprocess.CompletedProcess[str] | None:
+    """Best-effort single pdftotext invocation; returns None when pdftotext is
+    missing or the call fails outright."""
     if not shutil.which("pdftotext"):
         return None
     try:
-        pdf_path = os.path.abspath(pdf_path)
-        result = subprocess.run(
-            ["pdftotext", "-layout", pdf_path, "-"],
-            capture_output=True, text=True, timeout=120,
-            encoding="utf-8", errors="replace",
+        return subprocess.run(
+            ["pdftotext", *extra_args, os.path.abspath(pdf_path), "-"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            encoding="utf-8",
+            errors="replace",
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return clean_pdftotext(result.stdout)
     except Exception as e:
-        print(f"  [warn] extract_with_pdftotext failed: {type(e).__name__}: {e}", file=sys.stderr)
+        print(f"  [warn] pdftotext failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return None
+
+
+def extract_with_pdftotext(pdf_path: str) -> str | None:
+    """Extract text with pdftotext, choosing the mode per document (#128).
+
+    `-layout` keeps table columns aligned on single-column documents, but on a
+    multi-column page it welds every column's lines together: consecutive
+    sentences from different columns get interleaved, and the padding inflates
+    the output ~26x. Both extractions are cheap (seconds for a 140-page book),
+    so we run `-layout` first and re-run in reading order (no flag) only when
+    the gutter heuristic flags the document as multi-column.
+    """
+    layout = _run_pdftotext(pdf_path, ["-layout"], timeout=120)
+    if layout is not None and layout.returncode == 0 and layout.stdout.strip():
+        if looks_multicolumn(layout.stdout):
+            reading = _run_pdftotext(pdf_path, [], timeout=120)
+            if (
+                reading is not None
+                and reading.returncode == 0
+                and reading.stdout.strip()
+            ):
+                return clean_pdftotext(reading.stdout)
+        return clean_pdftotext(layout.stdout)
     return None
 
 
@@ -101,8 +153,11 @@ def looks_image_only(pdf_path: str, pages: int = 5) -> bool:
     try:
         result = subprocess.run(
             ["pdftotext", "-f", "1", "-l", str(pages), os.path.abspath(pdf_path), "-"],
-            capture_output=True, text=True, timeout=30,
-            encoding="utf-8", errors="replace",
+            capture_output=True,
+            text=True,
+            timeout=30,
+            encoding="utf-8",
+            errors="replace",
         )
         return result.returncode == 0 and not result.stdout.strip()
     except Exception:
@@ -112,6 +167,7 @@ def looks_image_only(pdf_path: str, pages: int = 5) -> bool:
 def extract_with_pypdf(pdf_path: str) -> str | None:
     try:
         import pypdf
+
         text_parts = []
         with open(pdf_path, "rb") as f:
             reader = pypdf.PdfReader(f)
@@ -126,19 +182,26 @@ def extract_with_pypdf(pdf_path: str) -> str | None:
     except ImportError:
         return None
     except Exception as e:
-        print(f"  [warn] extract_with_pypdf failed: {type(e).__name__}: {e}", file=sys.stderr)
+        print(
+            f"  [warn] extract_with_pypdf failed: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
         return None
 
 
 def extract_with_pdfminer(pdf_path: str) -> str | None:
     try:
         from pdfminer.high_level import extract_text
+
         text = extract_text(pdf_path)  # already form-feed delimited per page
         return clean_pdftotext(text) if text else text
     except ImportError:
         return None
     except Exception as e:
-        print(f"  [warn] extract_with_pdfminer failed: {type(e).__name__}: {e}", file=sys.stderr)
+        print(
+            f"  [warn] extract_with_pdfminer failed: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
         return None
 
 
@@ -164,7 +227,10 @@ def extract_with_docling(pdf_path: str) -> str | None:
     except ImportError:
         return None
     except Exception as e:
-        print(f"  [warn] extract_with_docling failed: {type(e).__name__}: {e}", file=sys.stderr)
+        print(
+            f"  [warn] extract_with_docling failed: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
         return None
 
 
@@ -184,6 +250,7 @@ def count_pages(pdf_path: str) -> int:
     # Fallback: count pages with pypdf
     try:
         import pypdf
+
         with open(pdf_path, "rb") as f:
             return len(pypdf.PdfReader(f).pages)
     except Exception:

--- a/tests/test_multicolumn_pdf_detection.py
+++ b/tests/test_multicolumn_pdf_detection.py
@@ -1,0 +1,132 @@
+"""Multi-column PDFs must be extracted in reading order, not `-layout`.
+
+`-layout` welds every column's physical lines together, interleaving
+consecutive sentences from different columns and padding the output ~26x
+with spaces (#128). The extractor detects multi-column documents with a
+gutter heuristic and falls back to reading order (plain `pdftotext`); this
+file tests the detector and the mode selection.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.parsers.pdf import extract_with_pdftotext, looks_multicolumn
+
+
+class TestLooksMulticolumn:
+    def test_flagged_when_most_substantive_lines_have_a_gutter(self):
+        # Three columns welded together: each line carries two 4+ space runs.
+        layout = "\n".join(
+            "column one text     column two text     column three text"
+            for _ in range(10)
+        )
+        assert looks_multicolumn(layout)
+
+    def test_single_column_reading_order_is_not_multicolumn(self):
+        lines = [
+            "The standard deduction amount has been increased for all filers.",
+            "This sentence continues on the same physical line with no gutter.",
+            "Taxpayers who made a qualifying investment may also be eligible.",
+        ]
+        assert not looks_multicolumn("\n".join(lines) * 5)
+
+    def test_short_lines_are_ignored(self):
+        # A table where every line is short has no long gutter lines to flag.
+        text = "\n".join(["a b" for _ in range(20)])
+        assert not looks_multicolumn(text)
+
+    def test_empty_text_is_not_multicolumn(self):
+        assert not looks_multicolumn("")
+
+    def test_threshold_is_respected(self):
+        gutter = "left column prose here     right column prose over there"
+        plain = (
+            "A single line of ordinary prose without any wide internal gutter at all."
+        )
+        # 50% gutter lines vs default 0.35 threshold -> flagged.
+        text = "\n".join([gutter, plain, gutter, plain])
+        assert looks_multicolumn(text)
+        # Same mix with a stricter threshold -> not flagged.
+        assert not looks_multicolumn(text, threshold=0.9)
+
+
+class TestExtractWithPdftotextModeSelection:
+    """The extractor must run plain pdftotext (reading order) for
+    multi-column documents and keep `-layout` for single-column ones."""
+
+    def test_multicolumn_document_uses_reading_order(self, monkeypatch):
+        multi = "\n".join(
+            "left column text     right column text     third column" for _ in range(20)
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd, 0, multi if "-layout" not in cmd else multi, ""
+            )
+
+        monkeypatch.setattr(
+            "book_to_skill.parsers.pdf.shutil.which", lambda _: "/bin/pdftotext"
+        )
+        monkeypatch.setattr("book_to_skill.parsers.pdf.subprocess.run", fake_run)
+
+        out = extract_with_pdftotext("book.pdf")
+        assert out is not None
+        assert len(calls) == 2
+        assert "-layout" in calls[0]  # probe with layout first
+        assert "-layout" not in calls[1]  # then reading order
+        assert "left column text" in out
+
+    def test_single_column_document_keeps_layout(self, monkeypatch):
+        single = "\n".join(
+            "A normal prose line that has no column gutter at all." for _ in range(20)
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, single, "")
+
+        monkeypatch.setattr(
+            "book_to_skill.parsers.pdf.shutil.which", lambda _: "/bin/pdftotext"
+        )
+        monkeypatch.setattr("book_to_skill.parsers.pdf.subprocess.run", fake_run)
+
+        out = extract_with_pdftotext("book.pdf")
+        assert out is not None
+        assert len(calls) == 1
+        assert "-layout" in calls[0]
+
+    def test_failed_layout_probe_returns_none(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+        monkeypatch.setattr(
+            "book_to_skill.parsers.pdf.shutil.which", lambda _: "/bin/pdftotext"
+        )
+        monkeypatch.setattr("book_to_skill.parsers.pdf.subprocess.run", fake_run)
+
+        assert extract_with_pdftotext("book.pdf") is None
+        assert len(calls) == 1
+
+    def test_missing_pdftotext_returns_none_without_calling(self, monkeypatch):
+        called = False
+
+        def fake_run(cmd, **kwargs):
+            nonlocal called
+            called = True
+            raise AssertionError("must not run")
+
+        monkeypatch.setattr("book_to_skill.parsers.pdf.shutil.which", lambda _: None)
+        monkeypatch.setattr("book_to_skill.parsers.pdf.subprocess.run", fake_run)
+
+        assert extract_with_pdftotext("book.pdf") is None
+        assert not called


### PR DESCRIPTION
## What

Fixes #128. `pdftotext -layout` welds every physical line across all columns, so on a multi-column document consecutive sentences from different columns get interleaved — the issue's "sentences that never existed in the book" failure — while padding the output ~26x (96.8% whitespace on IRS Pub 17).

`extract_with_pdftotext()` now:

1. Runs `pdftotext -layout` first (unchanged for single-column docs).
2. Flags the result with the issue's own gutter heuristic — `looks_multicolumn()`: the fraction of substantive (40+ char) lines carrying a 4+ space internal run, sampled over the first 4000 lines, threshold 0.35.
3. When flagged, re-runs plain `pdftotext` (reading order) and returns that instead. Single-column books keep `-layout` exactly as before; both runs are cheap (seconds on 142 pages).

## Verified against the issue's repro (IRS Pub 17)

- Layout output: 1,641,750 chars, `looks_multicolumn` → True.
- Final extraction: 957,292 chars (~the issue's 957,757 no-flag baseline), **0 gutter lines** in the output, sentences contiguous in reading order (the standard-deduction passage reads correctly end to end).

## Tests

9 new tests in `tests/test_multicolumn_pdf_detection.py`: detector behavior (flagged, single-column, short-line, empty, threshold), and mode selection with mocked `pdftotext` (multi-column → 2 calls with reading-order second, single-column → 1 call keeping `-layout`, failed probe → None, missing binary → None without calling). Full suite: **485 passed, 1 skipped**; `ruff check` and `ruff format --check` clean.

I implemented the issue's suggested detection approach as proposed. I did not fold in the three "smaller changes" (char-based token estimates, padding collapse, multi-column warning) — happy to follow up on any of them separately if you want them.
