### PR TITLE
feat(evals): add deterministic run manifests

### DIFF
--- a/docs/research/progressive-disclosure-evals.md
+++ b/docs/research/progressive-disclosure-evals.md
@@ -208,7 +208,7 @@ Status values:
 | ID | Status | Task | Depends on | Production change? |
 |---|---|---|---|---|
 | PD-00 | DONE | Freeze current baseline and evaluation contract | none | no |
-| PD-01 | BLOCKED | Implement deterministic manifest + hashing + budget schema | PD-00 | no |
+| PD-01 | DONE | Implement deterministic manifest + hashing + budget schema | PD-00 | no |
 | PD-02 | BLOCKED | Implement fixture/replay scorer with trajectory metrics | PD-01 | no |
 | PD-03 | BLOCKED | Implement paper-flat baseline pack builder | PD-01 | no |
 | PD-04 | BLOCKED | Add dry-run/live runner contract and first harness adapter | PD-02, PD-03 | no |
@@ -549,7 +549,7 @@ Agents update this table when a task changes status. Keep entries short; link to
 | Task | Status | PR / commit | Evidence | Notes |
 |---|---|---|---|---|
 | PD-00 | DONE | — | [`evals/results/pd00-baseline.md`](../../evals/results/pd00-baseline.md) | Deterministic synthetic discovery-tax baseline; no production authorization |
-| PD-01 | BLOCKED | — | — | waits for PD-00 |
+| PD-01 | DONE | — | `tests/evals/test_manifest.py` | Deterministic manifest, source SHA-256, budget/secret validation, and repeatable CLI verified locally |
 | PD-02 | BLOCKED | — | — | waits for PD-01 |
 | PD-03 | BLOCKED | — | — | waits for PD-01 |
 | PD-04 | BLOCKED | — | — | waits for PD-02/03 |

--- a/tests/evals/test_manifest.py
+++ b/tests/evals/test_manifest.py
@@ -1,0 +1,97 @@
+"""Tests for deterministic evaluation run manifests."""
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "evals" / "manifest.py"
+SPEC = importlib.util.spec_from_file_location("eval_manifest", MODULE_PATH)
+manifest = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = manifest
+SPEC.loader.exec_module(manifest)
+
+
+def config(source_name="source.txt"):
+    return {
+        "sources": [{"id": "fixture", "path": source_name}],
+        "condition": "flat",
+        "question_set_hash": "questions-sha256",
+        "models": {"answer": "test-model", "generation": "unsupported"},
+        "harness_id": "fixture-harness",
+        "prompt_hashes": {"answer": "prompt-sha256"},
+        "config_hashes": {"runner": "config-sha256"},
+        "seed": "unsupported",
+        "repetition": "unsupported",
+        "budgets": {"max_calls": 1, "max_input_tokens": 100, "max_output_tokens": 20},
+        "artifacts": ".eval-work/artifacts/run",
+        "results": ".eval-work/results/run.json",
+        "reason": "smallest discriminating run",
+        "decision": "whether to continue",
+    }
+
+
+def test_identical_inputs_have_identical_manifest_and_run_id(tmp_path):
+    (tmp_path / "source.txt").write_text("café", encoding="utf-8")
+    first = manifest.build_manifest(config(), tmp_path)
+    second = manifest.build_manifest(config(), tmp_path)
+
+    assert first == second
+    assert first["sources"] == [{"id": "fixture", "sha256": manifest.sha256_file(tmp_path / "source.txt")}]
+    assert "café" == json.loads(manifest.canonical_json({"text": "café"}))["text"]
+
+
+def test_material_config_or_source_change_alters_run_id(tmp_path, monkeypatch):
+    source = tmp_path / "source.txt"
+    source.write_bytes("café".encode("utf-8"))
+    monkeypatch.setattr(manifest, "_commit", lambda _: "a" * 40)
+    original = manifest.build_manifest(config(), tmp_path)
+    changed_condition = config()
+    changed_condition["condition"] = "structured"
+    assert manifest.build_manifest(changed_condition, tmp_path)["run_id"] != original["run_id"]
+
+    source.write_bytes("caffè".encode("utf-8"))
+    assert manifest.build_manifest(config(), tmp_path)["run_id"] != original["run_id"]
+
+    monkeypatch.setattr(manifest, "_commit", lambda _: "b" * 40)
+    assert manifest.build_manifest(config(), tmp_path)["run_id"] != original["run_id"]
+
+
+@pytest.mark.parametrize(
+    "mutate, expected",
+    [
+        (lambda value: value.pop("condition"), "missing required fields"),
+        (lambda value: value["budgets"].update(max_calls=-1), "max_calls"),
+        (lambda value: value.update(seed=-1), "seed"),
+        (lambda value: value.update(repetition=0), "repetition"),
+        (lambda value: value.update(api_key="not-allowed"), "guardrail only"),
+        (lambda value: value.update(harness_id="Bearer token-value"), "guardrail only"),
+        (lambda value: value.update(harness_id="sk-abcdefghijklmnop"), "guardrail only"),
+        (lambda value: value.update(harness_id="ghp_" + "a" * 36), "guardrail only"),
+        (lambda value: value.update(harness_id="AKIA" + "A" * 16), "guardrail only"),
+        (lambda value: value.update(harness_id="eyJsynthetic.payloadseg.signature"), "guardrail only"),
+        (lambda value: value.update(harness_id="glpat-" + "a" * 20), "guardrail only"),
+    ],
+)
+def test_invalid_configs_fail_clearly(tmp_path, mutate, expected):
+    (tmp_path / "source.txt").write_text("fixture", encoding="utf-8")
+    value = config()
+    mutate(value)
+    with pytest.raises(ValueError, match=expected):
+        manifest.build_manifest(value, tmp_path)
+
+
+def test_cli_is_repeatedly_stable(tmp_path):
+    (tmp_path / "source.txt").write_bytes("東京".encode("utf-8"))
+    config_path = tmp_path / "run.json"
+    config_path.write_text(json.dumps(config(), ensure_ascii=False), encoding="utf-8")
+    command = [sys.executable, str(MODULE_PATH), str(config_path)]
+    first = subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8")
+    second = subprocess.run(command, check=True, capture_output=True, text=True, encoding="utf-8")
+
+    assert first.stdout == second.stdout
+    assert json.loads(first.stdout)["run_id"]

--- a/tools/evals/manifest.py
+++ b/tools/evals/manifest.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Create deterministic, secret-free manifests for evaluation runs.
+
+Usage: python3 tools/evals/manifest.py config.json [--output manifest.json]
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = "pd-run-manifest/v1"
+_REQUIRED = {
+    "condition", "question_set_hash", "models", "harness_id", "prompt_hashes",
+    "config_hashes", "seed", "repetition", "budgets", "artifacts", "results",
+    "reason", "decision",
+}
+_SECRET_MARKERS = ("secret", "password", "credential", "authorization", "api_key", "private_key")
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"^Bearer\s+\S+$", re.IGNORECASE),
+    re.compile(r"^sk-[A-Za-z0-9_-]{16,}$"),
+    re.compile(r"^ghp_[A-Za-z0-9]{36}$"),
+    re.compile(r"^AKIA[A-Z0-9]{16}$"),
+    re.compile(r"^eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$"),
+    re.compile(r"^glpat-[A-Za-z0-9_-]{20}$"),
+)
+_SECRET_GUARDRAIL = "possible secret (guardrail only; not a DLP guarantee); store only identifiers or hashes"
+
+
+def canonical_json(value: Any) -> str:
+    """Return the UTF-8-preserving canonical JSON representation of *value*."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of a file's raw bytes."""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _fail(message: str) -> None:
+    raise ValueError(f"invalid run manifest config: {message}")
+
+
+def _reject_secrets(value: Any, location: str = "config") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                _fail(f"{location} has a non-string key")
+            if any(marker in key.lower() for marker in _SECRET_MARKERS):
+                _fail(f"{location}.{key} {_SECRET_GUARDRAIL}")
+            _reject_secrets(child, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_secrets(child, f"{location}[{index}]")
+    elif isinstance(value, str) and any(pattern.fullmatch(value) for pattern in _SECRET_VALUE_PATTERNS):
+        _fail(f"{location} {_SECRET_GUARDRAIL}")
+
+
+def _identifier(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _fail(f"{name} must be a non-empty string")
+    return value
+
+
+def _hashes(value: Any, name: str) -> Dict[str, str]:
+    if not isinstance(value, dict) or not value:
+        _fail(f"{name} must be a non-empty object of named hashes")
+    return {str(key): _identifier(digest, f"{name}.{key}") for key, digest in value.items()}
+
+
+def _supportable(value: Any, name: str, minimum: int) -> Any:
+    if value == "unsupported":
+        return value
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        qualifier = "positive" if minimum else "non-negative"
+        _fail(f"{name} must be {qualifier} integer or 'unsupported'")
+    return value
+
+
+def _budgets(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        _fail("budgets must be an object")
+    required = ("max_calls", "max_input_tokens", "max_output_tokens")
+    missing = [key for key in required if key not in value]
+    if missing:
+        _fail("budgets missing " + ", ".join(missing))
+    result: Dict[str, Any] = {}
+    for key in required:
+        item = value[key]
+        if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+            _fail(f"budgets.{key} must be a non-negative integer hard ceiling")
+        result[key] = item
+    if "max_cost_usd" in value:
+        cost = value["max_cost_usd"]
+        if isinstance(cost, bool) or not isinstance(cost, (int, float)) or not math.isfinite(cost) or cost < 0:
+            _fail("budgets.max_cost_usd must be a non-negative finite number")
+        result["max_cost_usd"] = cost
+    return result
+
+
+def _commit(base_dir: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=base_dir, capture_output=True,
+            text=True, encoding="utf-8", errors="replace", timeout=5, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unavailable"
+    return result.stdout.strip() if result.returncode == 0 and result.stdout.strip() else "unavailable"
+
+
+def build_manifest(config: Dict[str, Any], base_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Validate *config*, hash its sources, and return a deterministic manifest."""
+    if not isinstance(config, dict):
+        _fail("top level must be an object")
+    _reject_secrets(config)
+    missing = sorted(_REQUIRED - set(config))
+    if missing:
+        _fail("missing required fields: " + ", ".join(missing))
+    base_dir = (base_dir or Path.cwd()).resolve()
+    sources = config.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _fail("sources must be a non-empty list")
+    source_records = []
+    for index, source in enumerate(sources):
+        if not isinstance(source, dict):
+            _fail(f"sources[{index}] must be an object")
+        source_id = _identifier(source.get("id"), f"sources[{index}].id")
+        source_path = _identifier(source.get("path"), f"sources[{index}].path")
+        resolved = (base_dir / source_path).resolve()
+        if not resolved.is_file():
+            _fail(f"sources[{index}].path is not a readable file: {source_path}")
+        source_records.append({"id": source_id, "sha256": sha256_file(resolved)})
+    source_records.sort(key=lambda record: (record["id"], record["sha256"]))
+
+    models = config["models"]
+    if not isinstance(models, dict) or not models:
+        _fail("models must be a non-empty object")
+    normalized_models = {str(key): _identifier(value, f"models.{key}") for key, value in models.items()}
+    artifacts = _identifier(config["artifacts"], "artifacts")
+    results = _identifier(config["results"], "results")
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "sources": source_records,
+        "condition": _identifier(config["condition"], "condition"),
+        "question_set_hash": _identifier(config["question_set_hash"], "question_set_hash"),
+        "models": normalized_models,
+        "harness_id": _identifier(config["harness_id"], "harness_id"),
+        "prompt_hashes": _hashes(config["prompt_hashes"], "prompt_hashes"),
+        "config_hashes": _hashes(config["config_hashes"], "config_hashes"),
+        "seed": _supportable(config["seed"], "seed", 0),
+        "repetition": _supportable(config["repetition"], "repetition", 1),
+        "budgets": _budgets(config["budgets"]),
+        "commit": _commit(base_dir),
+        "artifacts": artifacts,
+        "results": results,
+        "reason": _identifier(config["reason"], "reason"),
+        "decision": _identifier(config["decision"], "decision"),
+    }
+    identity = {key: value for key, value in manifest.items() if key not in {"artifacts", "results"}}
+    if manifest["commit"] == "unavailable":
+        identity.pop("commit")
+    manifest["run_id"] = hashlib.sha256(canonical_json(identity).encode("utf-8")).hexdigest()
+    return manifest
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", type=Path, help="evaluation run config JSON")
+    parser.add_argument("--output", type=Path, help="write manifest JSON to this file")
+    args = parser.parse_args(argv)
+    try:
+        with args.config.open(encoding="utf-8") as stream:
+            config = json.load(stream)
+        rendered = canonical_json(build_manifest(config, args.config.parent)) + "\n"
+        if args.output:
+            args.output.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds deterministic, secret-guarded manifests for progressive-disclosure evaluation runs. The manifest records input identities, budgets, model/harness metadata, artifact paths, and a reproducible `run_id` without changing production extraction or skill generation.

## Type of change

- [x] Feature (non-breaking capability)
- [x] Chore / tooling

## What it does

- Adds a stdlib CLI at `tools/evals/manifest.py`.
- Hashes sources, canonicalizes JSON, validates budgets, and records Git commit best-effort.
- Derives `run_id` from all material inputs, including the commit when available.
- Rejects sensitive field names and common credential-shaped values as a guardrail, not a DLP guarantee.

## Motivation & context

Implements PD-01, the attribution contract required before replay and live evaluation runs. This PR stacks on #187 (PD-00 baseline).

## Evidence

- Added tests for deterministic identities, material changes, UTF-8 source bytes, invalid schemas/budgets, seed/repetition, credential-shaped values, and stable CLI output.
- `uv run --with pytest --with ruff python -m pytest -q` → `541 passed, 5 skipped`
- `uv run --with ruff ruff check .` → passed
- `python3 tools/validate_skill.py SKILL.md` → passed; existing soft body-length warning only

## Checklist

- [x] Focused, reviewable change
- [x] Standard-library implementation; no runtime dependency added
- [x] No production extractor, generator, or `SKILL.md` behavior changed
- [x] No raw copyrighted text or credentials added
- [x] Deterministic-hash and invalid-input tests added