### PR TITLE
fix(extractor): resolve literal bracketed filenames instead of treating them as globs

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -533,8 +533,10 @@ def resolve_input_files(paths: list[str]) -> list[Path]:
         # Normalise "~" once, at the entry point, so both the glob branch and
         # the file/directory branch below see a real path.
         path_str = os.path.expanduser(raw_path)
-        # Check if it has glob wildcards
-        if any(char in path_str for char in ("*", "?", "[")):
+        # Check if it has glob wildcards. A path that exists literally on disk
+        # (e.g. a filename containing a literal "[" or "]") is not a glob
+        # pattern even though it contains glob metacharacters.
+        if any(char in path_str for char in ("*", "?", "[")) and not Path(path_str).exists():
             glob_matches = glob.glob(path_str, recursive=True)
             # Sort expanded glob results deterministically
             expanded = []

--- a/tests/test_glob_bracket_literal_path.py
+++ b/tests/test_glob_bracket_literal_path.py
@@ -1,0 +1,53 @@
+"""Regression test: a filename containing a literal "[" or "]" resolves as
+a literal path, not a glob character class.
+
+`resolve_input_files()` treated any path containing "*", "?", or "[" as a
+glob pattern, even when the path already exists on disk as-is. A filename
+like "The C++ Programming Language [4th Edition].pdf" was mangled by
+`glob.glob()`'s character-class syntax and matched nothing, so the CLI
+failed with "No supported files found" even though the file exists.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import resolve_input_files  # noqa: E402
+
+
+def test_literal_bracket_filename_resolves(tmp_path):
+    target = tmp_path / "The C++ Programming Language [4th Edition].pdf"
+    target.write_bytes(b"%PDF-1.4")
+
+    result = resolve_input_files([str(target)])
+
+    assert result == [target.resolve()]
+
+
+def test_literal_bracket_directory_is_walked(tmp_path):
+    books = tmp_path / "[Archive] Books"
+    books.mkdir()
+    (books / "one.md").write_text("# One", encoding="utf-8")
+
+    result = resolve_input_files([str(books)])
+
+    assert [p.name for p in result] == ["one.md"]
+
+
+def test_real_glob_patterns_still_expand(tmp_path):
+    (tmp_path / "one.md").write_text("# One", encoding="utf-8")
+    (tmp_path / "two.md").write_text("# Two", encoding="utf-8")
+
+    result = resolve_input_files([str(tmp_path / "*.md")])
+
+    assert [p.name for p in result] == ["one.md", "two.md"]
+
+
+def test_nonexistent_bracket_path_falls_through_to_glob(tmp_path):
+    missing = tmp_path / "[missing].pdf"
+
+    result = resolve_input_files([str(missing)])
+
+    assert result == []


### PR DESCRIPTION
## Summary (Required)
`resolve_input_files()` misdetects any filename containing a literal `[`, `?`, or `*` as a glob pattern, even when the path already exists on disk as-is. A book title like `The C++ Programming Language [4th Edition] - Bjarne Stroustrup.pdf` gets run through `glob.glob()`'s character-class syntax and matches nothing, so the CLI exits with "No supported files found" for a file that is right there. This fixes it by only treating a path as a glob pattern when it doesn't already exist literally.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `resolve_input_files()` in `book_to_skill/utils.py` checked `any(char in path_str for char in ("*", "?", "["))` to decide whether a path is a glob pattern, with no check for whether that path already exists literally. `glob.glob()` interprets `[...]` as a character class, so a filename containing a literal `[` (a bracketed edition/year in a book title is common) silently resolves to zero matches instead of the file itself.

## Motivation & context (Required)
Closes # n/a — hit running `book-to-skill` against a real ebook whose filename contains `[4th Edition]`; no existing issue tracked it.

## How it works (Required for anything non-trivial)
One-line fix: `if any(char in path_str for char in ("*", "?", "[")) and not Path(path_str).exists():`. If the literal path already exists on disk (file or directory), it's not a glob pattern regardless of which characters it contains, so the glob branch is skipped and the existing file/directory-walk branch below handles it correctly. Genuine glob patterns (`*.md`) still don't exist literally, so they still take the glob branch unchanged. Same escape-hatch shape as the existing tilde-expansion fix in this function (#118).

## Evidence (Required)
- **Tests:** `tests/test_glob_bracket_literal_path.py` — `test_literal_bracket_filename_resolves` (a file with `[`/`]` in its name resolves to itself), `test_literal_bracket_directory_is_walked` (same for a directory), `test_real_glob_patterns_still_expand` (`*.md` still expands as before), `test_nonexistent_bracket_path_falls_through_to_glob` (a bracketed path that doesn't exist still falls through to the pre-existing "no matches" behavior, no crash). Full suite: `pytest -q` → `476 passed, 5 skipped`.
- **Before / after:** reproduced against a real file on disk named `The C++ Programming Language [4th Edition] - Bjarne Stroustrup.pdf`:

```
File exists on disk: True

BEFORE (old glob-detection logic):
  []

AFTER (fixed resolve_input_files):
  ['...\\The C++ Programming Language [4th Edition] - Bjarne Stroustrup.pdf']
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)
CLI-only behavior change, no UI — see the before/after terminal output in Evidence above.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
