### PR TITLE
feat(extractor): detect Russian (Глава) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -198,6 +198,15 @@ _BN_CHAPTER = re.compile(
     rf"^\s*(?:#{{1,6}}\s+)?অধ্যায়\s*([0-9{_BN_DIGITS}]+)\b"
 )
 
+# Russian (Cyrillic) chapter headings: "Глава 1", "ГЛАВА 12", "## Глава 2".
+# "Глава" ("chapter") + a number. Cyrillic uses ordinary Arabic digits, so —
+# unlike the Devanagari/Bengali blocks above — no digit remap is needed. A
+# dedicated matcher (rather than adding the word to _EXPLICIT_CHAPTER) is used
+# because that alternation is Latin-only and its number would still be read
+# there. Requiring whitespace then a number keeps prose that merely uses an
+# inflected form ("В этой главе…", "Главная страница") from matching.
+_RU_CHAPTER = re.compile(r"^\s*(?:#{1,6}\s+)?глава\s+([0-9]+)\b", re.IGNORECASE)
+
 # Korean chapter headings: "제1장 총칙", "## 제4장 근로시간과 휴식", "제6장의2 …".
 # 제 + Arabic numeral + a classifier (장 chapter / 편 part / 절 section / 관
 # subsection), with an optional "의N" branch suffix that Korean statutes use for
@@ -563,6 +572,9 @@ def _match_chapter_number(line: str) -> int | None:
     bm = _BN_CHAPTER.match(s)
     if bm:
         return int(bm.group(1).translate(_BN_DIGIT_MAP))
+    rum = _RU_CHAPTER.match(s)
+    if rum:
+        return int(rum.group(1))
 
     km = _KO_CHAPTER.match(s)
     if km:
@@ -583,6 +595,7 @@ def _chapter_number(line: str) -> int | None:
     Chinese ("第三章 …", "## 一 · …", "## 第一讲"), Thai ("บทที่ 3",
     "## บทที่ ๑"), Hindi ("अध्याय 1", "अध्याय १", "## अध्याय 2"),
     Bengali ("অধ্যায় 1", "অধ্যায় ১", "## অধ্যায় 2"),
+    Russian ("Глава 1", "ГЛАВА 12", "## Глава 2"),
     Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and
     Persian ("فصل ۱", "فصل اول", "فصل بیست و یکم", "بخش ۲: مفاهیم",
     "## فصل ۱: مقدمه", PDF-glued "فصل سی و چهارمخداحافظ…") heading styles — each

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -668,6 +668,27 @@ class TestDetectStructure:
         assert _chapter_number("এই অধ্যায়ে আমরা আলোচনা করব") is None
         assert _chapter_number("অধ্যায়") is None
 
+    def test_detects_russian_chapters(self):
+        """Russian headings: `Глава N`, case-insensitive, with Arabic digits."""
+        text = (
+            "Глава 1 Введение\nсодержание\n"
+            "ГЛАВА 2 Методы\nсодержание\n"
+            "Глава 3 Результаты\nсодержание"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_russian_markdown_prefix(self):
+        text = "## Глава 1 Первая\nсодержание\n## Глава 2 Вторая\nсодержание"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_russian_prose_is_not_a_chapter_heading(self):
+        """An inflected form or a different word (Главная) is not a heading."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("В этой главе мы обсудим") is None
+        assert _chapter_number("Главная страница") is None
+        assert _chapter_number("Глава") is None
+
     # ── Korean chapter headings ────────────────────────────────────────────
 
     def test_korean_je_n_jang(self):


### PR DESCRIPTION
## Summary (Required)

Russian (Cyrillic) chapter headings were not detected — `Глава 1` / `ГЛАВА 12` /
`## Глава 2` all returned no chapter, so Russian books fell back to length-based
splitting. This adds a `Глава` + number matcher, following the same per-script
pattern as the Hindi / Bengali / Thai / Korean branches.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `_RU_CHAPTER` to `book_to_skill/utils.py` and a dispatch branch in
  `_chapter_number`: `Глава` ("chapter", case-insensitive) followed by a number,
  with an optional Markdown `#` prefix (`## Глава 2`). Cyrillic uses ordinary
  Arabic digits, so — unlike the Devanagari/Bengali blocks — no digit remap is
  needed; it is the simplest per-script matcher so far.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, Persian,
Hindi, and Bengali. Russian (~250M speakers) writes chapters as `Глава N` in a
distinct script with no current support, so Russian books get no heading
detection and fall back to length splitting.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
A dedicated matcher is used rather than adding the word to `_EXPLICIT_CHAPTER`,
because that alternation is Latin-only. `_RU_CHAPTER` anchors on the line start
(after an optional `#`/`==` prefix, via the same second-pass strip the other
matchers use), requires the label `Глава` (case-insensitive) then whitespace and
a number. Requiring whitespace + a number keeps inflected forms and different
words from matching: `В этой главе…` (prepositional case) and `Главная страница`
("main page", where `Глава` is only a prefix) are both rejected, as is a bare
`Глава`.

## Evidence (Required)
- **Tests:** three cases in `TestDetectStructure` — `Глава`/`ГЛАВА` detected
  case-insensitively (3 chapters); Markdown-prefixed `## Глава N` (2 chapters);
  and a false-positive guard (`В этой главе …`, `Главная страница`, and a bare
  `Глава` → not a heading).

```
$ pytest -q tests/test_book_to_skill.py
228 passed
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the Hindi/Bengali pattern (dedicated label matcher), simplified because
Cyrillic uses Arabic digits — no numeral map. `Глава` is the unambiguous Russian
word for "chapter"; kept v1 to the digit form to avoid false positives from word
ordinals (`Глава первая`). `CHANGELOG.md` untouched — git-cliff generates it from
the title (#104). No open PR touches Russian chapter detection.
