### PR TITLE
feat(hosts): add Hermes Agent skill discovery and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in GitHub Copilot CLI, Amp, or Claude Code.</strong>
+  <strong>Turn any technical book, document folder, or collection of sources into a unified agent skill — ready to study, reference, and use while you work in GitHub Copilot CLI, Amp, Claude Code, or Hermes Agent.</strong>
 </p>
 
 <p align="center">
@@ -66,13 +66,13 @@ The usual workarounds don't help:
 
 Once installed, you just type `/your-book-slug replication` and the agent reads the right chapter and answers from the actual content. No hallucination. No digging through PDFs. The book becomes part of your workflow.
 
-Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — GitHub Copilot CLI, Amp, and Claude Code all read the same `SKILL.md` format.
+Works with any host that supports the open [Agent Skills](https://github.com/agentskills/agentskills) standard — GitHub Copilot CLI, Amp, Claude Code, and Hermes Agent all read the same `SKILL.md` format.
 
 ---
 
 ## 📦 What it generates
 
-Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Amp or cross-agent, `~/.claude/skills/<slug>/` for Claude Code):
+Running `/book-to-skill your-book.pdf` (or a folder, glob, or list of files) creates a full skill in your agent's skills directory (`~/.copilot/skills/<slug>/` for Copilot CLI, `~/.agents/skills/<slug>/` for Amp or cross-agent, `~/.claude/skills/<slug>/` for Claude Code, or `$HERMES_HOME/skills/<category>/<slug>/` for Hermes Agent):
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -135,6 +135,7 @@ npx skills add virgiliojr94/book-to-skill
 # Or manually — clone into your skills folder (registers /book-to-skill):
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 # (Copilot CLI: ~/.copilot/skills/ · Amp/cross-agent: ~/.agents/skills/)
+# (Hermes Agent: ${HERMES_HOME:-$HOME/.hermes}/skills/<category>/)
 ```
 
 📥 **All hosts, optional extractors, and the standalone CLI → [docs/install.md](docs/install.md)**

--- a/README.ru.md
+++ b/README.ru.md
@@ -15,7 +15,7 @@
 > Чтобы увидеть drift: `git log 903d102..master -- README.md`
 
 <p align="center">
-  <strong>Превратите любую техническую книгу, папку документов или набор источников в единый agent skill — чтобы изучать, ссылаться и использовать в GitHub Copilot CLI, Amp или Claude Code.</strong>
+  <strong>Превратите любую техническую книгу, папку документов или набор источников в единый agent skill — чтобы изучать, ссылаться и использовать в GitHub Copilot CLI, Amp, Claude Code или Hermes Agent.</strong>
 </p>
 
 <p align="center">
@@ -70,13 +70,13 @@
 
 После установки: `/your-book-slug replication` — агент читает нужную главу и отвечает из текста. Без галлюцинаций и копания в PDF.
 
-Работает с хостами open [Agent Skills](https://github.com/agentskills/agentskills) — GitHub Copilot CLI, Amp, Claude Code (общий формат `SKILL.md`).
+Работает с хостами open [Agent Skills](https://github.com/agentskills/agentskills) — GitHub Copilot CLI, Amp, Claude Code и Hermes Agent (общий формат `SKILL.md`).
 
 ---
 
 ## 📦 Что получается
 
-`/book-to-skill your-book.pdf` (или folder/glob) создаёт skill в директории skills агента (`~/.copilot/skills/<slug>/`, `~/.agents/skills/<slug>/`, `~/.claude/skills/<slug>/`):
+`/book-to-skill your-book.pdf` (или folder/glob) создаёт skill в директории skills агента (`~/.copilot/skills/<slug>/`, `~/.agents/skills/<slug>/`, `~/.claude/skills/<slug>/` или `$HERMES_HOME/skills/<category>/<slug>/` для Hermes Agent):
 
 | File | Purpose | Size |
 |------|---------|------|
@@ -139,6 +139,7 @@ npx skills add virgiliojr94/book-to-skill
 # Or manually:
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
 # (Copilot: ~/.copilot/skills/ · Amp: ~/.agents/skills/)
+# (Hermes Agent: ${HERMES_HOME:-$HOME/.hermes}/skills/<category>/)
 ```
 
 📥 **Все хосты → [docs/install.md](docs/install.md)**

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: book-to-skill
-description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, or Claude Code, apply an author's frameworks while working, or build a reusable knowledge base from a file."
+description: "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, plain text, RTF, MOBI/AZW with Calibre) into structured agent skills, extracting frameworks, mental models, principles, techniques, and anti-patterns. Use when the user wants to study a document through GitHub Copilot CLI, Amp, Claude Code, or Hermes Agent, apply an author's frameworks while working, or build a reusable knowledge base from a file."
 ---
 
 <!--
 Cross-agent notes (informational; ignored by host agents):
   - Compatible skill roots: GitHub Copilot CLI (~/.copilot/skills, ~/.agents/skills,
     .github/skills, .claude/skills, .agents/skills), Amp (.agents/skills,
-    ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills).
+    ~/.config/agents/skills, ~/.config/amp/skills), Claude Code (~/.claude/skills),
+    Hermes Agent ($HERMES_HOME/skills, .hermes/skills, .agents/skills).
   - `allowed-tools` is intentionally omitted to stay agent-neutral: Copilot CLI uses
     `shell`/MCP-server names, Claude uses `Bash`/`Read`/`Write`/`Glob`/`Grep`, Amp
     adds `shell_command`. The skill needs shell (to run extract.py) and file
@@ -21,7 +22,7 @@ Transform written knowledge into actionable agent skills by extracting structure
 
 ## Philosophy
 
-Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format GitHub Copilot CLI, Amp, Claude Code, or another compatible agent can leverage repeatedly.
+Books contain crystallized expertise: frameworks, principles, and techniques that took years to develop. This skill extracts that knowledge into a format GitHub Copilot CLI, Amp, Claude Code, Hermes Agent, or another compatible agent can leverage repeatedly.
 
 **Extract structure, not summaries.** A skill isn't a book report. It's a toolkit of:
 - Named frameworks (mental models with clear application)
@@ -74,6 +75,8 @@ This converter can run from multiple skill systems. When looking for this conver
 6. Project-local Amp / Copilot skills: `.agents/skills/`
 7. Amp global skills: `~/.config/agents/skills/`
 8. Amp legacy global skills: `~/.config/amp/skills/`
+9. Hermes Agent personal skills: `$HERMES_HOME/skills/` (defaults to `~/.hermes/skills/`)
+10. Hermes Agent project skills: `.hermes/skills/` or `.agents/skills/`
 
 For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
 
@@ -130,13 +133,18 @@ Run the extraction script, passing the input paths:
 
 ```bash
 SCRIPT_PATH=""
+HERMES_HOME_RESOLVED="${HERMES_HOME:-$HOME/.hermes}"
 for candidate in \
   "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
+  "$HERMES_HOME_RESOLVED/skills/book-to-skill/scripts/extract.py" \
+  "$HERMES_HOME_RESOLVED"/skills/*/book-to-skill/scripts/extract.py \
   ".github/skills/book-to-skill/scripts/extract.py" \
   ".claude/skills/book-to-skill/scripts/extract.py" \
   ".agents/skills/book-to-skill/scripts/extract.py" \
+  ".hermes/skills/book-to-skill/scripts/extract.py" \
+  ".hermes/skills"/*/book-to-skill/scripts/extract.py \
   "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
   "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
 do
@@ -313,12 +321,15 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 | **Amp** | `~/.agents/skills` → `~/.config/agents/skills` → `~/.config/amp/skills` | `.agents/skills` |
 | **Claude Code** | `~/.claude/skills` | `.claude/skills` |
 | **OpenAI Codex** | `~/.agents/skills` (discovered natively; follows symlinks) | `.agents/skills` |
+| **Hermes Agent** | `$HERMES_HOME/skills/<category>` (defaults to `~/.hermes/skills/<category>`) | `.hermes/skills/<category>` → `.agents/skills` |
+
+For Hermes Agent, use the active profile's `HERMES_HOME` and choose a category that matches the generated skill's subject. Do not construct profile paths manually. If the user selects a project-local Hermes root, run `hermes skills trust <project-root>` after generation and verify discovery with `hermes skills list`; project skills remain unavailable until the project is trusted.
 
 Selection rules:
 1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
 2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
 3. If the user explicitly asked for project-local output, prefer the project-local row.
-4. If you cannot identify the host, ask: "Which agent are you running this in — GitHub Copilot CLI, Amp, Codex, or Claude Code?"
+4. If you cannot identify the host, ask: "Which agent are you running this in — Hermes Agent, GitHub Copilot CLI, Amp, Codex, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.
 If it does, prompt the user to choose:
@@ -603,6 +614,7 @@ Reload (if your agent doesn't auto-detect new skills):
   GitHub Copilot CLI:  /skills reload
   Claude Code:         restart the session
   Amp:                 restart the session
+  Hermes Agent:         start a new session
 
 Share this skill (optional):
   GitHub repo, installable on any host (Step 11):  say "publish"

--- a/SKILL.md
+++ b/SKILL.md
@@ -134,9 +134,10 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 HERMES_HOME_RESOLVED="${HERMES_HOME:-$HOME/.hermes}"
-PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 HERMES_PROJECT_TRUSTED=false
-if [ "${HERMES_AGENT:-}" = true ] && command -v hermes >/dev/null 2>&1 && \
+if [ -n "$PROJECT_ROOT" ] && [ "${HERMES_AGENT:-}" = true ] && \
+  command -v hermes >/dev/null 2>&1 && \
   command -v python3 >/dev/null 2>&1 && \
   hermes config get skills.trusted_project_dirs --json 2>/dev/null | PROJECT_ROOT="$PROJECT_ROOT" python3 -c 'import json, os, pathlib, sys; root=pathlib.Path(os.environ["PROJECT_ROOT"]).resolve(); sys.exit(not any(pathlib.Path(p).expanduser().resolve() == root for p in json.load(sys.stdin)))' 2>/dev/null
 then

--- a/SKILL.md
+++ b/SKILL.md
@@ -134,19 +134,43 @@ Run the extraction script, passing the input paths:
 ```bash
 SCRIPT_PATH=""
 HERMES_HOME_RESOLVED="${HERMES_HOME:-$HOME/.hermes}"
-for candidate in \
-  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.agents/skills/book-to-skill/scripts/extract.py" \
-  "$HOME/.claude/skills/book-to-skill/scripts/extract.py" \
-  "$HERMES_HOME_RESOLVED/skills/book-to-skill/scripts/extract.py" \
-  "$HERMES_HOME_RESOLVED"/skills/*/book-to-skill/scripts/extract.py \
-  ".github/skills/book-to-skill/scripts/extract.py" \
-  ".claude/skills/book-to-skill/scripts/extract.py" \
-  ".agents/skills/book-to-skill/scripts/extract.py" \
-  ".hermes/skills/book-to-skill/scripts/extract.py" \
-  ".hermes/skills"/*/book-to-skill/scripts/extract.py \
-  "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py" \
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+HERMES_PROJECT_TRUSTED=false
+if [ "${HERMES_AGENT:-}" = true ] && command -v hermes >/dev/null 2>&1 && \
+  command -v python3 >/dev/null 2>&1 && \
+  hermes config get skills.trusted_project_dirs --json 2>/dev/null | PROJECT_ROOT="$PROJECT_ROOT" python3 -c 'import json, os, pathlib, sys; root=pathlib.Path(os.environ["PROJECT_ROOT"]).resolve(); sys.exit(not any(pathlib.Path(p).expanduser().resolve() == root for p in json.load(sys.stdin)))' 2>/dev/null
+then
+  HERMES_PROJECT_TRUSTED=true
+fi
+
+CANDIDATES=(
+  "$HOME/.copilot/skills/book-to-skill/scripts/extract.py"
+  "$HOME/.agents/skills/book-to-skill/scripts/extract.py"
+  "$HOME/.claude/skills/book-to-skill/scripts/extract.py"
+  "$HERMES_HOME_RESOLVED/skills/book-to-skill/scripts/extract.py"
+  "$HERMES_HOME_RESOLVED"/skills/*/book-to-skill/scripts/extract.py
+)
+if [ "${HERMES_AGENT:-}" != true ]; then
+  CANDIDATES+=(
+    ".github/skills/book-to-skill/scripts/extract.py"
+    ".claude/skills/book-to-skill/scripts/extract.py"
+    ".agents/skills/book-to-skill/scripts/extract.py"
+  )
+fi
+CANDIDATES+=(
+  "$HOME/.config/agents/skills/book-to-skill/scripts/extract.py"
   "$HOME/.config/amp/skills/book-to-skill/scripts/extract.py"
+)
+if [ "$HERMES_PROJECT_TRUSTED" = true ]; then
+  CANDIDATES=(
+    "$PROJECT_ROOT/.hermes/skills/book-to-skill/scripts/extract.py"
+    "$PROJECT_ROOT/.hermes/skills"/*/book-to-skill/scripts/extract.py
+    "$PROJECT_ROOT/.agents/skills/book-to-skill/scripts/extract.py"
+    "$PROJECT_ROOT/.agents/skills"/*/book-to-skill/scripts/extract.py
+    "${CANDIDATES[@]}"
+  )
+fi
+for candidate in "${CANDIDATES[@]}"
 do
   if [ -f "$candidate" ]; then
     SCRIPT_PATH="$candidate"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,9 @@ document into clean text + metadata; the agent turns that into a structured skil
                   ~/.copilot/skills/   GitHub Copilot CLI
                   ~/.agents/skills/    Copilot CLI or Amp (cross-agent)
                   ~/.claude/skills/    Claude Code
-                  .github|.claude|.agents/skills/  project-local
+                  $HERMES_HOME/skills/<category>/  Hermes Agent
+                  .github/skills/ | .claude/skills/ | .agents/skills/  project-local
+                  .hermes/skills/<category>/                         Hermes project-local
                   SKILL.md         core frameworks + chapter & topic index (~4K)
                   chapters/*.md    on-demand, loaded only when asked
                   glossary.md      terms
@@ -73,7 +75,7 @@ document into clean text + metadata; the agent turns that into a structured skil
 | `book_to_skill/dependencies.py` | optional-dependency probing + `--check` |
 | `book_to_skill/sanitize.py` | strips zero-width / Unicode-tag-block characters from extracted text (see Security) |
 | `tools/discovery_tax.py` | measures token cost vs context-dump / discovery loop |
-| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude\|copilot\|amp`) |
+| `tools/validate_skill.py` | checks a generated SKILL.md against host rules (`--lens claude\|copilot\|amp\|hermes`) |
 | `tools/scan_generated_skill.py` | advisory prompt-injection scan of a generated skill (see Security) |
 | `SKILL.md` | the generator spec (Steps 0–10 + fold-in workflow) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Turn any book, PDF or EPUB into a structured agent skill for Claude Code, GitHub Copilot CLI and Amp. Named frameworks and decision rules, loaded on demand."
+description: "Turn any book, PDF or EPUB into a structured agent skill for Claude Code, GitHub Copilot CLI, Amp and Hermes Agent. Named frameworks and decision rules, loaded on demand."
 seo_title: "book-to-skill - Turn Any Book Into an AI Agent Skill"
 hide:
   - navigation
@@ -13,7 +13,7 @@ hide:
   "name": "book-to-skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Linux, macOS, Windows",
-  "description": "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, RTF, MOBI/AZW) into structured, on-demand agent skills for Claude Code, GitHub Copilot CLI and Amp.",
+  "description": "Converts books and documents (PDF, EPUB, DOCX, HTML, Markdown, RTF, MOBI/AZW) into structured, on-demand agent skills for Claude Code, GitHub Copilot CLI, Amp and Hermes Agent.",
   "url": "https://booktoskill.is-a.dev/",
   "codeRepository": "https://github.com/virgiliojr94/book-to-skill",
   "license": "https://opensource.org/licenses/MIT",
@@ -63,14 +63,14 @@ Turn any book or document into a structured, on-demand agent skill — named fra
 
     ---
 
-    One `SKILL.md` runs on Claude Code, GitHub Copilot CLI, and Amp through the
-    open Agent Skills standard.
+    One `SKILL.md` runs on Claude Code, GitHub Copilot CLI, Amp, and Hermes Agent
+    through the open Agent Skills standard.
 
 </div>
 
 ## Install
 
-**As an agent skill** (gives you the `/book-to-skill` command in Claude Code, Copilot CLI, Amp):
+**As an agent skill** (gives you the `/book-to-skill` command in Claude Code, Copilot CLI, Amp, or Hermes Agent):
 
 ```bash
 npx skills add virgiliojr94/book-to-skill

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,12 @@
 ---
-description: "Install book-to-skill as an agent skill for Claude Code, GitHub Copilot CLI, Amp and Codex, or as a standalone pip CLI. Every host path and optional extractor covered."
-seo_title: "Install book-to-skill - Claude Code, Copilot CLI, Amp, or pip"
+description: "Install book-to-skill as an agent skill for Claude Code, GitHub Copilot CLI, Amp, Codex and Hermes Agent, or as a standalone pip CLI. Every host path and optional extractor covered."
+seo_title: "Install book-to-skill - Claude Code, Copilot CLI, Amp, Hermes, or pip"
 ---
 
 ## 📥 Install
 
 > **Two ways to use it, do not confuse them:**
-> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, Amp, or Codex) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
+> - **As an agent skill** (the `/book-to-skill` command in Claude Code, Copilot CLI, Amp, Codex, or Hermes Agent) → **`git clone` into your skills folder** (below). This is what gives you the slash command and the full convert-a-book flow.
 > - **As a standalone CLI** (just the text extractor) → `pip install` it from the repository, then `book-to-skill --help`. This does **not** register the agent skill; it only installs the extraction engine. See [the CLI section](#standalone-cli-pip).
 
 The skill follows the open [Agent Skills](https://github.com/agentskills/agentskills) standard, so a single install works for any compatible host.
@@ -39,6 +39,30 @@ git clone https://github.com/virgiliojr94/book-to-skill.git ~/.agents/skills/boo
 ```bash
 ln -s /path/to/book-to-skill ~/.agents/skills/book-to-skill
 ```
+
+**Hermes Agent**:
+
+```bash
+git clone https://github.com/virgiliojr94/book-to-skill.git \
+  "${HERMES_HOME:-$HOME/.hermes}/skills/productivity/book-to-skill"
+```
+
+`HERMES_HOME` is profile-aware and defaults to `~/.hermes`. The converter can
+live under another existing Hermes category if preferred. Start a new Hermes
+session, then invoke `/book-to-skill` or ask Hermes to use the `book-to-skill`
+skill. Generated book skills should go under the category that matches their
+subject rather than automatically reusing `productivity`.
+
+For a project-local installation, use `.hermes/skills/<category>/book-to-skill`
+and explicitly trust the project before starting a new session:
+
+```bash
+hermes skills trust /path/to/project
+hermes skills list
+```
+
+Hermes does not load project-local skills from `.hermes/skills/` or
+`.agents/skills/` until that project has been trusted.
 
 **Claude Code**:
 

--- a/tests/test_hermes_host_support.py
+++ b/tests/test_hermes_host_support.py
@@ -1,5 +1,6 @@
 """Hermes Agent host-discovery contract in the converter spec."""
 
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -17,6 +18,27 @@ def _extract_probe_script():
     return SKILL[start:end] + '\nprintf "%s" "$SCRIPT_PATH"\n'
 
 
+def _env_with_hermes_trust(tmp_path, home, hermes_home, trusted_dirs):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    hermes = bin_dir / "hermes"
+    hermes.write_text(
+        "#!/bin/sh\nprintf '%s\\n' " + repr(json.dumps([str(p) for p in trusted_dirs])) + "\n",
+        encoding="utf-8",
+    )
+    hermes.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "HERMES_AGENT": "true",
+            "HERMES_HOME": str(hermes_home),
+            "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+        }
+    )
+    return env
+
+
 def test_hermes_is_named_as_supported_host():
     assert "Hermes Agent" in SKILL
 
@@ -30,6 +52,9 @@ def test_hermes_extractor_probe_discovers_supported_layouts(tmp_path, layout):
     hermes_home = tmp_path / "hermes-profile"
     project = tmp_path / "project"
     project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    nested = project / "src" / "nested"
+    nested.mkdir(parents=True)
 
     roots = {
         "personal-flat": hermes_home / "skills" / "book-to-skill",
@@ -41,8 +66,131 @@ def test_hermes_extractor_probe_discovers_supported_layouts(tmp_path, layout):
     extractor.parent.mkdir(parents=True)
     extractor.touch()
 
-    env = os.environ.copy()
-    env.update({"HOME": str(home), "HERMES_HOME": str(hermes_home)})
+    env = _env_with_hermes_trust(
+        tmp_path,
+        home,
+        hermes_home,
+        [project] if layout.startswith("project-") else [],
+    )
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=nested,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    selected = Path(result.stdout)
+    if not selected.is_absolute():
+        selected = nested / selected
+    assert selected.resolve() == extractor.resolve()
+
+
+@pytest.mark.parametrize("project_skill_dir", [".hermes", ".agents"])
+def test_hermes_project_extractor_precedes_personal_installation(
+    tmp_path, project_skill_dir
+):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    nested = project / "src" / "nested"
+    nested.mkdir(parents=True)
+
+    personal = hermes_home / "skills" / "productivity" / "book-to-skill" / "scripts" / "extract.py"
+    project_local = (
+        project
+        / project_skill_dir
+        / "skills"
+        / "productivity"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    for extractor in (personal, project_local):
+        extractor.parent.mkdir(parents=True)
+        extractor.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [project])
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=nested,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert Path(result.stdout).resolve() == project_local.resolve()
+
+
+@pytest.mark.parametrize("project_skill_dir", [".hermes", ".agents"])
+@pytest.mark.parametrize("cwd_relative", [".", "src/nested"])
+def test_untrusted_hermes_project_cannot_override_personal_installation(
+    tmp_path, project_skill_dir, cwd_relative
+):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+    nested = project / "src" / "nested"
+    nested.mkdir(parents=True)
+    run_from = project if cwd_relative == "." else nested
+
+    personal = (
+        hermes_home
+        / "skills"
+        / "productivity"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    untrusted = (
+        project
+        / project_skill_dir
+        / "skills"
+        / "productivity"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    for extractor in (personal, untrusted):
+        extractor.parent.mkdir(parents=True)
+        extractor.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [])
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=run_from,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert Path(result.stdout).resolve() == personal.resolve()
+
+
+@pytest.mark.parametrize("project_skill_dir", [".agents", ".github", ".claude"])
+def test_untrusted_project_candidate_is_not_executed(tmp_path, project_skill_dir):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+    untrusted = (
+        project
+        / project_skill_dir
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    untrusted.parent.mkdir(parents=True)
+    untrusted.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [])
     result = subprocess.run(
         ["bash", "-c", _extract_probe_script()],
         cwd=project,
@@ -51,10 +199,66 @@ def test_hermes_extractor_probe_discovers_supported_layouts(tmp_path, layout):
         capture_output=True,
         text=True,
     )
-    selected = Path(result.stdout)
-    if not selected.is_absolute():
-        selected = project / selected
-    assert selected.resolve() == extractor.resolve()
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("project_skill_dir", [".github", ".claude"])
+def test_hermes_ignores_foreign_project_roots_when_trusted(
+    tmp_path, project_skill_dir
+):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+    foreign = (
+        project
+        / project_skill_dir
+        / "skills"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    foreign.parent.mkdir(parents=True)
+    foreign.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [project])
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == ""
+
+
+def test_non_hermes_host_keeps_original_personal_precedence(tmp_path):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+    personal = home / ".agents" / "skills" / "book-to-skill" / "scripts" / "extract.py"
+    project_local = project / ".agents" / "skills" / "book-to-skill" / "scripts" / "extract.py"
+    for extractor in (personal, project_local):
+        extractor.parent.mkdir(parents=True)
+        extractor.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [project])
+    env.pop("HERMES_AGENT")
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert Path(result.stdout).resolve() == personal.resolve()
 
 
 def test_hermes_destination_and_project_roots_are_documented():

--- a/tests/test_hermes_host_support.py
+++ b/tests/test_hermes_host_support.py
@@ -261,6 +261,45 @@ def test_non_hermes_host_keeps_original_personal_precedence(tmp_path):
     assert Path(result.stdout).resolve() == personal.resolve()
 
 
+def test_hermes_project_candidates_require_enclosing_git_root(tmp_path):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "not-a-git-repository"
+    project.mkdir()
+
+    personal = (
+        hermes_home
+        / "skills"
+        / "productivity"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    project_local = (
+        project
+        / ".hermes"
+        / "skills"
+        / "productivity"
+        / "book-to-skill"
+        / "scripts"
+        / "extract.py"
+    )
+    for extractor in (personal, project_local):
+        extractor.parent.mkdir(parents=True)
+        extractor.touch()
+
+    env = _env_with_hermes_trust(tmp_path, home, hermes_home, [project])
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert Path(result.stdout).resolve() == personal.resolve()
+
+
 def test_hermes_destination_and_project_roots_are_documented():
     assert "**Hermes Agent**" in SKILL
     assert "$HERMES_HOME/skills/<category>" in SKILL

--- a/tests/test_hermes_host_support.py
+++ b/tests/test_hermes_host_support.py
@@ -1,0 +1,69 @@
+"""Hermes Agent host-discovery contract in the converter spec."""
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _extract_probe_script():
+    start = SKILL.index('SCRIPT_PATH=""')
+    end = SKILL.index('\nif [ -z "$SCRIPT_PATH" ]', start)
+    return SKILL[start:end] + '\nprintf "%s" "$SCRIPT_PATH"\n'
+
+
+def test_hermes_is_named_as_supported_host():
+    assert "Hermes Agent" in SKILL
+
+
+@pytest.mark.parametrize(
+    "layout",
+    ["personal-flat", "personal-category", "project-flat", "project-category"],
+)
+def test_hermes_extractor_probe_discovers_supported_layouts(tmp_path, layout):
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-profile"
+    project = tmp_path / "project"
+    project.mkdir()
+
+    roots = {
+        "personal-flat": hermes_home / "skills" / "book-to-skill",
+        "personal-category": hermes_home / "skills" / "productivity" / "book-to-skill",
+        "project-flat": project / ".hermes" / "skills" / "book-to-skill",
+        "project-category": project / ".hermes" / "skills" / "productivity" / "book-to-skill",
+    }
+    extractor = roots[layout] / "scripts" / "extract.py"
+    extractor.parent.mkdir(parents=True)
+    extractor.touch()
+
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "HERMES_HOME": str(hermes_home)})
+    result = subprocess.run(
+        ["bash", "-c", _extract_probe_script()],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    selected = Path(result.stdout)
+    if not selected.is_absolute():
+        selected = project / selected
+    assert selected.resolve() == extractor.resolve()
+
+
+def test_hermes_destination_and_project_roots_are_documented():
+    assert "**Hermes Agent**" in SKILL
+    assert "$HERMES_HOME/skills/<category>" in SKILL
+    assert ".hermes/skills/<category>" in SKILL
+    assert "hermes skills trust" in SKILL
+
+
+def test_hermes_is_in_unknown_host_prompt_and_reload_guidance():
+    assert "Hermes Agent, GitHub Copilot CLI, Amp, Codex, or Claude Code" in SKILL
+    assert "Hermes Agent:         start a new session" in SKILL

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -26,3 +26,101 @@ def test_audit_accepts_skill_with_utf8_bom(tmp_path):
     p.write_bytes(b"\xef\xbb\xbf" + _SKILL.encode("utf-8"))
     errors, _ = validate_skill.audit(str(p))
     assert errors == []
+
+
+def test_hermes_lens_accepts_standard_skill(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(_SKILL, encoding="utf-8")
+    errors, _ = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+
+
+def test_hermes_lens_recognizes_hermes_metadata(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill.\n"
+        "version: 0.1.0\n"
+        "author: Test Author\n"
+        "license: MIT\n"
+        "platforms: [linux, macos, windows]\n"
+        "tags: [test]\n"
+        "category: productivity\n"
+        "required_environment_variables:\n"
+        "  - name: TEST_TOKEN\n"
+        "prerequisites:\n"
+        "  commands: [python3]\n"
+        "compatibility: Hermes Agent\n"
+        "environments: [local]\n"
+        "setup:\n"
+        "  help: Configure the skill.\n"
+        "required_credential_files: [~/.config/example]\n"
+        "related_skills: [example]\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    tags: [test]\n"
+        "---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    errors, warns = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+    assert not [warning for warning in warns if "frontmatter" in warning]
+
+
+def test_hermes_lens_warns_when_trigger_exceeds_house_guideline(tmp_path):
+    p = tmp_path / "SKILL.md"
+    description = "A " + "long " * 14 + "description."
+    p.write_text(
+        f"---\nname: my-skill\ndescription: {description}\n---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    errors, warns = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+    assert any("60 chars" in warning for warning in warns)
+
+
+def test_hermes_lens_does_not_enforce_foreign_allowed_tools(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill.\n"
+        "allowed-tools:\n"
+        "  - Bash\n"
+        "---\n\n```bash\npython3 scripts/example.py\n```\n",
+        encoding="utf-8",
+    )
+    errors, warns = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+    assert any("allowed-tools" in warning for warning in warns)
+
+
+def test_hermes_lens_accepts_underscore_identifiers(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(
+        "---\nname: valid_hermes_skill\ndescription: A test skill.\n---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    errors, _ = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+
+
+def test_hermes_lens_accepts_dot_identifiers(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(
+        "---\nname: valid.hermes.skill\ndescription: A test skill.\n---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    errors, _ = validate_skill.audit(str(p), lens="hermes")
+    assert errors == []
+
+
+def test_hermes_lens_rejects_unsupported_identifier_characters(tmp_path):
+    p = tmp_path / "SKILL.md"
+    p.write_text(
+        "---\nname: _invalid\ndescription: A test skill.\n---\n\n# Body\n",
+        encoding="utf-8",
+    )
+    errors, _ = validate_skill.audit(str(p), lens="hermes")
+    assert any("name:" in error for error in errors)

--- a/tools/validate_skill.py
+++ b/tools/validate_skill.py
@@ -9,6 +9,7 @@ Lenses:
   claude   — Claude Code rules (default; back-compat)
   copilot  — GitHub Copilot CLI rules
   amp      — Sourcegraph Amp rules
+  hermes   — Hermes Agent rules
 
 The SKILL.md format itself is an open standard
 (https://github.com/agentskills/agentskills) — `name` + `description` are the
@@ -22,8 +23,9 @@ Refs:
   Copilot    https://docs.github.com/en/copilot/concepts/agents/about-agent-skills
              https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills
   Amp        https://ampcode.com/manual#skills
+  Hermes     https://hermes-agent.nousresearch.com/docs/user-guide/features/skills
 
-Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp] [path/to/SKILL.md]
+Usage: python3 tools/validate_skill.py [--lens claude|copilot|amp|hermes] [path/to/SKILL.md]
 """
 import argparse
 import re
@@ -81,6 +83,25 @@ LENSES = {
         "reserved_name_words": set(),
         "bash_tool_names": {"shell_command", "Bash"},
         "unknown_tool_severity": "warn",
+    },
+    "hermes": {
+        "label": "Hermes Agent",
+        "tools": set(),
+        "recognized_keys": {
+            "name", "description", "version", "author", "license", "platforms",
+            "tags", "category", "required_environment_variables", "prerequisites",
+            "compatibility", "environments", "setup", "required_credential_files",
+            "related_skills", "metadata",
+        },
+        "reserved_name_words": set(),
+        "bash_tool_names": set(),
+        "unknown_tool_severity": "warn",
+        "enforces_allowed_tools": False,
+        "description_soft_limit": 60,
+        "name_pattern": r"[a-z0-9][a-z0-9._-]*",
+        "name_charset": (
+            "lowercase letters/digits/hyphens/dots/underscores and start with a letter or digit"
+        ),
     },
 }
 
@@ -141,8 +162,10 @@ def audit(path, lens="claude"):
     else:
         if len(name) > 64:
             errors.append(f"name: {len(name)} > 64 chars")
-        if not re.fullmatch(r"[a-z0-9-]+", name):
-            errors.append(f"name: '{name}' must be lowercase letters/digits/hyphens")
+        name_pattern = rules.get("name_pattern", r"[a-z0-9-]+")
+        if not re.fullmatch(name_pattern, name):
+            charset = rules.get("name_charset", "lowercase letters/digits/hyphens")
+            errors.append(f"name: '{name}' must be {charset}")
         for w in rules["reserved_name_words"]:
             if w in name.lower():
                 errors.append(f"name: '{name}' contains a reserved word")
@@ -153,6 +176,12 @@ def audit(path, lens="claude"):
         errors.append("description: missing (required)")
     elif len(desc) > 1024:
         errors.append(f"description: {len(desc)} > 1024 chars")
+    elif soft_limit := rules.get("description_soft_limit"):
+        if len(desc) > soft_limit:
+            warns.append(
+                f"description: {len(desc)} > {soft_limit} chars "
+                f"({label} house guideline for reliable routing)"
+            )
 
     # Tool grant analysis (lens-specific)
     tools = get_list_items(fm, "allowed-tools")
@@ -160,7 +189,7 @@ def audit(path, lens="claude"):
         inline = get_scalar(fm, "allowed-tools")
         if inline:
             tools = inline.split()
-    if tools:  # a restriction is declared -> the host enforces it
+    if tools and rules.get("enforces_allowed_tools", True):
         bases = {tool_base(t) for t in tools}
         known = {b for b in bases if b in rules["tools"]}
         unknown = [t for t in tools if tool_base(t) not in rules["tools"]]


### PR DESCRIPTION
## Summary (Required)

Adds Hermes Agent as a first-class Book-to-Skill host. The converter now discovers profile-aware, categorized Hermes installations through `$HERMES_HOME`, offers Hermes destinations and reload guidance, validates skills with a Hermes lens, and documents the manual installation flow.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** Hermes Agent host detection, `$HERMES_HOME`-aware personal and project roots, a `--lens hermes` validator mode, deterministic host-contract tests, and focused installation documentation.
- **Improves:** Explicit host routing from four hosts to five without changing path precedence for GitHub Copilot CLI, Amp, Claude Code, or Codex.

## Motivation & context (Required)

Hermes implements the open Agent Skills format and accepts the current root `SKILL.md`, but Book-to-Skill did not probe Hermes's profile-aware, categorized skill tree or offer Hermes as a generated-skill destination. A valid clone under `$HERMES_HOME/skills/<category>/book-to-skill` therefore could not be found by the converter's helper-script probe and required a local patch.

Closes: n/a — no existing issue; the behavior was reproduced against a local Hermes installation.

## How it works (Required for anything non-trivial)

The existing host-selection table and extractor candidate list are extended without changing precedence for existing hosts. `HERMES_HOME` is used when set and falls back to `$HOME/.hermes`; flat and one-category-deep personal and project-local converter paths are probed. Hermes project roots are resolved from the enclosing Git checkout and fail closed when no Git root exists; they are considered only when that exact project appears in Hermes's trusted-project configuration. When `HERMES_AGENT=true` identifies a Hermes runtime, trusted project candidates precede personal candidates; untrusted repository files cannot override a personal installation. Hermes destinations use a subject-appropriate category, and project-local output supports `.hermes/skills/<category>` after the project is explicitly trusted.

The validator gains a Hermes lens that recognizes Hermes metadata and underscore-containing identifiers. Its 60-character description convention remains advisory: descriptions over 60 characters warn, while the host-breaking 1024-character ceiling remains an error. Hermes does not enforce foreign `allowed-tools` declarations, so the lens reports that key as ignored rather than turning it into a false tool-permission failure. The generated-skill layout is intentionally unchanged in this PR; a standard `references/` migration can be evaluated separately with legacy-layout compatibility and before/after evidence.

## Evidence (Required)
- **Tests:** Added `tests/test_hermes_host_support.py` and Hermes lens cases in `tests/test_validate_skill.py`. They execute the converter probe against personal/project and flat/categorized layouts, and cover trust guidance, accepted metadata and identifiers, ignored foreign tool restrictions, and the description-routing warning.
- **Before / after:** The initial targeted tests failed 7/7 because Hermes paths and the validator lens were absent. Independent-review hardening tests then reproduced project-root discovery, project-over-personal precedence, project trust, identifier, and frontmatter-compatibility gaps. All Hermes-targeted tests now pass, along with the full suite.

```text
RED (initial host support)
7 failed, 2 deselected

RED (independent-review hardening)
Targeted tests reproduced each reported discovery, trust, identifier,
and frontmatter-key gap before its fix.

GREEN (targeted)
27 passed, 2 deselected in 0.93s

FULL SUITE
614 passed, 5 skipped in 2.26s

LINT
All checks passed!

VALIDATION
SKILL.md [Claude Code]: no Claude Code-breaking issues
SKILL.md [Hermes Agent]: no Hermes Agent-breaking issues

DEPENDENCY-FREE EXTRACTION SMOKE
Sources: 1 processed
Chapters: 1 detected overall
smoke assertions passed

SKILL.md SIZE
+37 lines. The added context is limited to host roots, project-root/precedence
handling, and an explicit Hermes trust gate that prevents untrusted `.hermes`,
`.agents`, `.github`, or `.claude` repository code from winning extractor
discovery, plus destination/trust selection and reload guidance.
```

The docs build also completes. Strict mode still reports the repository's existing missing `guide.md` / `skill-reference.md` and parent-README link warnings; this PR does not add any new missing target.

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

The terminal evidence above covers the host-discovery and validation behavior; there is no graphical interface change.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)

None. Existing host precedence, extraction behavior, and generated-skill layout remain unchanged.

## Notes for reviewers (Optional)

- This intentionally avoids bundling a broader `references/` layout migration. That is a separate generated-behavior change requiring its own tests and measurements.
- Hermes appears only as a supported Agent Skills host; no badge, promotional section, or related-project link is added.
- The README and Russian README receive only host-list/path parity updates; detailed setup stays in `docs/install.md`.
