### PR TITLE
fix(sanitize): strip deprecated and interlinear-annotation format controls

### DIFF
--- a/book_to_skill/sanitize.py
+++ b/book_to_skill/sanitize.py
@@ -57,10 +57,27 @@ _INVISIBLE_LETTER_CODEPOINTS = frozenset({
     0xFFA0,  # HALFWIDTH HANGUL FILLER
 })
 
+# 5. Deprecated / annotation format controls. All category Cf,
+#    Default_Ignorable, and render as nothing — the same invisible
+#    format-control shape as group 1, just blocks the original list missed.
+#    None has any use in extracted book prose.
+_ANNOTATION_FORMAT_CODEPOINTS = frozenset({
+    0x206A,  # INHIBIT SYMMETRIC SWAPPING
+    0x206B,  # ACTIVATE SYMMETRIC SWAPPING
+    0x206C,  # INHIBIT ARABIC FORM SHAPING
+    0x206D,  # ACTIVATE ARABIC FORM SHAPING
+    0x206E,  # NATIONAL DIGIT SHAPES
+    0x206F,  # NOMINAL DIGIT SHAPES
+    0xFFF9,  # INTERLINEAR ANNOTATION ANCHOR
+    0xFFFA,  # INTERLINEAR ANNOTATION SEPARATOR
+    0xFFFB,  # INTERLINEAR ANNOTATION TERMINATOR
+})
+
 _INVISIBLE_CODEPOINTS = (
     _ZERO_WIDTH_CODEPOINTS
     | _BIDI_CONTROL_CODEPOINTS
     | _INVISIBLE_LETTER_CODEPOINTS
+    | _ANNOTATION_FORMAT_CODEPOINTS
 )
 
 # 4. The Unicode tag block. Originally language tags, now used to smuggle an

--- a/tests/test_sanitize_annotation_controls.py
+++ b/tests/test_sanitize_annotation_controls.py
@@ -1,0 +1,40 @@
+"""Deprecated / interlinear-annotation format controls are stripped too.
+
+These are category Cf, Default_Ignorable code points that render as nothing —
+the same invisible format-control shape as the zero-width set — but the original
+blocklist missed them, so they passed straight through the extraction scrub (and,
+because the scanner shares is_invisible_codepoint, went unflagged there too).
+"""
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.sanitize import is_invisible_codepoint, sanitize_extracted_text
+
+# U+206A-206F (deprecated format controls) + U+FFF9-FFFB (interlinear annotation).
+ANNOTATION_CONTROLS = "".join(
+    chr(cp) for cp in [*range(0x206A, 0x2070), 0xFFF9, 0xFFFA, 0xFFFB]
+)
+
+
+def test_all_annotation_controls_are_invisible():
+    assert all(is_invisible_codepoint(ord(c)) for c in ANNOTATION_CONTROLS)
+
+
+def test_annotation_controls_are_stripped_and_counted():
+    text = f"study{ANNOTATION_CONTROLS}advice"
+    cleaned, removed = sanitize_extracted_text(text)
+    assert cleaned == "studyadvice"
+    assert removed == len(ANNOTATION_CONTROLS)
+
+
+def test_visible_lookalikes_are_kept():
+    # Braille blank (U+2800) and a musical symbol are real So characters, not
+    # invisible format controls — they must survive.
+    text = "a⠀b\U0001D159c"
+    cleaned, removed = sanitize_extracted_text(text)
+    assert cleaned == text
+    assert removed == 0


### PR DESCRIPTION
## Summary (Required)

The invisible-code-point scrub in `book_to_skill/sanitize.py` missed nine
`Cf` / Default_Ignorable format controls that render as nothing — the same
invisible-format-control attack shape it already blocks (group 1). They passed
straight through the extraction scrub, and since the generated-skill scanner
shares `is_invisible_codepoint`, went unflagged there too. This adds them.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [x] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `U+206A–U+206F` (deprecated format controls: symmetric-swapping,
  Arabic-form-shaping, digit-shapes) and `U+FFF9–U+FFFB` (interlinear annotation
  anchor/separator/terminator) to the sanitizer's invisible-code-point blocklist,
  as a new commented group. Because `is_invisible_codepoint` is shared, this
  hardens **both** the extraction scrub and the generated-skill scanner in one
  change.

## Motivation & context (Required)
These are all category `Cf`, `Default_Ignorable`, and render as nothing, with no
legitimate use in extracted book prose — the exact "invisible spacer / format
control" vector the file's comments describe (hidden text a human reviewer can't
see but the model reads). The original list simply didn't include them; this is
the same "a code point was missed" gap as the CJK-plane fixes (#136), one layer up.
Conservative: I deliberately did **not** add visible `So` characters like braille
blank (U+2800) or musical symbols, which are real content.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
A new `_ANNOTATION_FORMAT_CODEPOINTS` frozenset is unioned into
`_INVISIBLE_CODEPOINTS`, so `is_invisible_codepoint` and `sanitize_extracted_text`
strip and count them like the existing sets. No behavior change for any visible
character.

## Evidence (Required)
- **Tests:** new `tests/test_sanitize_annotation_controls.py` — all nine are
  reported invisible and stripped (with the removal count), and visible
  look-alikes (braille blank U+2800, a musical symbol) are kept.

```
$ pytest -q
490 passed, 11 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the file's curated-by-attack-shape design (a commented group with a
per-code-point reason). `CHANGELOG.md` untouched — git-cliff generates it from the
conventional title (#104). No open PR touches `sanitize.py`.
