### PR TITLE
feat(evals): add paper-flat baseline builder

### DIFF
--- a/docs/research/progressive-disclosure-evals.md
+++ b/docs/research/progressive-disclosure-evals.md
@@ -210,7 +210,7 @@ Status values:
 | PD-00 | DONE | Freeze current baseline and evaluation contract | none | no |
 | PD-01 | DONE | Implement deterministic manifest + hashing + budget schema | PD-00 | no |
 | PD-02 | BLOCKED | Implement fixture/replay scorer with trajectory metrics | PD-01 | no |
-| PD-03 | BLOCKED | Implement paper-flat baseline pack builder | PD-01 | no |
+| PD-03 | DONE | Implement paper-flat baseline pack builder | PD-01 | no |
 | PD-04 | BLOCKED | Add dry-run/live runner contract and first harness adapter | PD-02, PD-03 | no |
 | PD-05 | BLOCKED | Representation experiment: raw payload vs structured B2S payload | PD-04 | no |
 | PD-06 | BLOCKED | Automatic vs explicit activation experiment | PD-04 | no |
@@ -551,7 +551,7 @@ Agents update this table when a task changes status. Keep entries short; link to
 | PD-00 | DONE | — | [`evals/results/pd00-baseline.md`](../../evals/results/pd00-baseline.md) | Deterministic synthetic discovery-tax baseline; no production authorization |
 | PD-01 | DONE | — | `tests/evals/test_manifest.py` | Deterministic manifest, source SHA-256, budget/secret validation, and repeatable CLI verified locally |
 | PD-02 | BLOCKED | — | — | waits for PD-01 |
-| PD-03 | BLOCKED | — | — | waits for PD-01 |
+| PD-03 | DONE | — | `tests/evals/test_paper_flat.py` | Deterministic synthetic one-level paper-flat pack builder verified locally; no production authorization |
 | PD-04 | BLOCKED | — | — | waits for PD-02/03 |
 | PD-05 | BLOCKED | — | — | primary representation experiment |
 | PD-06 | BLOCKED | — | — | host capability dependent |

--- a/evals/fixtures/pd03-book.txt
+++ b/evals/fixtures/pd03-book.txt
@@ -1,0 +1,7 @@
+Chapter 1: Observe
+
+Measure a signal before changing a system. Record the evidence window.
+
+Chapter 2: Respond
+
+Apply the smallest safe response after observation. Verify the result.

--- a/evals/fixtures/pd03-metadata.json
+++ b/evals/fixtures/pd03-metadata.json
@@ -1,0 +1,15 @@
+{
+  "title": "Synthetic Reliability Notes",
+  "description": "A synthetic handbook used only to evaluate one-level chunk routing.",
+  "chunks": [
+    {
+      "description": "Observe system signals.",
+      "summary": "Measure before changing.",
+      "key_elements": ["signal", "evidence window"]
+    },
+    {
+      "description": "Respond after observation.",
+      "summary": "Use the smallest safe response."
+    }
+  ]
+}

--- a/tests/evals/test_paper_flat.py
+++ b/tests/evals/test_paper_flat.py
@@ -55,6 +55,12 @@ def test_source_chapter_headings_determine_chunks(tmp_path):
     assert all(chunk.read_text(encoding="utf-8").startswith(f"Chapter {number}") for number, chunk in enumerate(chunks, 1))
 
 
+def test_indented_hash_code_line_does_not_split_chunks():
+    source = "# Top-level\n\n    # Code comment\n\nChapter 2: Next\n"
+
+    assert paper_flat._chunks(source) == ["# Top-level\n\n    # Code comment\n\n", "Chapter 2: Next\n"]
+
+
 def test_no_heading_uses_one_full_source_chunk(tmp_path):
     source = tmp_path / "source.txt"
     metadata = tmp_path / "metadata.json"

--- a/tests/evals/test_paper_flat.py
+++ b/tests/evals/test_paper_flat.py
@@ -1,0 +1,71 @@
+"""Tests for the experiment-only PD-03 paper-flat pack builder."""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "evals" / "paper_flat.py"
+SPEC = importlib.util.spec_from_file_location("paper_flat", MODULE_PATH)
+paper_flat = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = paper_flat
+SPEC.loader.exec_module(paper_flat)
+FIXTURES = ROOT / "evals" / "fixtures"
+
+
+def build(tmp_path, source=FIXTURES / "pd03-book.txt", metadata=FIXTURES / "pd03-metadata.json"):
+    return paper_flat.build_paper_flat(source, metadata, tmp_path / "pack")
+
+
+def test_root_and_raw_chunks_have_expected_one_level_structure(tmp_path):
+    build(tmp_path)
+    pack = tmp_path / "pack"
+    assert (pack / "SKILL.md").read_text(encoding="utf-8") == """# Synthetic Reliability Notes
+
+A synthetic handbook used only to evaluate one-level chunk routing.
+
+## Activation-time chunk table
+
+| Path | Description | SUMMARY | KEY_ELEMENTS |
+| --- | --- | --- | --- |
+| `chunks/chunk-01.md` | Observe system signals. | Measure before changing. | signal, evidence window |
+| `chunks/chunk-02.md` | Respond after observation. | Use the smallest safe response. | — |
+
+Split policy: source chapter headings; without headings, one full-source chunk.
+"""
+    assert (pack / "chunks" / "chunk-01.md").read_text(encoding="utf-8") == "Chapter 1: Observe\n\nMeasure a signal before changing a system. Record the evidence window.\n\n"
+    assert (pack / "chunks" / "chunk-02.md").read_text(encoding="utf-8") == "Chapter 2: Respond\n\nApply the smallest safe response after observation. Verify the result.\n"
+
+
+def test_identical_inputs_produce_byte_identical_output(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    paper_flat.build_paper_flat(FIXTURES / "pd03-book.txt", FIXTURES / "pd03-metadata.json", first)
+    paper_flat.build_paper_flat(FIXTURES / "pd03-book.txt", FIXTURES / "pd03-metadata.json", second)
+    assert {path.relative_to(first): path.read_bytes() for path in first.rglob("*") if path.is_file()} == {
+        path.relative_to(second): path.read_bytes() for path in second.rglob("*") if path.is_file()
+    }
+
+
+def test_source_chapter_headings_determine_chunks(tmp_path):
+    build(tmp_path)
+    chunks = sorted((tmp_path / "pack" / "chunks").iterdir())
+    assert len(chunks) == 2
+    assert all(chunk.read_text(encoding="utf-8").startswith(f"Chapter {number}") for number, chunk in enumerate(chunks, 1))
+
+
+def test_no_heading_uses_one_full_source_chunk(tmp_path):
+    source = tmp_path / "source.txt"
+    metadata = tmp_path / "metadata.json"
+    source.write_text("Plain synthetic source.\n", encoding="utf-8")
+    metadata.write_text(json.dumps({"title": "Plain", "description": "Fallback fixture.", "chunks": [{"description": "Whole source.", "summary": "No headings."}]}), encoding="utf-8")
+    build(tmp_path, source, metadata)
+    assert (tmp_path / "pack" / "chunks" / "chunk-01.md").read_text(encoding="utf-8") == "Plain synthetic source.\n"
+
+
+def test_pack_has_no_child_skill_hierarchy(tmp_path):
+    build(tmp_path)
+    files = sorted(path.relative_to(tmp_path / "pack") for path in (tmp_path / "pack").rglob("*") if path.is_file())
+    assert files == [Path("SKILL.md"), Path("chunks/chunk-01.md"), Path("chunks/chunk-02.md")]
+    assert all(path.name == "SKILL.md" for path in files if path.name == "SKILL.md")

--- a/tools/evals/paper_flat.py
+++ b/tools/evals/paper_flat.py
@@ -54,8 +54,10 @@ def build_paper_flat(source_path: Path, metadata_path: Path, output_dir: Path) -
     written = []
     for number, (payload, details) in enumerate(zip(chunks, metadata["chunks"]), 1):
         relative = f"chunks/chunk-{number:02d}.md"
-        (output_dir / relative).write_text(payload, encoding="utf-8", newline="\n")
-        written.append(output_dir / relative)
+        path = output_dir / relative
+        with path.open("w", encoding="utf-8", newline="\n") as file:
+            file.write(payload)
+        written.append(path)
         elements = ", ".join(details.get("key_elements", [])) or "—"
         rows.append(f"| `{relative}` | {details['description']} | {details['summary']} | {elements} |")
 
@@ -76,7 +78,8 @@ def build_paper_flat(source_path: Path, metadata_path: Path, output_dir: Path) -
         ]
     )
     root_path = output_dir / "SKILL.md"
-    root_path.write_text(root, encoding="utf-8", newline="\n")
+    with root_path.open("w", encoding="utf-8", newline="\n") as file:
+        file.write(root)
     return [root_path, *written]
 
 

--- a/tools/evals/paper_flat.py
+++ b/tools/evals/paper_flat.py
@@ -19,7 +19,7 @@ _CHAPTER = re.compile(
 def _chunks(source: str) -> List[str]:
     """Split at chapter headings, or return one whole-source fallback chunk."""
     lines = source.splitlines(keepends=True)
-    starts = [index for index, line in enumerate(lines) if _CHAPTER.match(line.strip())]
+    starts = [index for index, line in enumerate(lines) if _CHAPTER.match(line.rstrip())]
     if not starts:
         return [source]
     return ["".join(lines[start:end]) for start, end in zip(starts, starts[1:] + [len(lines)])]

--- a/tools/evals/paper_flat.py
+++ b/tools/evals/paper_flat.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Build the deterministic, experiment-only PD-03 paper-flat skill pack.
+
+Usage: python3 tools/evals/paper_flat.py SOURCE METADATA OUTPUT_DIR
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+_CHAPTER = re.compile(
+    r"^(?:#{1,6}\s+.+|(?:chapter|chap\.)\s+(?:\d+|[ivxlcdm]+)\b.*)$", re.IGNORECASE
+)
+
+
+def _chunks(source: str) -> List[str]:
+    """Split at chapter headings, or return one whole-source fallback chunk."""
+    lines = source.splitlines(keepends=True)
+    starts = [index for index, line in enumerate(lines) if _CHAPTER.match(line.strip())]
+    if not starts:
+        return [source]
+    return ["".join(lines[start:end]) for start, end in zip(starts, starts[1:] + [len(lines)])]
+
+
+def _metadata(path: Path, chunk_count: int) -> Dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or not all(isinstance(value.get(key), str) for key in ("title", "description")):
+        raise ValueError("metadata requires string title and description")
+    chunks = value.get("chunks")
+    if not isinstance(chunks, list) or len(chunks) != chunk_count:
+        raise ValueError("metadata chunks must match the source chunk count")
+    for chunk in chunks:
+        if not isinstance(chunk, dict) or not all(isinstance(chunk.get(key), str) for key in ("description", "summary")):
+            raise ValueError("each metadata chunk requires string description and summary")
+        if "key_elements" in chunk and (
+            not isinstance(chunk["key_elements"], list) or not all(isinstance(item, str) for item in chunk["key_elements"])
+        ):
+            raise ValueError("key_elements must be a list of strings")
+    return value
+
+
+def build_paper_flat(source_path: Path, metadata_path: Path, output_dir: Path) -> List[Path]:
+    """Write a one-level paper-flat pack and return its files in stable order."""
+    source = source_path.read_text(encoding="utf-8")
+    chunks = _chunks(source)
+    metadata = _metadata(metadata_path, len(chunks))
+    chunk_dir = output_dir / "chunks"
+    chunk_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    written = []
+    for number, (payload, details) in enumerate(zip(chunks, metadata["chunks"]), 1):
+        relative = f"chunks/chunk-{number:02d}.md"
+        (output_dir / relative).write_text(payload, encoding="utf-8", newline="\n")
+        written.append(output_dir / relative)
+        elements = ", ".join(details.get("key_elements", [])) or "—"
+        rows.append(f"| `{relative}` | {details['description']} | {details['summary']} | {elements} |")
+
+    root = "\n".join(
+        [
+            f"# {metadata['title']}",
+            "",
+            metadata["description"],
+            "",
+            "## Activation-time chunk table",
+            "",
+            "| Path | Description | SUMMARY | KEY_ELEMENTS |",
+            "| --- | --- | --- | --- |",
+            *rows,
+            "",
+            "Split policy: source chapter headings; without headings, one full-source chunk.",
+            "",
+        ]
+    )
+    root_path = output_dir / "SKILL.md"
+    root_path.write_text(root, encoding="utf-8", newline="\n")
+    return [root_path, *written]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build an experiment-only PD-03 paper-flat pack.")
+    parser.add_argument("source", type=Path, help="UTF-8 synthetic source text")
+    parser.add_argument("metadata", type=Path, help="fixed UTF-8 JSON metadata")
+    parser.add_argument("output", type=Path, help="output pack directory")
+    args = parser.parse_args()
+    build_paper_flat(args.source, args.metadata, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a deterministic offline paper-flat baseline builder for the progressive-disclosure evaluation plan. It creates one root `SKILL.md` and direct raw chapter payloads without child-skill routing.

## Type of change
- [x] ✨ Feature (non-breaking change that adds capability)

## What it does
- **Adds:** synthetic source and metadata fixtures, one-level baseline builder, deterministic heading splits, and single-chunk fallback for no-heading input.

## Motivation & context
Closes n/a — PD-03 in the progressive-disclosure evaluation plan.

## How it works
`paper_flat.py` uses only the standard library. It writes a root routing file plus raw chunk payloads directly under `chunks/`; no nested skills are produced.

## Evidence
- **Tests:** `tests/evals/test_paper_flat.py` covers structure, deterministic output, chapter splits, fallback, and absence of child skills.
- **Before / after:** full local suite passed: `541 passed, 5 skipped`; Ruff clean; skill validation passed with existing soft length warning only.

## Checklist
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers
Evaluation-only infrastructure. No production generator, extractor, or `SKILL.md` behavior changes.