### PR TITLE
fix(epub): report images that text-only extraction drops (#127)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -117,7 +117,7 @@ Store the answer as `BOOK_TYPE`:
 - Option 3 → `BOOK_TYPE=text`
 
 **If `BOOK_TYPE=technical`**, inform the user before proceeding:
-> "📐 Technical mode selected — using Docling for structure-aware extraction (tables, code blocks, formulas preserved as markdown). This takes ~1.5s per page, so expect a few minutes for longer sources. Starting now…"
+> "📐 Technical mode selected — using Docling for structure-aware extraction of PDFs (tables, code blocks, formulas preserved as markdown). EPUB sources are extracted as text only: their images are never read, so figures are not preserved. This takes ~1.5s per page, so expect a few minutes for longer sources. Starting now…"
 
 **If `BOOK_TYPE=text`**, inform:
 > "📄 Text mode selected — using the fastest suitable extractor for each file type. Plain text/Markdown/HTML are usually ready in seconds; PDFs use pdftotext when available."
@@ -515,6 +515,12 @@ the relevant chapter file before answering.
 This skill covers the book content only. For hands-on implementation in your codebase,
 combine with project-specific tools. For topics beyond this book, check related skills
 or ask the agent directly.
+
+If `metadata.json` reports `"images_dropped": N`, add a line stating the boundary so
+the skill does not silently overclaim:
+
+> Figures in the source were not read — the N images were not extracted, so
+> figure-borne content (diagrams, matrices, decision tables) is absent from this skill.
 ```
 
 ---

--- a/book_to_skill/parsers/epub.py
+++ b/book_to_skill/parsers/epub.py
@@ -123,3 +123,42 @@ def count_epub_chapters(epub_path: str) -> int:
     except Exception:
         return 0
 
+
+# Image extensions that are not declared in the OPF manifest but still sit in
+# the archive. Some EPUB producers ship a permissive manifest (or none at all),
+# so a manifest-only count would silently under-report; the extension scan is
+# the fallback, not the primary, because the manifest is the spec-defined list
+# of everything the book actually uses.
+_IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".bmp", ".tif", ".tiff", ".avif")
+
+
+def count_epub_images(epub_path: str) -> int:
+    """Count the images inside an EPUB without extracting them.
+
+    Primary source is the OPF manifest: every ``<item>`` whose ``media-type``
+    starts with ``image/`` is a figure the book ships (and that text-only
+    extraction drops). Falls back to scanning the archive for known image
+    extensions when no OPF is found or it declares no images. Returns 0 on any
+    error — this is a reporting aid, never a reason to fail extraction.
+    """
+    try:
+        with zipfile.ZipFile(epub_path) as zf:
+            opf_path = _find_opf_path(zf)
+            if opf_path:
+                opf_text = zf.read(opf_path).decode("utf-8", errors="replace")
+                manifest_images = [
+                    tag
+                    for tag in re.findall(r"<item\b[^>]*?/?>", opf_text)
+                    if re.search(r'\bmedia-type=["\']image/', tag)
+                ]
+                if manifest_images:
+                    return len(manifest_images)
+            return sum(
+                1
+                for n in zf.namelist()
+                if n.lower().endswith(_IMAGE_EXTENSIONS)
+                and not n.startswith("META-INF/")
+            )
+    except Exception:
+        return 0
+

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -46,6 +46,7 @@ from book_to_skill.parsers.epub import (
     extract_with_ebooklib,
     extract_with_zipfile,
     count_epub_chapters,
+    count_epub_images,
 )
 from book_to_skill.sanitize import sanitize_extracted_text
 
@@ -657,6 +658,17 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
                 )
         pages = count_epub_chapters(input_str)
         pages_label = "spine_items"
+        images_dropped = count_epub_images(input_str)
+        if images_dropped:
+            # Text-only extraction never writes images. The count turns a
+            # silent loss into a stated limit (issue #127): the metadata row
+            # and the run report both surface it, and the generated skill's
+            # Scope & Limits section inherits it via the Step 8 template.
+            print(
+                f"  [info] {images_dropped} image(s) in this EPUB are not "
+                "extracted — figure content is unavailable",
+                file=sys.stderr,
+            )
     elif ext == ".pdf":
         print(f"Extracting PDF: {input_str}")
         if looks_image_only(input_str):
@@ -783,6 +795,11 @@ def extract_single_file(input_path: Path, extraction_mode: str, install_mode: st
         "estimated_tokens": tokens,
         "text": text,
         **structure,
+        **(
+            {"images_dropped": images_dropped}
+            if ext == ".epub"
+            else {}
+        ),
     }
 
 
@@ -919,6 +936,7 @@ def main():
     # Consolidate metadata
     total_file_size_mb = sum(src["file_size_mb"] for src in extracted_sources)
     total_pages = sum(src["pages"] for src in extracted_sources)
+    total_images_dropped = sum(src.get("images_dropped", 0) for src in extracted_sources)
     total_chars = len(consolidated_text)
     total_words = len(consolidated_text.split())
     total_tokens = estimate_tokens(consolidated_text)
@@ -967,11 +985,21 @@ def main():
                 "estimated_tokens": src["estimated_tokens"],
                 "chapters_detected": src["chapters_detected"],
                 "chapters_method": src["chapters_method"],
-                "has_toc": src["has_toc"]
+                "has_toc": src["has_toc"],
+                **(
+                    {"images_dropped": src["images_dropped"]}
+                    if "images_dropped" in src
+                    else {}
+                )
             }
             for src in extracted_sources
         ],
         **consolidated_structure,
+        **(
+            {"images_dropped": total_images_dropped}
+            if total_images_dropped
+            else {}
+        ),
     }
     
     # encoding="utf-8" is required, not cosmetic: the payload is dumped with
@@ -1004,6 +1032,14 @@ def main():
         print(
             "   WARN    : only one section found in a document this long — chapter "
             "detection likely failed; check the headings before generating."
+        )
+    if total_images_dropped:
+        # Issue #127: EPUB extraction is text-only, so every image in the
+        # archive is dropped without a signal. Surface the loss here and in
+        # metadata.json so "confidently incomplete" becomes a stated limit.
+        print(
+            f"   WARN    : {total_images_dropped} image(s) in the source were not "
+            "extracted — figures, diagrams and charts are unavailable."
         )
     print(f"   ToC     : {'yes' if consolidated_structure['has_toc'] else 'not detected'}")
     if not consolidated_structure["has_toc"]:

--- a/tests/test_epub_images_reported.py
+++ b/tests/test_epub_images_reported.py
@@ -1,0 +1,202 @@
+"""
+EPUB images must not be dropped silently (issue #127).
+
+Text-only extraction never writes images, so the loss is invisible unless the
+pipeline counts them. These tests pin the count helper and the plumbing that
+surfaces the count in metadata.json and in the run report.
+"""
+
+import json
+import sys
+import textwrap
+import zipfile
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.parsers.epub import count_epub_images
+from book_to_skill.utils import extract_single_file, main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_epub_with_images(path: Path, images: list[str]) -> Path:
+    """EPUB whose OPF manifest declares ``images`` as image items."""
+    items = "\n".join(
+        f'<item id="img{i}" href="{name}" media-type="image/jpeg"/>'
+        for i, name in enumerate(images)
+    )
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "content.opf",
+            textwrap.dedent(
+                f"""\
+                <?xml version="1.0"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                  <metadata/>
+                  <manifest>
+                    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+                    {items}
+                  </manifest>
+                  <spine>
+                    <itemref idref="ch1"/>
+                  </spine>
+                </package>
+                """
+            ),
+        )
+        zf.writestr(
+            "chapter1.xhtml",
+            "<html><body><p>Chapter with figures referenced by caption only.</p>"
+            + "".join(f'<img src="{name}"/>' for name in images)
+            + "</body></html>",
+        )
+        for name in images:
+            zf.writestr(name, b"\xff\xd8\xff\xe0faketest")
+    return path
+
+
+def _make_epub_without_images(path: Path) -> Path:
+    """Minimal EPUB with no image items in the manifest and no image files."""
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "content.opf",
+            textwrap.dedent(
+                """\
+                <?xml version="1.0"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+                  <metadata/>
+                  <manifest>
+                    <item id="ch1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+                  </manifest>
+                  <spine>
+                    <itemref idref="ch1"/>
+                  </spine>
+                </package>
+                """
+            ),
+        )
+        zf.writestr(
+            "chapter1.xhtml",
+            "<html><body><p>Plain prose only.</p></body></html>",
+        )
+    return path
+
+
+def _make_md_file(path: Path, content: str = "# Title\n\nPlain text body.") -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# count_epub_images
+# ---------------------------------------------------------------------------
+
+
+class TestCountEpubImages:
+    def test_counts_manifest_image_items(self, tmp_path):
+        epub = _make_epub_with_images(
+            tmp_path / "fig.epub", ["fig1.jpg", "fig2.jpg", "fig3.jpg"]
+        )
+        assert count_epub_images(str(epub)) == 3
+
+    def test_counts_image_files_when_manifest_declares_none(self, tmp_path):
+        """A producer that ships images but forgets the manifest must not
+        under-report — the archive scan is the fallback."""
+        epub = tmp_path / "loose.epub"
+        with zipfile.ZipFile(epub, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("chapter1.xhtml", "<html><body><p>text</p></body></html>")
+            zf.writestr("OEBPS/fig1.png", b"\x89PNGfaketest")
+            zf.writestr("OEBPS/fig2.svg", b"<svg/>")
+        assert count_epub_images(str(epub)) == 2
+
+    def test_zero_for_imageless_epub(self, tmp_path):
+        epub = _make_epub_without_images(tmp_path / "plain.epub")
+        assert count_epub_images(str(epub)) == 0
+
+    def test_zero_on_unreadable_archive(self, tmp_path):
+        missing = tmp_path / "does-not-exist.epub"
+        assert count_epub_images(str(missing)) == 0
+
+
+# ---------------------------------------------------------------------------
+# extract_single_file plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSingleFileReportsImages:
+    def test_image_epub_reports_images_dropped(self, tmp_path):
+        epub = _make_epub_with_images(tmp_path / "fig.epub", ["fig1.jpg", "fig2.jpg"])
+        result = extract_single_file(epub, "text", "no")
+        assert result["format"] == "epub"
+        assert result["images_dropped"] == 2
+
+    def test_plain_epub_reports_zero(self, tmp_path):
+        epub = _make_epub_without_images(tmp_path / "plain.epub")
+        result = extract_single_file(epub, "text", "no")
+        assert result["images_dropped"] == 0
+
+    def test_non_epub_has_no_images_dropped_key(self, tmp_path):
+        md = _make_md_file(tmp_path / "notes.md")
+        result = extract_single_file(md, "text", "no")
+        assert "images_dropped" not in result
+
+
+# ---------------------------------------------------------------------------
+# main(): metadata.json + run report
+# ---------------------------------------------------------------------------
+
+
+class TestMainSurfacesImageLoss:
+    def _run(self, tmp_path, monkeypatch, *paths):
+        out_dir = tmp_path / "output"
+        out_text = out_dir / "full_text.txt"
+        out_meta = out_dir / "metadata.json"
+        monkeypatch.setattr(
+            "sys.argv", ["extract.py", *map(str, paths), "--install-missing", "no"]
+        )
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_DIR", out_dir)
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_TEXT", out_text)
+        monkeypatch.setattr("book_to_skill.utils.OUTPUT_META", out_meta)
+        monkeypatch.setattr("book_to_skill.utils.prepare_dependencies", lambda *a: None)
+        main()
+        return out_text, out_meta
+
+    def test_metadata_records_image_loss(self, tmp_path, monkeypatch, capsys):
+        epub = _make_epub_with_images(tmp_path / "fig.epub", ["fig1.jpg", "fig2.jpg"])
+        _, out_meta = self._run(tmp_path, monkeypatch, epub)
+
+        meta = json.loads(out_meta.read_text(encoding="utf-8"))
+        assert meta["images_dropped"] == 2
+        assert meta["sources"][0]["images_dropped"] == 2
+
+        # The loss is surfaced, not silent.
+        assert "2 image(s) in the source were not extracted" in capsys.readouterr().out
+
+    def test_metadata_omits_field_when_nothing_dropped(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        md = _make_md_file(tmp_path / "notes.md")
+        _, out_meta = self._run(tmp_path, monkeypatch, md)
+
+        meta = json.loads(out_meta.read_text(encoding="utf-8"))
+        assert "images_dropped" not in meta
+        assert "not extracted" not in capsys.readouterr().out
+
+    def test_per_source_image_count_survives_multi_source(self, tmp_path, monkeypatch):
+        epub = _make_epub_with_images(tmp_path / "fig.epub", ["fig1.jpg"])
+        md = _make_md_file(tmp_path / "notes.md")
+        _, out_meta = self._run(tmp_path, monkeypatch, epub, md)
+
+        meta = json.loads(out_meta.read_text(encoding="utf-8"))
+        assert meta["images_dropped"] == 1
+        by_name = {src["filename"]: src for src in meta["sources"]}
+        assert by_name["fig.epub"]["images_dropped"] == 1
+        assert "images_dropped" not in by_name["notes.md"]


### PR DESCRIPTION
## What

EPUB extraction is text-only, so every image in an EPUB was dropped without any signal. This PR implements the scope agreed in the issue thread: **count and report**, **warn when figure-borne content is likely**, and **say it in the generated skill**.

- **`count_epub_images()`** (`parsers/epub.py`): counts images from the OPF manifest (`media-type="image/..."` items), falling back to an archive extension scan when the manifest declares none. Degrades to 0 on error, exactly like `count_epub_chapters`.
- **Surfaced in three places**:
  1. extraction-time note to stderr (per source),
  2. the run report (`WARN: N image(s) in the source were not extracted — figures, diagrams and charts are unavailable.`),
  3. `metadata.json` as `"images_dropped": N` — per source row and consolidated at the top level (only when N > 0, so text-only sources are untouched).
- **SKILL.md**: the generated skill's Scope & Limits template now instructs the agent to state that figures in the source were not read when `metadata.json` reports `images_dropped`; the technical-mode message no longer promises Docling structure preservation for EPUB (Docling only ever runs on the PDF path).

## Why

A figure-heavy EPUB (226 images / 7.8 MB of the 8.4 MB in the issue's repro) produced a skill that was confidently incomplete — captions survived, their payload didn't, and nothing in the output said so. Per the maintainer's direction, book-to-skill is *not* going to read figures; this converts the silent loss into a stated limit without crossing that boundary.

## Validation

- 10 new tests (`tests/test_epub_images_reported.py`): manifest counting, extension fallback, zero for imageless EPUBs, unreadable-archive safety, `extract_single_file` plumbing (EPUB row, zero, non-EPUB absence), and `main()` metadata + run-report behavior (single and multi-source).
- Regression proven: with the count removed, 4/4 plumbing tests fail.
- Full suite: **486 passed, 1 skipped**; `ruff check` clean on all touched files.
- End-to-end smoke test with a 4-image EPUB: `[info] 4 image(s)...` at extraction, `WARN` line in the report, `images_dropped: 4` in metadata (top-level and per source).
