### PR TITLE
test(evals): stabilize paper-flat file ordering

### DIFF
--- a/tests/evals/test_paper_flat.py
+++ b/tests/evals/test_paper_flat.py
@@ -72,6 +72,9 @@ def test_no_heading_uses_one_full_source_chunk(tmp_path):
 
 def test_pack_has_no_child_skill_hierarchy(tmp_path):
     build(tmp_path)
-    files = sorted(path.relative_to(tmp_path / "pack") for path in (tmp_path / "pack").rglob("*") if path.is_file())
+    files = sorted(
+        (path.relative_to(tmp_path / "pack") for path in (tmp_path / "pack").rglob("*") if path.is_file()),
+        key=lambda path: path.as_posix(),
+    )
     assert files == [Path("SKILL.md"), Path("chunks/chunk-01.md"), Path("chunks/chunk-02.md")]
     assert all(path.name == "SKILL.md" for path in files if path.name == "SKILL.md")


### PR DESCRIPTION
## Summary

Make the paper-flat evaluation tree assertion sort relative paths by their POSIX string representation. This keeps the expected ordering stable on Windows and POSIX.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [x] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes:** the platform-dependent `Path` ordering used by `test_pack_has_no_child_skill_hierarchy`.
- **Improves:** the same generated pack now has one deterministic assertion order on Windows and POSIX.
- **Adds:** no runtime behavior, dependencies, or generated-skill content.

## Motivation & context

Closes n/a — the failure is a test-only portability defect found by the repository test suite on Windows. Windows normalizes case while comparing `Path` objects, so `chunks/...` sorted before `SKILL.md` despite the test expecting the POSIX order.

## How it works

The test keeps its existing path objects and expected values, but sorts the relative paths with `path.as_posix()` as the key. String ordering of those POSIX representations is explicit and independent of host path-comparison semantics.

## Evidence

- **Tests:** existing paper-flat tests exercise the generated synthetic pack; no source document or generated-skill behavior changed.
- **Before / after:** before, the full suite had 584 passed, 1 failed, and 7 skipped on Windows; after, it has 585 passed, 0 failed, and 7 skipped.

```
pytest -q tests/evals/test_paper_flat.py  -> 6 passed
pytest -q tests                           -> 585 passed, 7 skipped
ruff check .                              -> clean
python tools/validate_skill.py SKILL.md   -> no Claude Code-breaking issues
```

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

The change is confined to `tests/evals/test_paper_flat.py`. It uses only the repository tracked synthetic paper-flat fixtures and does not run extraction against a book or document.