### PR TITLE
feat(extractor): detect Hindi (Devanagari) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -157,6 +157,18 @@ _TH_CHAPTER = re.compile(
     rf"^\s*(?:#{{1,6}}\s+)?(?:บทที่|ตอนที่|ภาคที่|บท|ตอน|ภาค)\s*([0-9{_TH_DIGITS}]+)\b"
 )
 
+# Hindi (Devanagari) chapter headings: "अध्याय 1", "अध्याय १", "## अध्याय 2".
+# अध्याय ("chapter") + a number. Devanagari digits (U+0966-U+096F) are positional
+# like Arabic, so — as with Thai — only a digit remap is needed, no composition.
+# Optional Markdown "#" prefix so "## अध्याय १" is recognized in converted ebooks.
+# Scoped to the digit form (not word ordinals like "पहला अध्याय") and requiring a
+# number keeps prose that merely uses the word अध्याय from matching.
+_HI_DIGITS = "०-९"
+_HI_DIGIT_MAP = str.maketrans("०१२३४५६७८९", "0123456789")
+_HI_CHAPTER = re.compile(
+    rf"^\s*(?:#{{1,6}}\s+)?अध्याय\s*([0-9{_HI_DIGITS}]+)\b"
+)
+
 # Korean chapter headings: "제1장 총칙", "## 제4장 근로시간과 휴식", "제6장의2 …".
 # 제 + Arabic numeral + a classifier (장 chapter / 편 part / 절 section / 관
 # subsection), with an optional "의N" branch suffix that Korean statutes use for
@@ -497,6 +509,9 @@ def _match_chapter_number(line: str) -> int | None:
     tm = _TH_CHAPTER.match(s)
     if tm:
         return int(tm.group(1).translate(_TH_DIGIT_MAP))
+    hm = _HI_CHAPTER.match(s)
+    if hm:
+        return int(hm.group(1).translate(_HI_DIGIT_MAP))
     km = _KO_CHAPTER.match(s)
     if km:
         return int(km.group(1))
@@ -512,7 +527,8 @@ def _chapter_number(line: str) -> int | None:
     Handles Arabic ("Chapter 5", "Capítulo 5: ..."), Roman-numeral
     ("I: Loomings", "## i. introduction", "II. The Carpet-Bag"),
     Chinese ("第三章 …", "## 一 · …", "## 第一讲"), Thai ("บทที่ 3",
-    "## บทที่ ๑"), Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and
+    "## บทที่ ๑"), Hindi ("अध्याय 1", "अध्याय १", "## अध्याय 2"),
+    Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and
     Persian ("فصل ۱", "فصل اول", "فصل بیست و یکم", "بخش ۲: مفاهیم",
     "## فصل ۱: مقدمه", PDF-glued "فصل سی و چهارمخداحافظ…") heading styles — each
     optionally preceded by a Markdown/AsciiDoc heading marker

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -627,6 +627,27 @@ class TestDetectStructure:
         assert _chapter_number("บทความนี้ยาวมากและมีรายละเอียดเยอะ") is None
         assert _chapter_number("ตอนนี้เรามาดูกันว่าเกิดอะไรขึ้น") is None
 
+    # ── Hindi (Devanagari) chapter headings ────────────────────────────────
+    def test_detects_hindi_chapters(self):
+        """Hindi headings: `अध्याय N`, with Devanagari or Arabic digits."""
+        text = (
+            "अध्याय १ प्रस्तावना\nसामग्री\n"
+            "अध्याय २ विधियाँ\nसामग्री\n"
+            "अध्याय 3 परिणाम\nसामग्री"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_hindi_markdown_prefix(self):
+        text = "## अध्याय १ पहला\nसामग्री\n## अध्याय २ दूसरा\nसामग्री"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_hindi_prose_is_not_a_chapter_heading(self):
+        """`अध्याय` used in prose (no number, or not at the start) is not a heading."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("इस अध्याय में हम चर्चा करेंगे") is None
+        assert _chapter_number("अध्याय") is None
+
     # ── Korean chapter headings ────────────────────────────────────────────
 
     def test_korean_je_n_jang(self):


### PR DESCRIPTION
## Summary (Required)

Hindi (Devanagari) chapter headings were not detected — `अध्याय 1` / `अध्याय १` /
`## अध्याय 2` all returned no chapter, so Hindi books fell back to length-based
splitting. This adds an `अध्याय` + number matcher, following the same per-script
pattern as the Thai / Korean / Persian branches.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `_HI_CHAPTER` (and `_HI_DIGIT_MAP`) to `book_to_skill/utils.py` and a
  dispatch branch in `_chapter_number`: `अध्याय` ("chapter") followed by a number,
  in Devanagari digits (U+0966–U+096F) or ASCII, with an optional Markdown `#`
  prefix (`## अध्याय १`). Devanagari digits are positional, so — like Thai — only a
  digit remap is needed, no numeral composition.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, and Persian
(#139); Hindi is a large gap with no support. Without it, Hindi books get no
heading detection and fall back to length splitting. Matches the established
per-script approach.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`_HI_CHAPTER` anchors on the line start (after an optional `#`/`==` prefix, via the
same second-pass strip the other matchers use), requires the label `अध्याय`
immediately followed by a number, and remaps Devanagari digits to ASCII before
`int()`. Scoped to the digit form (not word ordinals like `पहला अध्याय`) and
requiring a number, so prose that merely uses the word अध्याय does not match.

## Evidence (Required)
- **Tests:** three cases in `TestDetectStructure` — `अध्याय` with Devanagari and
  ASCII digits detected (3 chapters); Markdown-prefixed `## अध्याय N`; and a
  false-positive guard (`इस अध्याय में हम …` and a bare `अध्याय` → not a heading).

```
$ pytest -q
524 passed, 11 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the Thai/Korean/Persian pattern (label + positional-digit remap).
`अध्याय` is the unambiguous Hindi word for "chapter"; I kept v1 to the digit form
to avoid false positives from word ordinals. `CHANGELOG.md` untouched — git-cliff
generates it from the title (#104). No open PR touches Hindi chapter detection.
