### PR TITLE
feat(extractor): detect Bengali (অধ্যায়) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -186,6 +186,17 @@ _HI_CHAPTER = re.compile(
     rf"^\s*(?:#{{1,6}}\s+)?अध्याय\s*([0-9{_HI_DIGITS}]+)\b"
 )
 
+# Bengali chapter headings: "অধ্যায় 1", "অধ্যায় ১", "## অধ্যায় 2".
+# অধ্যায় ("chapter") + a number. Bengali digits (U+09E6-U+09EF) are positional
+# like the Hindi block above, so only a digit remap is needed. Optional Markdown
+# "#" prefix so "## অধ্যায় ১" is recognized in converted ebooks. Requiring a
+# number keeps prose that merely uses the word অধ্যায় from matching.
+_BN_DIGITS = "০-৯"
+_BN_DIGIT_MAP = str.maketrans("০১২৩৪৫৬৭৮৯", "0123456789")
+_BN_CHAPTER = re.compile(
+    rf"^\s*(?:#{{1,6}}\s+)?অধ্যায়\s*([0-9{_BN_DIGITS}]+)\b"
+)
+
 # Korean chapter headings: "제1장 총칙", "## 제4장 근로시간과 휴식", "제6장의2 …".
 # 제 + Arabic numeral + a classifier (장 chapter / 편 part / 절 section / 관
 # subsection), with an optional "의N" branch suffix that Korean statutes use for
@@ -531,6 +542,9 @@ def _match_chapter_number(line: str) -> int | None:
     hm = _HI_CHAPTER.match(s)
     if hm:
         return int(hm.group(1).translate(_HI_DIGIT_MAP))
+    bm = _BN_CHAPTER.match(s)
+    if bm:
+        return int(bm.group(1).translate(_BN_DIGIT_MAP))
     km = _KO_CHAPTER.match(s)
     if km:
         return int(km.group(1))
@@ -547,6 +561,7 @@ def _chapter_number(line: str) -> int | None:
     ("I: Loomings", "## i. introduction", "II. The Carpet-Bag"),
     Chinese ("第三章 …", "## 一 · …", "## 第一讲"), Thai ("บทที่ 3",
     "## บทที่ ๑"), Hindi ("अध्याय 1", "अध्याय १", "## अध्याय 2"),
+    Bengali ("অধ্যায় 1", "অধ্যায় ১", "## অধ্যায় 2"),
     Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and
     Persian ("فصل ۱", "فصل اول", "فصل بیست و یکم", "بخش ۲: مفاهیم",
     "## فصل ۱: مقدمه", PDF-glued "فصل سی و چهارمخداحافظ…") heading styles — each

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -648,6 +648,26 @@ class TestDetectStructure:
         assert _chapter_number("इस अध्याय में हम चर्चा करेंगे") is None
         assert _chapter_number("अध्याय") is None
 
+    def test_detects_bengali_chapters(self):
+        """Bengali headings: `অধ্যায় N`, with Bengali or Arabic digits."""
+        text = (
+            "অধ্যায় ১ ভূমিকা\nবিষয়বস্তু\n"
+            "অধ্যায় ২ পদ্ধতি\nবিষয়বস্তু\n"
+            "অধ্যায় 3 ফলাফল\nবিষয়বস্তু"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_bengali_markdown_prefix(self):
+        text = "## অধ্যায় ১ প্রথম\nবিষয়বস্তু\n## অধ্যায় ২ দ্বিতীয়\nবিষয়বস্তু"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_bengali_prose_is_not_a_chapter_heading(self):
+        """`অধ্যায়` used in prose (no number, or not at the start) is not a heading."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("এই অধ্যায়ে আমরা আলোচনা করব") is None
+        assert _chapter_number("অধ্যায়") is None
+
     # ── Korean chapter headings ────────────────────────────────────────────
 
     def test_korean_je_n_jang(self):


### PR DESCRIPTION
## Summary (Required)

Bengali chapter headings were not detected — `অধ্যায় 1` / `অধ্যায় ১` /
`## অধ্যায় 2` all returned no chapter, so Bengali books fell back to
length-based splitting. This adds an `অধ্যায়` + number matcher, following the
same per-script pattern as the Hindi / Thai / Korean branches.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `_BN_CHAPTER` (and `_BN_DIGIT_MAP`) to `book_to_skill/utils.py` and a
  dispatch branch in `_chapter_number`: `অধ্যায়` ("chapter") followed by a number,
  in Bengali digits (U+09E6–U+09EF) or ASCII, with an optional Markdown `#`
  prefix (`## অধ্যায় ১`). Bengali digits are positional, so — like the Hindi
  block it mirrors — only a digit remap is needed, no numeral composition.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, Persian, and
Hindi; Bengali (~230M+ speakers) is the adjacent unclaimed gap with no support.
Without it, Bengali books get no heading detection and fall back to length
splitting. Matches the established per-script approach.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`_BN_CHAPTER` anchors on the line start (after an optional `#`/`==` prefix, via
the same second-pass strip the other matchers use), requires the label `অধ্যায়`
immediately followed by a number, and remaps Bengali digits to ASCII before
`int()`. Scoped to the digit form (not word ordinals) and requiring a number, so
prose that merely uses the word অধ্যায় (e.g. `এই অধ্যায়ে আমরা…`) does not match.

## Evidence (Required)
- **Tests:** three cases in `TestDetectStructure` — `অধ্যায়` with Bengali and
  ASCII digits detected (3 chapters); Markdown-prefixed `## অধ্যায় N` (2
  chapters); and a false-positive guard (`এই অধ্যায়ে আমরা …` and a bare `অধ্যায়`
  → not a heading).

```
$ pytest -q
542 passed, 11 skipped
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the Hindi/Thai/Korean pattern (label + positional-digit remap), mirroring
the merged Hindi `अध्याय` matcher one block above it. `অধ্যায়` is the unambiguous
Bengali word for "chapter"; kept v1 to the digit form to avoid false positives
from word ordinals. `CHANGELOG.md` untouched — git-cliff generates it from the
title (#104). No open PR touches Bengali chapter detection.
