### PR TITLE
feat(extractor): detect Vietnamese (Chương) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -101,12 +101,13 @@ def estimate_tokens(text: str) -> int:
 
 
 # Explicit chapter heading: "Chapter 5", "Capítulo 5: ...", "Chapter 1. Intro".
-# Also French/German/Italian/Dutch chapter words (chapitre/kapitel/capitolo/
-# hoofdstuk), matching the ToC languages added alongside. "ch.?" stays last so
-# the longer words match in full. Captures the number (bounded to 1..99 — drops
-# years like "2025.") and whatever follows it on the line, so we can reject prose.
+# Also French/German/Italian/Dutch/Vietnamese chapter words (chapitre/kapitel/
+# capitolo/hoofdstuk/chương), matching the ToC languages added alongside. "ch.?"
+# stays last so the longer words match in full. Captures the number (bounded to
+# 1..99 — drops years like "2025.") and whatever follows it on the line, so we
+# can reject prose.
 _EXPLICIT_CHAPTER = re.compile(
-    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|ch\.?)\s*(?:(\d{1,2})|(?P<roman>[IVXLCDMivxlcdm]{1,7}))\b(?P<rest>.*)$",
+    r"^\s*(?:chapter|chapitre|kapitel|cap[ií]tulo|capitolo|hoofdstuk|chương|ch\.?)\s*(?:(\d{1,2})|(?P<roman>[IVXLCDMivxlcdm]{1,7}))\b(?P<rest>.*)$",
     re.IGNORECASE,
 )
 # A heading's number is followed by end-of-line, punctuation (“. : - —“), or a

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1070,6 +1070,16 @@ class TestDetectStructure:
     def test_dutch_hoofdstuk(self):
         assert detect_structure("Hoofdstuk 1\nx\nHoofdstuk 2\nx")["chapters_detected"] == 2
 
+    def test_vietnamese_chuong(self):
+        assert detect_structure("Chương 1\nx\nChương 2\nx")["chapters_detected"] == 2
+
+    def test_vietnamese_chuong_not_program(self):
+        # "Chương trình" (program) starts with the chapter word but is not a
+        # heading — no number follows "Chương", so it must not match.
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("Chương trình 1 của khóa học") is None
+
     def test_german_kapitel_with_title(self):
         text = "Kapitel 1: Einführung\nx\nKapitel 2: Methoden\nx"
         assert detect_structure(text)["chapters_detected"] == 2


### PR DESCRIPTION
## Summary (Required)

Vietnamese chapter headings were not detected — `Chương 1` / `Chương 12` were
not recognized, so Vietnamese books fell back to length-based splitting. This
adds `chương` to the existing Latin-script `_EXPLICIT_CHAPTER` alternation,
alongside the French/German/Italian/Dutch chapter words already there.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `chương` to the `_EXPLICIT_CHAPTER` regex in `book_to_skill/utils.py`
  (and updates the adjacent comment). Vietnamese uses Latin script with a decimal
  chapter number, so it slots straight into the existing alternation — no new
  matcher or dispatch branch needed.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, Persian, and
Hindi. Vietnamese (~85M speakers) writes chapters as `Chương N` in Latin script,
so it only needs one more alternative in the existing word list rather than a
per-script matcher. Without it, Vietnamese books get no heading detection and
fall back to length splitting.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`Chương` is added to the alternation of chapter words; the existing number
capture, `_HEADING_TAIL` prose-rejection, and 1..99 bound all apply unchanged.
`Chương trình` ("program") starts with the chapter word but is not followed by a
number, so — as with the other words — it does not match and prose is not
misread as a heading.

## Evidence (Required)
- **Tests:** two cases — `Chương 1 … Chương 2` detected as 2 chapters; and a
  false-positive guard that `Chương trình 1 của khóa học` (Vietnamese for
  "program", no number after `Chương`) is not a heading.

```
$ pytest -q
541 passed, 11 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Smallest possible change — one word added to the existing Latin-script
alternation rather than a new per-script matcher, since Vietnamese chapter
numbers are plain decimals. `CHANGELOG.md` untouched — git-cliff generates it
from the title (#104). No open PR touches Vietnamese chapter detection.
