### PR TITLE
fix: detect chapters numbered with Kangxi-radical numerals

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -70,8 +70,12 @@ _EPUB_IMAGE_NOTICE_THRESHOLD = 5
 # those characters fell through to the whitespace-word branch, where a
 # space-less run of them counts as a single "word": the same ~1000x undercount
 # #103 fixed for the BMP, one plane up.
+# The Kangxi-radical range (U+2F00-U+2FDF) is included because some Chinese
+# ebooks render ordinary Han characters — 网 as ⽹ (U+2F79), 大 as ⼤
+# (U+2F24), 一 as ⼀ (U+2F00) — as radical forms throughout the whole text;
+# without it such a book still falls through to the whitespace-word branch.
 _CJK_RE = re.compile(
-    r"[　-〿぀-ヿ㐀-䶿一-鿿"
+    r"[⼀-⿟　-〿぀-ヿ㐀-䶿一-鿿"
     r"가-힣豈-﫿＀-￯"
     r"\U00020000-\U0003FFFF]"
 )
@@ -140,6 +144,19 @@ _CN_NUM_VALUES = {
 }
 _CN_NUM_UNITS = {"十": 10, "百": 100, "千": 1000}
 _CN_NUM_CLASS = "〇零一二两三四五六七八九十百千"
+
+# Kangxi-radical numerals → CJK ideograph numerals. Some Chinese ebooks
+# (e.g. certain e-reader platforms) encode numerals as Kangxi radicals from
+# the U+2F00 block instead of CJK unified ideographs — "第⼀章" with
+# U+2F00 (⼀) rather than U+4E00 (一). NFKC does not map these, so normalize
+# them explicitly before chapter detection. Only numerals that exist as
+# Kangxi radicals are listed (三/四/五/六/七/九 have no radical form).
+_KANGXI_NUMERAL_TRANS = {
+    0x2F00: ord("一"),  # ⼀ KANGXI RADICAL ONE
+    0x2F06: ord("二"),  # ⼆ KANGXI RADICAL TWO
+    0x2F0B: ord("八"),  # ⼋ KANGXI RADICAL EIGHT
+    0x2F17: ord("十"),  # ⼗ KANGXI RADICAL TEN
+}
 # Full-width Arabic digits (U+FF10–U+FF19) are common in Japanese typesetting,
 # e.g. "第１章". int() already parses them (str.isdigit() is True), so only the
 # regex character classes need to accept them.
@@ -391,7 +408,9 @@ def _roman_to_int(s: str) -> int | None:
 def _match_chapter_number(line: str) -> int | None:
     """Return the chapter number if the line is a genuine chapter heading,
     with no Markdown/AsciiDoc heading prefix (the caller strips it first)."""
-    s = line.strip()
+    # Normalize Kangxi-radical numerals (⼀⼆⼋⼗) to ideographs so Chinese
+    # ebooks that encode chapter numbers in the U+2F00 block are detected.
+    s = line.strip().translate(_KANGXI_NUMERAL_TRANS)
     if len(s) > 80:
         return None
     m = _EXPLICIT_CHAPTER.match(s)

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -871,6 +871,33 @@ class TestDetectStructure:
         assert _cn_numeral_to_int("不是数字") is None
         assert _cn_numeral_to_int("9999") is None  # out of 1..999 chapter range
 
+    # ── Kangxi-radical numerals (U+2F00 block) ──────────────────────────────
+    # Some Chinese ebooks (e.g. certain e-reader platforms) encode numerals as
+    # Kangxi radicals instead of CJK ideographs: 第⼀章 with U+2F00, not U+4E00.
+    # NFKC does not map these, so detection must normalize them explicitly.
+
+    def test_kangxi_radical_chapter_headings(self):
+        text = (
+            "第⼀章\n正文\n"      # U+2F00 KANGXI RADICAL ONE
+            "第⼆章\n正文\n"      # U+2F06 KANGXI RADICAL TWO
+            "第⼋章\n正文\n"      # U+2F0B KANGXI RADICAL EIGHT
+            "第⼗章\n正文\n"      # U+2F17 KANGXI RADICAL TEN
+            "第⼗⼀章\n正文\n"    # ⼗⼀ = 11
+            "第⼗⼆章\n正文\n"    # ⼗⼆ = 12
+        )
+        assert detect_structure(text)["chapters_detected"] == 6
+
+    def test_kangxi_mixed_with_ideograph_chapters(self):
+        # Real-world mix from an actual ebook: radicals for 一/二/八/十,
+        # ideographs for the rest — all 12 chapters must be found.
+        nums = ["⼀", "⼆", "三", "四", "五", "六", "七", "⼋", "九", "⼗", "⼗⼀", "⼗⼆"]
+        text = "".join(f"第{n}章\n正文。\n" for n in nums)
+        assert detect_structure(text)["chapters_detected"] == 12
+
+    def test_kangxi_radical_in_markdown_heading(self):
+        text = "## 第⼀讲\n正文\n## 第⼆讲\n正文\n"
+        assert detect_structure(text)["chapters_detected"] == 2
+
     def test_french_chapitre(self):
         assert detect_structure("Chapitre 1\nx\nChapitre 2\nx")["chapters_detected"] == 2
 
@@ -1862,6 +1889,12 @@ class TestCjkTokenEstimate:
 
     def test_empty_is_zero(self):
         assert estimate_tokens("") == 0
+
+    def test_kangxi_radicals_counted_as_cjk(self):
+        # Some Chinese ebooks render Han characters as Kangxi radicals
+        # throughout (网 as ⽹ U+2F79, 大 as ⼤ U+2F24, 一 as ⼀ U+2F00).
+        # A space-less run of them must not fall into the word branch.
+        assert estimate_tokens("⼀" * 1500) == 1000
 
 
 class TestPdfLibsCleanup:


### PR DESCRIPTION
Some Chinese ebooks encode chapter numerals as Kangxi radicals from the U+2F00 block instead of CJK unified ideographs — '第⼀章' with U+2F00 (⼀) rather than U+4E00 (一). NFKC does not map these, so _CN_CHAPTER never matches and the chapters are silently dropped from detect_structure().

Found on a real 287-page ebook from a Chinese e-reader platform: only 6 of 12 chapters were detected (三/四/五/六/七/九 — the numerals that have no radical form); 一/二/八/十/十一/十二 were all missed.

Fix: translate ⼀⼆⼋⼗ (the only numerals that exist as Kangxi radicals) to ideographs at the top of _match_chapter_number(), so every matcher — CN, MD-CN, and the Latin/Thai/Korean paths — sees normalized text.

Also add the Kangxi-radical range (U+2F00-U+2FDF) to _CJK_RE: ebooks with this encoding render ordinary Han characters as radicals throughout (网 as ⽹, 大 as ⼤), so they should be counted as CJK, not fall through to the whitespace-word branch.

Validated on the real book: 6 -> 12 chapters detected. 4 new regression tests; full suite 485 passed.

<!--
PR title: use Conventional Commits, e.g. `fix(extractor): scan full text`, `feat(cli): ...`.
Fill EVERY section marked (Required). Sections marked (Optional) can be deleted if not applicable.
A PR that leaves Required sections empty or unchecked will be asked to complete them before review.
-->

## Summary (Required)
<!-- In 1-3 sentences and plain language: what does this PR do? Someone skimming
     should understand the change without reading the diff. -->


## Type of change (Required)
<!-- Mark all that apply with [x]. -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
<!-- Be specific. Use the lines that apply, delete the rest. -->
- **Fixes:** <!-- the exact wrong behavior, and the root cause -->
- **Improves:** <!-- what gets better, and by how much (numbers, not adjectives) -->
- **Adds:** <!-- the new capability and who it is for -->

## Motivation & context (Required)
<!-- Why is this needed? What problem or use case drives it? -->
Closes #<!-- issue number, or "n/a" with a one-line reason if there is no issue -->

## How it works (Required for anything non-trivial)
<!-- The approach: key decision(s), why this way, any alternative you rejected.
     For a one-line fix, "see diff" is fine. -->


## Evidence (Required)
<!-- Proof, not claims. This project's rule is "measure, don't assert". -->
- **Tests:** <!-- which tests you added/changed and what they assert -->
- **Before / after:** <!-- terminal output, repro of the bug, or measured numbers.
     For performance: a `tools/discovery_tax.py` number or a timed before/after.
     For a bug fix: the failing input and the now-correct output. -->

```
<!-- paste the before/after terminal output here -->
```

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)
<!-- Drag in an image: the bug vs the fix, the generated skill, the dashboard, etc.
     A picture of broken-vs-fixed is the fastest way to get a PR reviewed.
     Delete this section only for invisible internals. -->


## Checklist (Required — all must be checked)
- [ ] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [ ] Branch is rebased on the latest `master` and has no merge conflicts
- [ ] Tests added/updated for behavior changes
- [ ] `pytest -q` is green on a clean checkout
- [ ] `ruff check .` is clean
- [ ] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [ ] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [ ] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)
<!-- What breaks, who is affected, and the migration path. Delete if none. -->

## Notes for reviewers (Optional)
<!-- Anything that helps review: areas you are unsure about, follow-ups you left
     out on purpose, things explicitly out of scope. -->
