### PR TITLE
test: skip POSIX-only work-dir security tests on Windows

### DIFF
--- a/tests/test_output_dir_security.py
+++ b/tests/test_output_dir_security.py
@@ -6,7 +6,15 @@ import pytest
 from book_to_skill.exceptions import ExtractionError
 from book_to_skill.utils import prepare_output_dir
 
+# POSIX-only: chmod mode bits and unprivileged symlink creation don't apply on
+# Windows (os.getuid is the same platform marker the ownership test below uses).
+_posix_only = pytest.mark.skipif(
+    not hasattr(os, "getuid"),
+    reason="POSIX permission/symlink semantics not enforced on Windows",
+)
 
+
+@_posix_only
 def test_prepare_output_dir_creates_dir_with_restrictive_permissions(tmp_path):
     target = tmp_path / "work"
 
@@ -16,6 +24,7 @@ def test_prepare_output_dir_creates_dir_with_restrictive_permissions(tmp_path):
     assert stat.S_IMODE(target.stat().st_mode) == 0o700
 
 
+@_posix_only
 def test_prepare_output_dir_rejects_symlink(tmp_path):
     real_dir = tmp_path / "real"
     real_dir.mkdir()
@@ -34,6 +43,7 @@ def test_prepare_output_dir_rejects_non_directory(tmp_path):
         prepare_output_dir(target)
 
 
+@_posix_only
 def test_prepare_output_dir_tightens_permissions_on_existing_own_dir(tmp_path):
     target = tmp_path / "work"
     target.mkdir()


### PR DESCRIPTION
## Summary (Required)

Three tests in `tests/test_output_dir_security.py` (added in #141) assert POSIX
behavior — `chmod` mode bits (`0o700`) and unprivileged symlink creation — that
does not hold on Windows, so `pytest -q` fails with `assert 511 == 448` and
`WinError 1314` for any Windows contributor. This guards them with the same
platform marker the file already uses on its ownership test.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [x] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** adds `@pytest.mark.skipif(not hasattr(os, "getuid"), ...)` to
  `test_prepare_output_dir_creates_dir_with_restrictive_permissions`,
  `test_prepare_output_dir_rejects_symlink`, and
  `test_prepare_output_dir_tightens_permissions_on_existing_own_dir` — the three
  that were left unguarded. The fourth test in the file already carries this exact
  guard for the ownership check.

## Motivation & context (Required)
The security hardening in #141 is POSIX-only (`chmod`, `os.getuid` ownership,
`O_NOFOLLOW`-style symlink rejection); its tests correctly reflect that but three
weren't platform-guarded. CI runs on Linux so it stayed green, but the suite is
red on Windows — a platform the project actively supports (the UTF-8/BOM/CRLF
history). This makes `pytest -q` green for Windows contributors again.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`os.getuid` exists only on POSIX, so the guard skips these three on Windows (where
the assertions can't hold) and runs them unchanged on Linux CI. A single
module-level `_posix_only` mark keeps it DRY; no product code and no test logic
changes.

## Evidence (Required)
- **Tests:** on Windows the three now report SKIPPED and the full suite is green;
  on Linux they still run and pass (behavior unchanged).

```
# before (Windows):  3 failed, 411 passed
# after  (Windows):  411 passed, 7 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Test-only; no product behavior changes. `CHANGELOG.md` untouched — git-cliff
generates it from the conventional title (#104). No open PR touches this file.
