### PR TITLE
fix: add pdfminer fallback for PDF page counts

### DIFF
--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -169,22 +169,42 @@ def extract_with_docling(pdf_path: str) -> str | None:
 
 
 def count_pages(pdf_path: str) -> int:
-    # Try pdfinfo first
+    """Return the number of pages in a PDF using progressively safer fallbacks."""
+    # Try pdfinfo first.
     if shutil.which("pdfinfo"):
         try:
             pdf_path = os.path.abspath(pdf_path)
             result = subprocess.run(
-                ["pdfinfo", pdf_path], capture_output=True, text=True, timeout=15
+                ["pdfinfo", pdf_path],
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
             for line in result.stdout.splitlines():
                 if line.startswith("Pages:"):
                     return int(line.split(":")[1].strip())
         except Exception:
             pass
-    # Fallback: count pages with pypdf
+
+    # Fallback: count pages with pypdf.
     try:
         import pypdf
+
         with open(pdf_path, "rb") as f:
             return len(pypdf.PdfReader(f).pages)
     except Exception:
-        return 0
+        pass
+
+    # Final fallback: pdfminer.extract_text() preserves page boundaries
+    # using form-feed characters, so the number of pages can be derived
+    # without requiring a separate PDF page-counting dependency.
+    try:
+        from pdfminer.high_level import extract_text
+
+        text = extract_text(pdf_path)
+        if text:
+            return text.count("\f") + (0 if text.endswith("\f") else 1)
+    except Exception:
+        pass
+
+    return 0

--- a/book_to_skill/parsers/pdf.py
+++ b/book_to_skill/parsers/pdf.py
@@ -205,6 +205,7 @@ def count_pages(pdf_path: str) -> int:
         if text:
             return text.count("\f") + (0 if text.endswith("\f") else 1)
     except Exception:
+        # All page-counting methods are best-effort; preserve the historical 0 result.
         pass
 
     return 0

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -1817,6 +1817,30 @@ class TestPdftotextEncoding:
         assert captured.get("errors") == "replace"
 
 
+class TestPdfPageCount:
+    """Tests for PDF page-count fallback behavior."""
+
+    def test_count_pages_uses_pdfminer_when_pdfinfo_and_pypdf_are_unavailable(
+        self, monkeypatch
+    ):
+        """Use pdfminer as the final fallback when other page counters are unavailable."""
+        fake_pdf = "fake.pdf"
+
+        monkeypatch.setattr(pdf_parser.shutil, "which", lambda _: None)
+
+        high_level = mock.MagicMock()
+        high_level.extract_text.return_value = (
+            "page one\fpage two\fpage three"
+        )
+
+        pdfminer = mock.MagicMock()
+        pdfminer.high_level = high_level
+
+        monkeypatch.setitem(sys.modules, "pdfminer", pdfminer)
+        monkeypatch.setitem(sys.modules, "pdfminer.high_level", high_level)
+
+        assert pdf_parser.count_pages(fake_pdf) == 3
+
 class TestLooksImageOnly:
     """Scanned PDFs are caught by probing the first pages, before the chain runs."""
 


### PR DESCRIPTION
## Summary

Add a pdfminer fallback to `count_pages()` for environments where both `pdfinfo` and `pypdf` are unavailable or unable to determine the PDF page count.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📚 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

Extends `book_to_skill.parsers.pdf.count_pages()` with a third fallback:

`pdfinfo` → `pypdf` → `pdfminer` → `0`

The new fallback uses `pdfminer.high_level.extract_text()` and counts form-feed page boundaries in the extracted text.

The existing `pdfinfo` and `pypdf` paths remain unchanged in their role and order.

## Motivation & context

The PDF extraction pipeline already uses pdfminer as a supported PDF text-extraction backend.

However, `count_pages()` previously stopped after `pdfinfo` and `pypdf` failed and returned `0`, even in environments where pdfminer was available and could successfully extract the document.

This can produce incomplete PDF metadata even though the same PDF is otherwise successfully processed by the project.

## Evidence

- Added a regression test covering the case where `pdfinfo` and `pypdf` are unavailable.
- The test simulates a three-page pdfminer extraction using form-feed page boundaries.
- Verified the fallback returns `3` pages.
- Full test suite: `540 passed, 11 skipped`.
- `git diff --check` passes.

## Checklist

- [x] The change is covered by tests.
- [x] Existing `pdfinfo` and `pypdf` paths remain first in the fallback chain.
- [x] The final `0` fallback is preserved when all page-counting methods fail.
- [x] No unrelated files or generated artifacts are included.
- [x] The PR follows the project's required structure.