### PR TITLE
fix(validate_skill): parse a SKILL.md saved with a UTF-8 BOM

### DIFF
--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -1,0 +1,28 @@
+"""tools/validate_skill.py — frontmatter parsing is BOM-tolerant."""
+
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "validate_skill", Path(__file__).resolve().parent.parent / "tools" / "validate_skill.py"
+)
+validate_skill = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(validate_skill)
+
+_SKILL = "---\nname: my-skill\ndescription: A test skill.\n---\n\n# Body\n"
+
+
+def test_audit_accepts_skill_without_bom(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_bytes(_SKILL.encode("utf-8"))
+    errors, _ = validate_skill.audit(str(p))
+    assert errors == []
+
+
+def test_audit_accepts_skill_with_utf8_bom(tmp_path):
+    # A SKILL.md saved with a UTF-8 BOM used to fail with "no valid YAML
+    # frontmatter" because the BOM broke text.startswith("---").
+    p = tmp_path / "SKILL.md"
+    p.write_bytes(b"\xef\xbb\xbf" + _SKILL.encode("utf-8"))
+    errors, _ = validate_skill.audit(str(p))
+    assert errors == []

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -127,7 +127,9 @@ def tool_base(entry):
 def audit(path, lens="claude"):
     rules = LENSES[lens]
     label = rules["label"]
-    text = Path(path).read_text(encoding="utf-8")
+    # utf-8-sig so a SKILL.md saved with a UTF-8 BOM still parses — otherwise the
+    # leading ﻿ makes text.startswith("---") false and frontmatter is missed.
+    text = Path(path).read_text(encoding="utf-8-sig")
     fm, body = parse_frontmatter(text)
     errors, warns = [], []
     if fm is None:


### PR DESCRIPTION
## Summary (Required)

`tools/validate_skill.py` reads the file with `encoding="utf-8"`, so a `SKILL.md`
saved with a UTF-8 BOM keeps a leading `﻿` and fails `text.startswith("---")`
— the auditor then reports "no valid YAML frontmatter" for an otherwise valid
skill. Reading with `utf-8-sig` fixes it.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** `audit()` in `tools/validate_skill.py` now reads with
  `encoding="utf-8-sig"` instead of `"utf-8"`, so a BOM-prefixed `SKILL.md` parses
  correctly. `utf-8-sig` decodes both BOM and non-BOM files, so no-BOM skills are
  unaffected.

## Motivation & context (Required)
`validate_skill.py` is a standalone auditor a user can run on any `SKILL.md`.
Windows editors and some generators emit a UTF-8 BOM; such a file was reported as
having no frontmatter, which is misleading. Same encoding-robustness the extractor
already applies when reading text.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
One-line change (`utf-8` → `utf-8-sig`) plus a comment. The BOM is stripped on
read, so `parse_frontmatter` sees `---` at position 0.

## Evidence (Required)
- **Tests:** new `tests/test_validate_skill.py` — `audit()` returns no errors for a
  valid `SKILL.md` both without a BOM and with a UTF-8 BOM (the latter previously
  errored with "no valid YAML frontmatter").

```
$ pytest -q
489 passed, 11 skipped
$ python3 tools/validate_skill.py SKILL.md
✓ SKILL.md [Claude Code]: no Claude Code-breaking issues (1 warning(s))
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
First tests for `validate_skill.py`. `CHANGELOG.md` untouched — git-cliff generates
it from the conventional title (#104). No open PR touches this file.
