### PR TITLE
fix: detect plain numbered chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -508,35 +508,54 @@ def _roman_to_int(s: str) -> int | None:
 
 def _match_chapter_number(line: str) -> int | None:
     """Return the chapter number if the line is a genuine chapter heading,
-    with no Markdown/AsciiDoc heading prefix (the caller strips it first)."""
+    with no Markdown/AsciiDoc heading prefix (the caller strips it first).
+    """
     # Normalize Kangxi-radical numerals (⼀⼆⼋⼗) to ideographs so Chinese
     # ebooks that encode chapter numbers in the U+2F00 block are detected.
     s = line.strip().translate(_KANGXI_NUMERAL_TRANS)
+
     if len(s) > 80:
         return None
+
+    # Plain numbered chapter headings used by many technical books,
+    # e.g. "1  Introduction" or "12  Advanced Topics".
+    #
+    # Require at least two spaces after the chapter number. This avoids
+    # treating ordinary numbered list items such as "1. Item" as chapters.
+    plain = re.match(r"^([1-9]\d{0,2})\s{2,}\S", s)
+    if plain:
+        return int(plain.group(1))
+
     m = _EXPLICIT_CHAPTER.match(s)
     if m and _HEADING_TAIL.match(m.group("rest")):
         if m.group(1):
             return int(m.group(1))
         return _roman_to_int(m.group("roman").upper())
+
     rm = _ROMAN_HEAD.match(s) or _LC_MD_ROMAN.match(s)
     if rm:
         return _roman_to_int(rm.group(1))
+
     cm = _CN_CHAPTER.match(s) or _MD_CN_HEADING.match(s)
     if cm:
         return _cn_numeral_to_int(cm.group(1))
+
     tm = _TH_CHAPTER.match(s)
     if tm:
         return int(tm.group(1).translate(_TH_DIGIT_MAP))
+
     hm = _HI_CHAPTER.match(s)
     if hm:
         return int(hm.group(1).translate(_HI_DIGIT_MAP))
+
     km = _KO_CHAPTER.match(s)
     if km:
         return int(km.group(1))
+
     fa = _fa_chapter_number(s)
     if fa is not None:
         return fa
+
     return None
 
 

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -919,6 +919,24 @@ class TestDetectStructure:
         text = "Capítulo 1\nalgum texto\nCapítulo 2\nmais texto\n"
         assert detect_structure(text)["chapters_detected"] == 2
 
+    def test_detects_plain_numbered_chapter_headings(self):
+        """Plain numbered headings such as '1  Introduction' are chapters."""
+        text = (
+            "1  Introdução e Visão Geral\n"
+            "Texto do capítulo.\n"
+            "2  Princípios Fundamentais\n"
+            "Texto do capítulo.\n"
+            "3  Produtos de Trabalho\n"
+            "Texto do capítulo.\n"
+            "4  Práticas para Elaboração\n"
+            "Texto do capítulo.\n"
+        )
+
+        result = detect_structure(text)
+
+        assert result["chapters_detected"] == 4
+        assert result["chapters_method"] == "numeric"
+
     def test_distinct_numbering_dedups_toc_and_body(self):
         # A ToC heading and the body heading for the same chapter count once.
         text = "Capítulo 1: Alicerces\n...\nCapítulo 1\nbody of chapter one\n"


### PR DESCRIPTION
## Summary

Add support for technical books that identify top-level chapters using a plain number followed by whitespace and a title, such as `1  Introduction` or `2  Fundamentals`, without an explicit `Chapter` or `Capítulo` marker.

This format is used by the CPRE Foundation Level Handbook and was previously not recognized by `_match_chapter_number()`.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance
- [ ] ♻️ Refactor
- [ ] 📚 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change

## What it does

Adds detection for plain numbered chapter headings in the form:

`<chapter number><two or more spaces><title>`

For example:

`1  Introdução e Visão Geral`
`2  Princípios Fundamentais da Engenharia de Requisitos`

The detected chapter number is returned through the existing numeric chapter detection path.

The matcher is intentionally conservative and requires at least two spaces after the chapter number, avoiding common false positives such as:

`1. Item`
`2. Item`
`2025. Text`

## Motivation & context

While processing the CPRE Foundation Level Handbook, the existing chapter detection reported no numeric chapters because the handbook uses numbered headings without an explicit chapter keyword.

The document structure contains top-level headings such as:

`1  Introdução e Visão Geral`
`2  Princípios Fundamentais da Engenharia de Requisitos`
`3  Produtos de Trabalho e Práticas de Documentação`

These headings represent genuine top-level chapters but were not recognized by the existing _match_chapter_number() logic.

## How it works

The change adds a dedicated matcher to `_match_chapter_number()`:

`^([1-9]\d{0,2})\s{2,}\S`

This recognizes a positive chapter number followed by at least two whitespace characters and a non-whitespace title character.

A regression test was added to verify that four plain numbered headings are detected as numeric chapters.

## Validation

- Added regression test for plain numbered chapter headings.
- Verified relevant false-positive guards for numbered list items, years, inline cross-references, and existing titled headings.
- Full test suite: `540 passed, 11 skipped`.
- `git diff --check` passes.
## Evidence

- Regression test added for plain numbered chapter headings.
- The new matcher recognizes headings such as `1  Introduction` and `4  Practices` through the existing numeric chapter detection path.
- Relevant false-positive tests continue to pass for numbered list items, years, inline cross-references, and existing chapter headings.
- Full test suite: `540 passed, 11 skipped`.
- `git diff --check` passes.

## Checklist

- [x] The change is covered by tests.
- [x] Existing behavior for supported chapter formats remains intact.
- [x] False-positive guards for numbered lists and years were verified.
- [x] No unrelated files or generated artifacts are included.
- [x] The PR follows the project's required structure.