### PR TITLE
fix(extractor): reject punctuation-only setext titles, matching the ATX branch

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -388,6 +388,13 @@ def _structural_chapter_count(text: str) -> int:
             and prev
             and not _SETEXT_UNDERLINE.match(prev)
             and len(s) >= len(prev)
+            # A title made only of punctuation is never a chapter. Two thematic
+            # breaks in a row ("***" over "---"), an ASCII box rule, a row of
+            # dots, or a table border sitting above an underline all reach this
+            # point. The ATX branch below already rejects them with the same
+            # test; the setext branch had no equivalent, so the identical string
+            # counted as a heading here and not there.
+            and re.search(r"\w", prev)
         ):
             depth = 1 if s[0] == "=" else 2
             levels.setdefault(depth, set()).add(prev.lower())

--- a/tests/test_setext_punctuation_guard.py
+++ b/tests/test_setext_punctuation_guard.py
@@ -1,0 +1,131 @@
+r"""A setext title made only of punctuation is not a chapter heading.
+
+`_structural_chapter_count` has two heading branches. The ATX branch rejects a
+title with no word character — that is what keeps a `=====` table border or a
+`***` thematic break from being counted:
+
+    if title and re.search(r"\w", title):
+
+The setext branch had no equivalent. So the *identical string* was rejected as
+`## ***` and accepted as `***` sitting above a row of `-`. Two thematic breaks
+in a row, an ASCII box rule, a row of dots, or a punctuation table border above
+an underline all minted a phantom heading.
+
+The function's own docstring claims "thematic breaks, table borders, and
+front-matter `---` do not match", which was only true while the underline was
+shorter than the line above it.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.utils import _structural_chapter_count
+
+# Two real sections in every fixture below, so any count above 2 is a phantom.
+# `___` is deliberately NOT here: "_" is a word character to `\w`, so it is kept
+# by both branches. See TestSharedUnderscoreGap.
+PUNCTUATION_TITLES = ["***", "+-----+", ".......", "|||||", "* * *", "###", "-- --"]
+
+
+def _with_setext(title: str) -> str:
+    """A book whose middle holds `title` underlined by an equally long rule."""
+    return (
+        "# Book\n\n## Alpha\na\n\n"
+        f"{title}\n{'-' * max(3, len(title))}\n\n"
+        "## Beta\nb\n"
+    )
+
+
+def _with_atx(title: str) -> str:
+    return f"# Book\n\n## Alpha\na\n\n## {title}\n\n## Beta\nb\n"
+
+
+class TestPunctuationOnlySetextTitleRejected:
+    @pytest.mark.parametrize("title", PUNCTUATION_TITLES)
+    def test_no_phantom_heading(self, title):
+        assert _structural_chapter_count(_with_setext(title)) == 2
+
+    @pytest.mark.parametrize("title", PUNCTUATION_TITLES)
+    def test_matches_the_atx_branch(self, title):
+        """The same string must be judged the same way by both branches."""
+        assert _structural_chapter_count(_with_setext(title)) == (
+            _structural_chapter_count(_with_atx(title))
+        )
+
+    def test_two_thematic_breaks_in_a_row(self):
+        """`***` then `---` are both valid thematic breaks, not a heading."""
+        text = "# Book\n\n## Alpha\na\n\n***\n---\n\n## Beta\nb\n"
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_underline_longer_than_the_punctuation_run(self):
+        """The length guard does not help when the rule is the longer line."""
+        text = "# Book\n\n## Alpha\na\n\n***\n" + "-" * 40 + "\n\n## Beta\nb\n"
+
+        assert _structural_chapter_count(text) == 2
+
+
+class TestRealSetextHeadingsStillCounted:
+    """The branch must keep doing its job."""
+
+    def test_word_titles_still_counted(self):
+        text = "Alpha\n=====\n\ntext\n\nBeta\n====\n\ntext\n"
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_mixed_punctuation_and_words_is_kept(self):
+        """A word character anywhere is enough — titles carry punctuation."""
+        text = (
+            "Chapter One -- Beginnings\n-------------------------\n\ntext\n\n"
+            "Chapter Two -- Endings\n----------------------\n\ntext\n"
+        )
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_title_with_digits_and_punctuation(self):
+        text = "1.2 Scope\n---------\n\ntext\n\n1.3 Limits\n----------\n\ntext\n"
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_cjk_setext_title_counted(self):
+        r"""`\w` is Unicode-aware, so a CJK title is not punctuation."""
+        text = "\u7b2c\u4e00\u7ae0\n====\n\ntext\n\n\u7b2c\u4e8c\u7ae0\n====\n\ntext\n"
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_snake_case_title_kept(self):
+        assert _structural_chapter_count(_with_setext("snake_case_title")) == 3
+
+
+class TestSharedUnderscoreGap:
+    """`___` is a thematic break but `_` is a word character, so both branches
+    still count it. Pre-existing and identical on either side — pinned here so
+    the parity this PR establishes is visible, and so closing the gap later is a
+    deliberate change to BOTH branches rather than a silent divergence.
+    """
+
+    def test_underscore_rule_still_counted_by_both_branches(self):
+        setext = _structural_chapter_count(_with_setext("___"))
+        atx = _structural_chapter_count(_with_atx("___"))
+
+        assert setext == atx == 3
+
+
+class TestUnaffectedBehaviour:
+    def test_document_with_no_headings(self):
+        assert _structural_chapter_count("just prose\nmore prose\n") == 0
+
+    def test_setext_still_needs_a_long_enough_underline(self):
+        text = "# Book\n\n## Alpha\na\n\nA long paragraph line here.\n---\n\n## Beta\nb\n"
+
+        assert _structural_chapter_count(text) == 2
+
+    def test_blank_line_above_underline_is_not_a_heading(self):
+        text = "# Book\n\n## Alpha\na\n\n\n-------\n\n## Beta\nb\n"
+
+        assert _structural_chapter_count(text) == 2


### PR DESCRIPTION
> Follow-up to your review on #135: you traced the over-count there to the setext branch having no guard, and I asked whether to give it the ATX reject-list as a separate PR. This is that PR, scoped to the unambiguous half only.

## Summary

`_structural_chapter_count` has two heading branches. The ATX branch rejects a title with no word character — that is what stops a `=====` table border or a `***` thematic break being counted. The setext branch had no equivalent, so the **identical string** was rejected as `## ***` and accepted as `***` sitting above a row of `-`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** a punctuation-only line above a setext underline was counted as a chapter heading. Two thematic breaks in a row (`***` over `---`) produced a heading titled `***`.
- **Improves:** the two branches now judge the same string the same way — asserted directly, not just implied.

## Motivation & context

Closes n/a — surfaced by your analysis on #135.

The docstring already promises this behaviour: *"thematic breaks, table borders, and front-matter `---` do not match"*. That was only true while the underline was **shorter** than the line above it, because `len(s) >= len(prev)` was doing the work. A long rule defeats it:

```
paragraph + SHORT "---" rule   -> 2   (correct)
paragraph + LONG  "-----" rule -> 3   (length guard defeated)
```

So this is a documented-versus-actual mismatch, not a new rule.

## How it works

One condition added to the setext branch, the same test the ATX branch already applies:

```python
and re.search(r"\w", prev)
```

## Evidence

Two real sections in every fixture, so any count above 2 is a phantom:

```
title       setext before   setext after   ATX (unchanged)
***               3              2          2
+-----+           3              2          2
.......           3              2          2
|||||             3              2          2
* * *             3              2          2
###               3              2          2
-- --             3              2          2
```

**Tests** — new `tests/test_setext_punctuation_guard.py`, 25 cases in four groups:

- `TestPunctuationOnlySetextTitleRejected` — the seven titles above (parametrized), each also asserted **equal to the ATX result** for the same string, plus two thematic breaks in a row and the long-underline case.
- `TestRealSetextHeadingsStillCounted` — word titles, titles carrying punctuation (`Chapter One -- Beginnings`), digit-and-dot titles (`1.2 Scope`), a CJK title (`\w` is Unicode-aware), and `snake_case_title`.
- `TestSharedUnderscoreGap` — see below.
- `TestUnaffectedBehaviour` — no-heading documents, the length guard, blank line above an underline.

RED against `master`: **16 failed, 9 passed**. GREEN:

```
$ python -m pytest tests/ -q
512 passed, 11 skipped in 5.21s

$ ruff check .
All checks passed!
```

## Screenshots / output

The before/after table above is the output; this is a count with nothing visual to capture.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

**Deliberately NOT fixed — the ambiguous half.** A title *with* word characters still counts: `Options` above `-------`, and a plain-text table header like `Name   Value` above `------------`. Those are indistinguishable from a real setext heading by shape alone, and you already accepted that cost on #135. I did not want to smuggle a heuristic in behind a consistency fix.

**One shared gap I found and left alone.** `___` is a valid thematic break, but `_` **is** a word character to `\w` — so `___` is counted by *both* branches, before and after this PR:

```
"___" as setext -> 3      "## ___" as ATX -> 3
```

I could have used `[^\W_]` instead and killed it, but that would make setext *stricter* than ATX and re-open the divergence this PR closes. Fixing it properly means changing both branches, which is a separate decision — so I pinned the parity in `TestSharedUnderscoreGap` instead, with a comment saying as much. Happy to send that follow-up if you want it.

**Unrelated, still open from earlier:** my #71 comment about `validate_docx_xml_safety` decoding every archive member five times is still unanswered. That PR looks stalled — say the word and I will send it as a standalone PR against `master` instead.
