### PR TITLE
ci: add version comments to SHA pins and pin codeql-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pytest
@@ -33,8 +33,8 @@ jobs:
     name: lint (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install ruff
@@ -49,8 +49,8 @@ jobs:
     name: smoke (dependency-free extraction)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Extract a sample with no optional deps installed
@@ -68,8 +68,8 @@ jobs:
     name: security (bandit + zizmor)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install scanners
@@ -91,8 +91,8 @@ jobs:
     name: validate SKILL.md (Claude Code rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Audit SKILL.md against Claude Code skill rules

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,13 +18,13 @@ jobs:
     name: analyze (python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: python
           queries: security-and-quality
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:python"


### PR DESCRIPTION
## Summary (Required)

`ci.yml` already pins every action to a full commit SHA, but without the trailing version comment — so a reader cannot tell which release a pin is, and Dependabot will not propose an update for it. This adds the comment to all ten pins (no SHA changes) and pins the three floating tags left in `codeql.yml`. `deploy-docs.yml` already uses exactly this form; this makes the other two match it.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [x] 🔒 Security
- [x] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** `codeql.yml` resolved `actions/checkout@v7.0.1`, `github/codeql-action/init@v4` and `github/codeql-action/analyze@v4` at run time, so a moved tag changed what CI executed without any commit in this repo.
- **Improves:** zizmor on `.github/workflows/` goes from **18 findings (3 high)** to **15 findings (0 high)**; all six `unpinned-uses` findings are gone. Dependabot can now see a version for the ten `ci.yml` pins it was previously blind to.

## Motivation & context (Required)

Closes n/a — no issue open for this; noticed while reading the workflows.

A bare SHA is reproducible but opaque: `actions/setup-python@5fda3b95…` tells a reviewer nothing, and Dependabot's `github-actions` ecosystem needs the `# vX.Y.Z` comment to know what the pin currently is before it can offer a bump. Without it the pins are frozen rather than maintained. `deploy-docs.yml` already carries the comments, so this is finishing a convention the repo has, not proposing a new one.

## How it works (Required for anything non-trivial)

Generated with `pinact run` (v4.1.1), then verified with `pinact run --check --verify-comment --min-age 7 --verify-min-age` and `actionlint`.

One deliberate choice worth flagging: **`codeql-action` is pinned to v4.37.8, not the current v4.37.9.** v4.37.9 shipped on 2026-08-26, three days ago. Pinning only releases that have been public for at least seven days is what gives a bad or compromised release time to be found and yanked before it reaches CI. v4.37.8 (2026-08-21) clears that window. Dependabot will move it forward on its own schedule.

`ci.yml` SHAs are byte-identical before and after — only the comments are new.

## Evidence (Required)

- **Tests:** none added; this touches no Python. All existing suites run on a clean checkout of the branch.

```
$ pytest tests/ -q
587 passed, 5 skipped in 0.66s

$ ruff check .
All checks passed!

$ ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/
All checks passed!

$ bandit -q -r book_to_skill scripts tools --severity-level high --confidence-level medium
(exit 0)

$ python3 tools/validate_skill.py SKILL.md
✓ SKILL.md [Claude Code]: no Claude Code-breaking issues (1 warning(s))
  (the warning is the pre-existing 724-line body, unchanged by this PR)

$ actionlint
(exit 0)

$ pinact run --check --verify-comment --min-age 7 --verify-min-age
(exit 0)

zizmor .github/workflows/
  before: 18 findings (8 suppressed): 1 low, 6 medium, 3 high
  after:  15 findings (8 suppressed): 0 low, 7 medium, 0 high
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)

Deliberately left out to keep this to one thing — happy to open either as a follow-up if you want them:

- `dependabot.yml` has no `cooldown:`. Adding `cooldown: {default-days: 7}` would make Dependabot itself respect the same seven-day rule this PR applies by hand, so the pins stay current without a fresh release landing in CI on day one.
- zizmor's seven remaining medium findings are all `artipacked` — `actions/checkout` leaves the GitHub token in `.git/config` unless `persist-credentials: false` is set. That is a real hardening step but a different change, and it touches job behaviour rather than just pins.
