### PR TITLE
fix(extractor): fall back to literal path when bracket-containing files exist

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -533,32 +533,37 @@ def resolve_input_files(paths: list[str]) -> list[Path]:
         # Normalise "~" once, at the entry point, so both the glob branch and
         # the file/directory branch below see a real path.
         path_str = os.path.expanduser(raw_path)
-        # Check if it has glob wildcards
-        if any(char in path_str for char in ("*", "?", "[")):
+        p = Path(path_str)
+        has_glob_chars = any(char in path_str for char in ("*", "?", "["))
+
+        # A literal path that exists takes priority over glob expansion: "["
+        # is a valid character in a real filename (e.g. Zotero's default
+        # "Author - Title [year].pdf" naming), but glob.glob() treats it as
+        # opening a character class and silently matches nothing. Only
+        # expand as a glob pattern when there's no literal match.
+        if has_glob_chars and not p.exists():
             glob_matches = glob.glob(path_str, recursive=True)
             # Sort expanded glob results deterministically
             expanded = []
             for match in glob_matches:
-                p = Path(match)
-                if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS:
-                    expanded.append(p.resolve())
+                gp = Path(match)
+                if gp.is_file() and gp.suffix.lower() in SUPPORTED_EXTENSIONS:
+                    expanded.append(gp.resolve())
             expanded.sort(key=lambda x: str(x).lower())
             resolved.extend(expanded)
+        elif p.is_dir():
+            # Sort expanded directory results deterministically
+            dir_files = []
+            for root, _, files in os.walk(p):
+                for file in files:
+                    file_path = Path(root) / file
+                    if file_path.suffix.lower() in SUPPORTED_EXTENSIONS:
+                        dir_files.append(file_path.resolve())
+            dir_files.sort(key=lambda x: str(x).lower())
+            resolved.extend(dir_files)
         else:
-            p = Path(path_str)
-            if p.is_dir():
-                # Sort expanded directory results deterministically
-                dir_files = []
-                for root, _, files in os.walk(p):
-                    for file in files:
-                        file_path = Path(root) / file
-                        if file_path.suffix.lower() in SUPPORTED_EXTENSIONS:
-                            dir_files.append(file_path.resolve())
-                dir_files.sort(key=lambda x: str(x).lower())
-                resolved.extend(dir_files)
-            else:
-                # Keep even if it doesn't exist so the error check can report it
-                resolved.append(p.resolve())
+            # Keep even if it doesn't exist so the error check can report it
+            resolved.append(p.resolve())
 
     # Deduplicate while preserving insertion order (user order for explicit files)
     seen = set()

--- a/tests/test_bracket_path_literal_fallback.py
+++ b/tests/test_bracket_path_literal_fallback.py
@@ -1,0 +1,68 @@
+"""Regression tests: a literal path containing "[" or "]" resolves correctly.
+
+`resolve_input_files` routes any path containing a glob metacharacter
+("*", "?", "[") to `glob.glob()`. Before this fix, that happened
+unconditionally, even when the path was a real file that exists on disk --
+`glob.glob()` treats "[...]" as a character class, so a filename like
+Zotero's default "Author - Title [year].pdf" matched nothing and was
+silently dropped, surfacing only as a misleading "No supported files found"
+error with no indication the file was ever seen.
+
+This fix checks literal existence first and only falls back to glob
+expansion when there's no literal match -- it does not change what happens
+for a bracket path that matches nothing either way (still an empty result,
+covered below for contrast with the fixed case).
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import resolve_input_files  # noqa: E402
+
+
+def test_literal_file_with_brackets_in_name_resolves(tmp_path):
+    """The exact Zotero-style filename from the issue report."""
+    target = tmp_path / "Landon - Building Great Sentences [2013].pdf"
+    target.write_bytes(b"%PDF-1.4 fake pdf content")
+
+    result = resolve_input_files([str(target)])
+
+    assert result == [target.resolve()]
+
+
+def test_literal_directory_with_brackets_in_name_is_walked(tmp_path):
+    """A directory name containing brackets still gets walked, not glob-matched."""
+    docs = tmp_path / "notes [drafts]"
+    docs.mkdir()
+    (docs / "a.md").write_text("# A", encoding="utf-8")
+    (docs / "ignored.bin").write_text("binary", encoding="utf-8")
+
+    result = resolve_input_files([str(docs)])
+
+    assert [p.name for p in result] == ["a.md"]
+
+
+def test_real_glob_pattern_with_brackets_still_expands(tmp_path):
+    """A genuine character-class glob (no literal file of that exact name) still works."""
+    (tmp_path / "ch1.md").write_text("# Ch1", encoding="utf-8")
+    (tmp_path / "ch2.md").write_text("# Ch2", encoding="utf-8")
+    (tmp_path / "chA.md").write_text("# ChA", encoding="utf-8")
+
+    pattern = str(tmp_path / "ch[0-9].md")
+    result = resolve_input_files([pattern])
+
+    assert [p.name for p in result] == ["ch1.md", "ch2.md"]
+
+
+def test_nonexistent_bracket_path_still_returns_empty_unchanged(tmp_path):
+    """A bracket path matching nothing literally or via glob still returns []
+    -- unchanged pre-existing behavior for any non-matching glob pattern,
+    not something this fix touches (it only changes the literal-exists case)."""
+    missing = tmp_path / "Author - Title [2020].pdf"
+
+    result = resolve_input_files([str(missing)])
+
+    assert result == []


### PR DESCRIPTION
## Summary (Required)
resolve_input_files() routed any path containing "[" to glob.glob() unconditionally, before checking whether it existed literally on disk. glob.glob() treats "[...]" as a character class, so a real filename like Zotero's default "Author - Title [year].pdf" naming matched nothing and was silently dropped. Fix checks literal existence first, falling back to glob expansion only when there's no literal match.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** a literal file or directory whose name contains "[" (or "?"/"*") no longer gets silently dropped. Root cause: the glob-char check ran before any literal-existence check, so `glob.glob()` — which treats "[...]" as a character class — matched nothing and the path never reached the literal-path fallback that already existed for non-glob paths.

## Motivation & context (Required)
Closes #158

## How it works (Required for anything non-trivial)
Restructured the branch condition from "has glob chars? / else" to "(has glob chars AND doesn't exist literally)? / is a directory? / else (literal file)". A literal path that exists — file or directory — now always takes that path, regardless of whether its name happens to contain glob metacharacters. Genuine glob patterns (no literal file/dir of that exact name) fall through to `glob.glob()` exactly as before.

Also removed a duplicate `Path(path_str)` construction (previously built once in the glob-miss branch and again in the else branch; now built once at the top of the loop) and renamed the inner glob-loop variable from `p` to `gp` to stop it shadowing the outer `p`.

## Evidence (Required)
- **Tests:** new `tests/test_bracket_path_literal_fallback.py`, 4 tests — a literal bracket-named file resolves, a literal bracket-named directory is walked, a genuine bracket-glob pattern (`ch[0-9].md`) still expands correctly, and a bracket path matching nothing either way still returns `[]` unchanged (confirms this fix doesn't touch that pre-existing, out-of-scope case).
- **Before / after:**

```
Before (on upstream/master):
>>> resolve_input_files(["Landon - Building Great Sentences [2013].pdf"])
[]   # file exists on disk, silently dropped

After (this branch):
>>> resolve_input_files(["Landon - Building Great Sentences [2013].pdf"])
[WindowsPath('.../Landon - Building Great Sentences [2013].pdf')]

pytest -q:
  Before this branch (clean upstream/master): 1 failed, 470 passed, 6 skipped
  After this branch:                          1 failed, 474 passed, 6 skipped
  (+4 = the new test file; same pre-existing unrelated failure both times:
   test_prepare_output_dir_rejects_symlink, Windows symlink privilege)

ruff check . -> All checks passed!
vuln-hunter scan_diff -> No findings.
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, this PR doesn't touch SKILL.md, so this requirement does not bind
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
No `BUILDLOG.md` entry, same as PR #170 — that's my own workflow's convention, not this project's.