### PR TITLE
docs(evals): freeze PD-00 baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/BACKERS.md
 
 # Social-card render cache (mkdocs-material[imaging]).
 .cache/
+
+# Local evaluation work products
+.eval-work/

--- a/docs/research/progressive-disclosure-evals.md
+++ b/docs/research/progressive-disclosure-evals.md
@@ -207,7 +207,7 @@ Status values:
 
 | ID | Status | Task | Depends on | Production change? |
 |---|---|---|---|---|
-| PD-00 | READY | Freeze current baseline and evaluation contract | none | no |
+| PD-00 | DONE | Freeze current baseline and evaluation contract | none | no |
 | PD-01 | BLOCKED | Implement deterministic manifest + hashing + budget schema | PD-00 | no |
 | PD-02 | BLOCKED | Implement fixture/replay scorer with trajectory metrics | PD-01 | no |
 | PD-03 | BLOCKED | Implement paper-flat baseline pack builder | PD-01 | no |
@@ -548,7 +548,7 @@ Agents update this table when a task changes status. Keep entries short; link to
 
 | Task | Status | PR / commit | Evidence | Notes |
 |---|---|---|---|---|
-| PD-00 | READY | — | — | First implementation task |
+| PD-00 | DONE | — | [`evals/results/pd00-baseline.md`](../../evals/results/pd00-baseline.md) | Deterministic synthetic discovery-tax baseline; no production authorization |
 | PD-01 | BLOCKED | — | — | waits for PD-00 |
 | PD-02 | BLOCKED | — | — | waits for PD-01 |
 | PD-03 | BLOCKED | — | — | waits for PD-01 |

--- a/evals/fixtures/pd00-synthetic-book.txt
+++ b/evals/fixtures/pd00-synthetic-book.txt
@@ -1,0 +1,22 @@
+Synthetic Progressive Disclosure Book
+
+Sumário
+Capítulo 1 — Orientação
+Capítulo 2 — Recuperação
+Capítulo 3 — Verificação
+
+Capítulo 1 — Orientação
+A orientação apresenta o objetivo da avaliação. O leitor identifica o livro,
+o capítulo e a pergunta antes de carregar detalhes. Esta seção usa texto
+sintético, curto e determinístico para exercitar a descoberta de capítulos.
+
+Capítulo 2 — Recuperação
+A recuperação localiza a evidência necessária depois da orientação. O agente
+consulta o sumário, abre o capítulo relevante e evita carregar capítulos sem
+relação com a pergunta. Esta seção permanece sintética e não reproduz obra
+publicada.
+
+Capítulo 3 — Verificação
+A verificação confirma que a resposta usa a evidência do capítulo alvo. O
+relatório separa contagens medidas da estimativa do loop de descoberta. Esta
+seção é o alvo determinístico para a linha de base PD-00.

--- a/evals/results/pd00-baseline.md
+++ b/evals/results/pd00-baseline.md
@@ -1,0 +1,55 @@
+# PD-00 Discovery-Tax Baseline
+
+## Fixture and source safety
+
+Fixture: [`../fixtures/pd00-synthetic-book.txt`](../fixtures/pd00-synthetic-book.txt).
+It is a deterministic, synthetic three-chapter text written for this evaluation.
+No copyrighted book text is included or used.
+
+## Reproduction
+
+Exact command:
+
+```sh
+python3 tools/discovery_tax.py --full-text evals/fixtures/pd00-synthetic-book.txt --target-chapter 3 --core-tokens 4000
+```
+
+Environment: Python 3.12.3; `tiktoken` was not installed. Token method:
+`words/0.75 heuristic (tiktoken not installed)`, selected by the current
+`tools/discovery_tax.py` fallback.
+
+Current output:
+
+```text
+Discovery Loop Tax — measured on a real book
+  token method : words/0.75 heuristic (tiktoken not installed)
+  source       : pd00-synthetic-book.txt
+  chapters      : 3 detected
+  target        : chapter 3  (Capítulo 3 — Verificação)
+  book total    : 180 tokens
+  Cost to answer ONE targeted question (tokens entering context):
+    context-dump      :       180   (resident, re-billed EVERY turn)
+    discovery (best)  :        53   ToC (1) + raw target chapter (52)
+    discovery (loop)  :       106   + 1 prior chapter for a missing definition (53)
+    book-to-skill     :     5,000   core [design cap (no --skill-dir)] (4,000) + compiled chapter (1,000)
+  book-to-skill advantage:
+    vs context-dump   : 0.0x fewer tokens
+    vs discovery best : 0.0x fewer tokens
+    vs discovery loop : 0.0x fewer tokens
+  Note: the discovery figures are a model using the book's real ToC/chapter
+  sizes; a single read, not a recurring cost. context-dump recurs every turn.
+```
+
+## Classification
+
+**Measured:** fixture identity; three chapters detected; text sizes counted by
+the tool's stated fallback tokenization method; and this command's deterministic
+stdout for this environment.
+
+**Modeled:** `discovery (best)` and `discovery (loop)` are discovery-path cost
+models, not observations of an agent trajectory. `book-to-skill` uses the
+configured 4,000-token core design cap plus a 1,000-token compiled-chapter
+allowance because no `--skill-dir` was supplied. The reported advantages are
+therefore modeled comparisons, not performance measurements.
+
+This baseline does not authorize any paper-derived production change.


### PR DESCRIPTION
## Summary

Freezes the PD-00 progressive-disclosure evaluation baseline without changing production extraction or generation behavior. Adds a synthetic three-chapter fixture and a reproducible discovery-tax report that separates measurements from cost models.

## Type of change

- [x] 📝 Docs only
- [x] 🧹 Chore / CI / tooling

## What it does

- **Fixes:** n/a; establishes the required baseline before new evaluation infrastructure.
- **Improves:** result attribution by recording the exact command, tokenization fallback, fixture source safety, and measured-versus-modeled boundary.
- **Adds:** a deterministic synthetic fixture and PD-00 evidence ledger entry for later progressive-disclosure experiments.

## Motivation & context

Closes #n/a — planned research/evaluation groundwork, not a production feature.

## How it works

Uses the existing standard-library `tools/discovery_tax.py` against a synthetic, copyright-safe fixture. The result report captures the deterministic output and classifies path/cost comparisons as models rather than agent-performance observations. `.eval-work/` remains local-only.

## Evidence

- **Tests:** deterministic `tools/discovery_tax.py` output checked twice against the synthetic fixture.
- **Validation:** `uv run --with pytest --with ruff python -m pytest -q`; `uv run --with ruff ruff check .`; `python3 tools/validate_skill.py SKILL.md`.
- **Results:** all checks pass; `validate_skill.py` reports only its existing soft body-length warning.

## Checklist

- [x] Focused, reviewable change
- [x] No production extractor, generator, or `SKILL.md` behavior changed
- [x] No raw copyrighted book text added
- [x] Evidence distinguishes measured values from modeled values