### PR TITLE
fix(config): give each run its own workdir so concurrent extractions cannot clobber each other

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -163,17 +163,21 @@ Before extraction, the script checks optional Python packages needed for the det
 
 **Tip — preflight the environment:** run `"$PYTHON_BIN" "$SCRIPT_PATH" --check` to print a per-format report of which extractors are installed and the exact command to install whatever is missing, without processing any file. Useful when a user reports a setup or quality problem.
 
-This creates:
-- `<tempdir>/book_skill_work/full_text.txt` — combined extracted text of all sources with clear visually demarcated boundaries.
-- `<tempdir>/book_skill_work/metadata.json` — overall combined size, words, pages, token counts, dropped EPUB image counts, and a detailed list of individual processed `sources`.
+This creates a **per-run** work directory — `<tempdir>/book_skill_work-<pid>/` by default, or exactly the path you set in `BOOK_SKILL_WORKDIR` — containing:
+- `full_text.txt` — combined extracted text of all sources with clear visually demarcated boundaries.
+- `metadata.json` — overall combined size, words, pages, token counts, dropped EPUB image counts, the resolved `workdir`, and a detailed list of individual processed `sources`.
 
-Read `<tempdir>/book_skill_work/metadata.json` to inspect the results.
+The run prints all three paths on completion (`Workdir ->`, `Text ->`, `Meta ->`). **Take the paths from that output (or from `metadata.json`'s own `workdir` field) rather than assuming a fixed location** — the directory name differs per run so that concurrent extractions on one machine cannot overwrite each other's results.
+
+Read that run's `metadata.json` to inspect the results.
+
+**Always confirm the extraction is the document you asked for** before generating anything: check `filename` / `source_file` in `metadata.json`, or the `SOURCE:` header on the first line of `full_text.txt`. If you are waiting on a background run, wait on *its* specific workdir — polling a shared path can surface a different run's output.
 
 ---
 
 ## Step 2.5 — Pre-flight cost estimate
 
-Read `<tempdir>/book_skill_work/metadata.json` and present the user with an estimate **before doing any generation**:
+Read this run's `metadata.json` (the `Meta ->` path from the extraction output) and present the user with an estimate **before doing any generation**:
 
 ```
 📖 Sources detected: <total_sources> source(s)
@@ -542,17 +546,34 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
 
-"$PYTHON_BIN" - <<'PY'
-import os
+Remove **the work directory this run actually used** — the `Workdir ->` path from the
+extraction output, which is also stored as `workdir` in `metadata.json`. Never delete a
+directory you did not create: another extraction may be running beside yours.
+
+```bash
+# WORKDIR is the path this run reported; quote it in case of spaces.
+rm -rf "$WORKDIR"
+```
+
+Equivalently, if you still have the metadata file:
+
+```bash
+"$PYTHON_BIN" - "$WORKDIR_METADATA_JSON" <<'PY'
+import json
 import shutil
-import tempfile
+import sys
 from pathlib import Path
-shutil.rmtree(
-    os.environ.get("BOOK_SKILL_WORKDIR", Path(tempfile.gettempdir()) / "book_skill_work"),
-    ignore_errors=True,
-)
+
+meta_path = Path(sys.argv[1])
+workdir = json.loads(meta_path.read_text(encoding="utf-8")).get("workdir")
+if workdir:
+    shutil.rmtree(workdir, ignore_errors=True)
 PY
 ```
+
+Older copies of this file removed a single fixed `book_skill_work` directory. That path is
+no longer used, so such a cleanup is now a harmless no-op rather than something that could
+delete a concurrent run's output.
 
 Then report to the user:
 
@@ -653,7 +674,7 @@ Read and parse the existing skill's files:
 - Read `$SKILLS_HOME/<skill_name>/glossary.md`, `$SKILLS_HOME/<skill_name>/patterns.md`, and `$SKILLS_HOME/<skill_name>/cheatsheet.md` to see what terms and frameworks are already indexed.
 
 ### 2. Match Content & Identify Revisions vs. Additions
-Analyze the new extracted text in `<tempdir>/book_skill_work/full_text.txt` to identify if the new content represents:
+Analyze the new extracted text in this run's `full_text.txt` (the `Text ->` path from the extraction output) to identify if the new content represents:
 - **Updates/Revisions to existing chapters**: If a section of the new content directly updates or expands an existing chapter's topic, read the existing chapter file, merge the new details into it, and rewrite the file.
 - **New additions**: If the content introduces new chapters, papers, or separate sections, create **new chapter summary files** under `chapters/`. Start numbering these files after the highest existing chapter number (e.g. if the existing chapters stop at `ch12`, create `ch13-*.md`, `ch14-*.md`, etc.).
 

--- a/book_to_skill/config.py
+++ b/book_to_skill/config.py
@@ -2,12 +2,29 @@ import os
 import tempfile
 from pathlib import Path
 
-OUTPUT_DIR = Path(
-    os.environ.get(
-        "BOOK_SKILL_WORKDIR",
-        str(Path(tempfile.gettempdir()) / "book_skill_work"),
-    )
-)
+def default_output_dir() -> Path:
+    """Per-run work directory, unique to this process.
+
+    The PID is part of the name so two extractions running at the same time
+    cannot overwrite each other. Every run previously shared one fixed path
+    ($TMPDIR/book_skill_work), so whichever run finished second silently
+    replaced the first run's full_text.txt and metadata.json — and an agent
+    polling for metadata.json could pick up a *different document's*
+    extraction without any error, then build a skill from the wrong source.
+
+    The name is deliberately a sibling of the old fixed path rather than a
+    child of it. An older cleanup routine that removes "book_skill_work"
+    then simply finds nothing, instead of deleting a live concurrent run.
+
+    BOOK_SKILL_WORKDIR still overrides this completely.
+    """
+    return Path(tempfile.gettempdir()) / f"book_skill_work-{os.getpid()}"
+
+
+# `or` rather than a get() default: BOOK_SKILL_WORKDIR set to an empty string
+# would otherwise become Path(""), i.e. the current directory — which the run
+# would then populate and chmod to 0700.
+OUTPUT_DIR = Path(os.environ.get("BOOK_SKILL_WORKDIR") or default_output_dir())
 OUTPUT_TEXT = OUTPUT_DIR / "full_text.txt"
 OUTPUT_META = OUTPUT_DIR / "metadata.json"
 

--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -1059,6 +1059,9 @@ def main():
         "estimated_tokens": total_tokens,
         "estimated_tokens_human": f"~{total_tokens // 1000}K",
         "images_dropped": total_images_dropped,
+        # Self-describing so a consumer can clean up exactly the directory this
+        # run created, without having to reconstruct the per-run default path.
+        "workdir": str(OUTPUT_DIR),
         "output_text": str(OUTPUT_TEXT),
         "total_sources": len(extracted_sources),
         "sources": [
@@ -1120,8 +1123,9 @@ def main():
             "   WARN    : No table of contents detected — chapter mapping in Step 3 "
             "will rely on heading scan only, which may miss or duplicate sections."
         )
-    print(f"\n   Text -> {OUTPUT_TEXT}")
-    print(f"   Meta -> {OUTPUT_META}")
+    print(f"\n   Workdir -> {OUTPUT_DIR}")
+    print(f"   Text    -> {OUTPUT_TEXT}")
+    print(f"   Meta    -> {OUTPUT_META}")
     if errors:
         print(f"\n   WARNING: {len(errors)} source(s) skipped due to errors:")
         for path, err in errors:

--- a/tests/test_per_run_workdir.py
+++ b/tests/test_per_run_workdir.py
@@ -1,0 +1,99 @@
+"""Regression tests: each run gets its own work directory.
+
+Every extraction used to write to one fixed path ($TMPDIR/book_skill_work),
+so two runs started at the same time — routine when several agent sessions
+share a machine — silently overwrote each other's full_text.txt and
+metadata.json. Nothing errored: the run that finished second simply replaced
+the first one's output, and an agent waiting on metadata.json could pick up a
+*different document's* extraction and build a skill from the wrong source.
+
+The default now carries the PID. BOOK_SKILL_WORKDIR still overrides it, and an
+empty BOOK_SKILL_WORKDIR must not collapse to Path("") — i.e. the current
+directory, which the run would then populate and chmod to 0700.
+"""
+
+import importlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT_DIR))
+
+from book_to_skill.config import default_output_dir  # noqa: E402
+
+
+def _reimport_config(monkeypatch, workdir_env):
+    """Re-evaluate config.py's module-level OUTPUT_DIR under a given env."""
+    if workdir_env is None:
+        monkeypatch.delenv("BOOK_SKILL_WORKDIR", raising=False)
+    else:
+        monkeypatch.setenv("BOOK_SKILL_WORKDIR", workdir_env)
+    import book_to_skill.config as config
+
+    return importlib.reload(config)
+
+
+def test_default_workdir_is_unique_per_process(monkeypatch):
+    """Two concurrent runs must not share a directory."""
+    monkeypatch.setattr(os, "getpid", lambda: 1111)
+    first = default_output_dir()
+    monkeypatch.setattr(os, "getpid", lambda: 2222)
+    second = default_output_dir()
+
+    assert first != second
+    assert "1111" in first.name
+    assert "2222" in second.name
+
+
+def test_default_workdir_is_sibling_not_child_of_legacy_path(monkeypatch):
+    """An older cleanup that removes "book_skill_work" must not hit a live run.
+
+    Nesting under the legacy directory would mean a stale cleanup routine
+    deleting a concurrent extraction's output, which is worse than the bug
+    being fixed. The per-run directory is therefore a sibling.
+    """
+    monkeypatch.setattr(os, "getpid", lambda: 4242)
+    legacy = Path(tempfile.gettempdir()) / "book_skill_work"
+
+    assert legacy not in default_output_dir().parents
+
+
+def test_default_workdir_lives_in_tempdir(monkeypatch):
+    monkeypatch.setattr(os, "getpid", lambda: 4242)
+
+    assert default_output_dir().parent == Path(tempfile.gettempdir())
+
+
+def test_env_override_wins(monkeypatch, tmp_path):
+    chosen = tmp_path / "private-workdir"
+    config = _reimport_config(monkeypatch, str(chosen))
+
+    assert config.OUTPUT_DIR == chosen
+    assert config.OUTPUT_TEXT == chosen / "full_text.txt"
+    assert config.OUTPUT_META == chosen / "metadata.json"
+
+
+def test_empty_env_override_does_not_become_cwd(monkeypatch):
+    """BOOK_SKILL_WORKDIR="" must fall back, not resolve to Path("")."""
+    config = _reimport_config(monkeypatch, "")
+
+    assert config.OUTPUT_DIR != Path("")
+    assert config.OUTPUT_DIR != Path.cwd()
+    assert config.OUTPUT_DIR.parent == Path(tempfile.gettempdir())
+
+
+def test_unset_env_uses_per_run_default(monkeypatch):
+    config = _reimport_config(monkeypatch, None)
+
+    assert config.OUTPUT_DIR.name.startswith("book_skill_work-")
+    assert str(os.getpid()) in config.OUTPUT_DIR.name
+
+
+def test_config_restored_for_other_tests(monkeypatch):
+    """Reloading config in this module must not leak into the rest of the suite."""
+    config = _reimport_config(monkeypatch, None)
+
+    assert config.OUTPUT_TEXT.parent == config.OUTPUT_DIR
+    assert config.OUTPUT_META.parent == config.OUTPUT_DIR


### PR DESCRIPTION
> **Prior art: this is the same defect [#126](https://github.com/virgiliojr94/book-to-skill/pull/126) diagnosed** ("Concurrent runs silently corrupt each other"). Credit to @julianobarbosa for finding it and for the reasoning that silent corruption is worse than a crash — I hit this independently and reached the same conclusion before finding that PR. This offers a **different, smaller fix for the same problem**, and the two are complementary rather than competing (see *How it works*). Happy to close this if you'd rather take #126's approach whole.

## Summary (Required)

Every extraction defaulted to one fixed work directory, so two runs in flight silently overwrote each other's `full_text.txt` and `metadata.json` — with no error, and with `metadata.json` then describing text it did not produce. The default is now per-run (`book_skill_work-<pid>`), so concurrent extractions never share a directory.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** two concurrent extractions clobbering each other. Root cause: `OUTPUT_DIR` defaulted to a single fixed `$TMPDIR/book_skill_work` shared by every run. The loser's output is replaced with no error, so an agent waiting on `metadata.json` can pick up **a different document's extraction** and build a skill from the wrong source.
- **Fixes:** a latent case beside it — `BOOK_SKILL_WORKDIR=""` resolved to `Path("")`, i.e. the **current directory**, which `prepare_output_dir()` then populated and `chmod`ed to `0700`.
- **Fixes:** `SKILL.md`'s cleanup step, which pointed at the retired fixed path and would otherwise have silently stopped removing anything.
- **Improves:** `metadata.json` gains a `workdir` field and the completion banner prints the directory, so a consumer can clean up exactly what the run created instead of reconstructing a path.

## Motivation & context (Required)

Closes n/a — no filed issue; found in practice, and independently reported in #126.

Two agent sessions on one machine converted different books at the same time. The second run replaced the first's `full_text.txt` and `metadata.json` in the shared directory. The waiting session saw `metadata.json` appear, read it, and began generating — from the wrong book. It was caught only because the metadata named a different `source_file`. Nothing in the tool's output indicated a problem.

Multiple concurrent sessions on one machine is a normal way to use this converter, which is what makes the silence expensive: the failure is invisible until you notice the finished skill describes the wrong document.

## How it works (Required for anything non-trivial)

`default_output_dir()` puts the PID in the directory name. `BOOK_SKILL_WORKDIR` still overrides it completely, and the empty-string case now falls back instead of resolving to the CWD.

**Sibling, not child.** The per-run directory is `book_skill_work-<pid>`, deliberately *beside* the old path rather than `book_skill_work/<pid>/` underneath it. Nesting would mean any older cleanup routine doing `rmtree("book_skill_work")` — including the one shipped in previous `SKILL.md` versions — deleting a **live concurrent run's** directory, which is worse than the bug being fixed. As a sibling, stale cleanup code finds nothing and no-ops. It fails safe across versions.

**How this relates to #126.** #126 keeps the shared path and adds `claim_workdir()`, a PID lock that refuses to start when another live run holds the directory, pointing the user at `BOOK_SKILL_WORKDIR`. That converts silent corruption into a loud failure — a real improvement — but concurrent runs still don't work without manual intervention: in the scenario above, the second session would have errored out and required a human to set an env var and re-run.

The two fixes address different halves and compose well:

| | #126 lock | this PR |
|---|---|---|
| Two runs on the **default** path | Second run refuses to start | Both just work |
| Two runs explicitly pointed at the **same** `BOOK_SKILL_WORKDIR` | **Caught** | Not caught |
| Manual intervention to run concurrently | Required | None |
| Added machinery | Lock file, staleness reclaim, `EPERM` handling | None |

**A unique default makes the common case correct without intervention; a lock is the backstop for the case a unique default cannot cover** — someone deliberately pointing two runs at one directory. If you want both, #126's `claim_workdir()` layers cleanly on top of this and becomes a rarely-hit guard rather than the primary mechanism. I've kept this PR to the one change so it's reviewable on its own; #126 also carries an unrelated ToC fix and `SKILL.md` workflow proposals, and is currently conflicting.

**Rejected alternative:** `tempfile.mkdtemp()`. Fully unique, but the path is unguessable, so a run whose stdout is lost leaves an orphan directory nobody can identify. The PID keeps it greppable and ties the directory to the process that made it.

## Evidence (Required)

- **Tests:** `tests/test_per_run_workdir.py`, 7 cases — two PIDs yield different directories; the per-run path is a **sibling, not a descendant**, of the legacy path (the fail-safe property above); it lives in `tempdir`; `BOOK_SKILL_WORKDIR` still wins; `BOOK_SKILL_WORKDIR=""` resolves to neither `Path("")` nor the CWD; unset uses the per-run default.
- Full suite on a clean checkout of this branch: **501 passed, 4 skipped**. `ruff check .` clean. `tools/validate_skill.py SKILL.md` passes.

**Before** — two runs launched together, on different books, both writing the same directory. The second overwrites the first; note both report the *same* paths:

```
$ python3 scripts/extract.py alpha.txt --mode text &
$ python3 scripts/extract.py beta.txt  --mode text &

   Text -> /tmp/book_skill_work/full_text.txt      # run A
   Meta -> /tmp/book_skill_work/metadata.json
   Text -> /tmp/book_skill_work/full_text.txt      # run B — same files
   Meta -> /tmp/book_skill_work/metadata.json

$ head -2 /tmp/book_skill_work/full_text.txt
SOURCE: beta.txt                                   # A's text is gone; no error
```

**After** — same command, on this branch:

```
$ python3 scripts/extract.py alpha.txt --mode text &
$ python3 scripts/extract.py beta.txt  --mode text &

   Workdir -> /tmp/book_skill_work-99921           # run A
   Text    -> /tmp/book_skill_work-99921/full_text.txt
   Meta    -> /tmp/book_skill_work-99921/metadata.json

   Workdir -> /tmp/book_skill_work-99922           # run B
   Text    -> /tmp/book_skill_work-99922/full_text.txt
   Meta    -> /tmp/book_skill_work-99922/metadata.json

$ jq -r '.filename + " -> " + .workdir' /tmp/book_skill_work-*/metadata.json
alpha.txt -> /tmp/book_skill_work-99921
beta.txt  -> /tmp/book_skill_work-99922
```

Empty-override case, which previously resolved to the CWD:

```
$ BOOK_SKILL_WORKDIR="" python3 -c "from book_to_skill.config import OUTPUT_DIR; print(OUTPUT_DIR)"
before: .                                          # CWD, then chmod 0700
after:  /tmp/book_skill_work-95501
```

## Screenshots / output (Required if behavior or output changes)

Output changes in one place — the completion banner gains a `Workdir ->` line and the existing labels are aligned with it. Both states are in the terminal blocks above.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

**`SKILL.md` justification (+21 net lines).** Three of the four edits are corrections that the code change forces, not additions: the Step 10 cleanup snippet targeted the now-retired fixed path and would have silently stopped deleting anything, and two other references named that path. Step 2 gains a short note that the directory is per-run and that the paths should be read from the run's own output. The one genuine addition is two sentences telling the agent to confirm the extraction is the document it asked for by checking `filename` / `source_file` before generating — that check is the only reason this bug was caught rather than shipped, and it is the cheapest possible guard against the whole class. The pre-existing `>500 lines` soft warning from `validate_skill.py` is unchanged in kind (703 → 724).

## Notes for reviewers (Optional)

- Per-run directories are not reused, so a crashed run leaves its directory until the OS clears the temp dir. That is the trade for collision safety; normal cleanup removes them, and `metadata.json.workdir` makes the target unambiguous. If you'd prefer active reaping of stale directories I can add it, though it reintroduces the risk of one run deleting another's.
- `CHANGELOG.md` untouched, per CONTRIBUTING.
- Entirely happy to close this in favour of #126, or to rework it as a follow-up that layers `claim_workdir()` on top of the per-run default — whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
