### PR TITLE
feat(extractor): detect Greek (Κεφάλαιο) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -207,6 +207,15 @@ _BN_CHAPTER = re.compile(
 # inflected form ("В этой главе…", "Главная страница") from matching.
 _RU_CHAPTER = re.compile(r"^\s*(?:#{1,6}\s+)?глава\s+([0-9]+)\b", re.IGNORECASE)
 
+# Greek chapter headings: "Κεφάλαιο 1", "ΚΕΦΑΛΑΙΟ 12", "## Κεφάλαιο 2".
+# "Κεφάλαιο" ("chapter") + a number. Greek uses ordinary Arabic digits, so — like
+# the Russian block above — no digit remap is needed. The 4th letter is written
+# [άα] because all-caps Greek drops the accent ("ΚΕΦΑΛΑΙΟ" has plain Α, not Ά),
+# and case-folding alone would not bridge Ά↔Α. Requiring whitespace then a number
+# keeps prose that merely uses the word (also "capital", "Το κεφάλαιο αυτό…") from
+# matching.
+_EL_CHAPTER = re.compile(r"^\s*(?:#{1,6}\s+)?κεφ[άα]λαιο\s+([0-9]+)\b", re.IGNORECASE)
+
 # Korean chapter headings: "제1장 총칙", "## 제4장 근로시간과 휴식", "제6장의2 …".
 # 제 + Arabic numeral + a classifier (장 chapter / 편 part / 절 section / 관
 # subsection), with an optional "의N" branch suffix that Korean statutes use for
@@ -575,6 +584,9 @@ def _match_chapter_number(line: str) -> int | None:
     rum = _RU_CHAPTER.match(s)
     if rum:
         return int(rum.group(1))
+    elm = _EL_CHAPTER.match(s)
+    if elm:
+        return int(elm.group(1))
 
     km = _KO_CHAPTER.match(s)
     if km:
@@ -596,6 +608,7 @@ def _chapter_number(line: str) -> int | None:
     "## บทที่ ๑"), Hindi ("अध्याय 1", "अध्याय १", "## अध्याय 2"),
     Bengali ("অধ্যায় 1", "অধ্যায় ১", "## অধ্যায় 2"),
     Russian ("Глава 1", "ГЛАВА 12", "## Глава 2"),
+    Greek ("Κεφάλαιο 1", "ΚΕΦΑΛΑΙΟ 12", "## Κεφάλαιο 2"),
     Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and
     Persian ("فصل ۱", "فصل اول", "فصل بیست و یکم", "بخش ۲: مفاهیم",
     "## فصل ۱: مقدمه", PDF-glued "فصل سی و چهارمخداحافظ…") heading styles — each

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -689,6 +689,26 @@ class TestDetectStructure:
         assert _chapter_number("Главная страница") is None
         assert _chapter_number("Глава") is None
 
+    def test_detects_greek_chapters(self):
+        """Greek headings: `Κεφάλαιο N`, incl. all-caps (accent-dropped) ΚΕΦΑΛΑΙΟ."""
+        text = (
+            "Κεφάλαιο 1 Εισαγωγή\nπεριεχόμενο\n"
+            "ΚΕΦΑΛΑΙΟ 2 Μέθοδοι\nπεριεχόμενο\n"
+            "Κεφάλαιο 3 Αποτελέσματα\nπεριεχόμενο"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_greek_markdown_prefix(self):
+        text = "## Κεφάλαιο 1 Πρώτο\nπεριεχόμενο\n## Κεφάλαιο 2 Δεύτερο\nπεριεχόμενο"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_greek_prose_is_not_a_chapter_heading(self):
+        """`κεφάλαιο` used in prose (no number, or mid-sentence) is not a heading."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("Σε αυτό το κεφάλαιο θα δούμε") is None
+        assert _chapter_number("Κεφάλαιο") is None
+
     # ── Korean chapter headings ────────────────────────────────────────────
 
     def test_korean_je_n_jang(self):


### PR DESCRIPTION
## Summary (Required)

Greek chapter headings were not detected — `Κεφάλαιο 1` / `ΚΕΦΑΛΑΙΟ 12` /
`## Κεφάλαιο 2` all returned no chapter, so Greek books fell back to length-based
splitting. This adds a `Κεφάλαιο` + number matcher, following the same per-script
pattern as the Russian / Hindi / Bengali branches.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `_EL_CHAPTER` to `book_to_skill/utils.py` and a dispatch branch in
  `_chapter_number`: `Κεφάλαιο` ("chapter", case-insensitive) followed by a
  number, with an optional Markdown `#` prefix (`## Κεφάλαιο 2`). Greek uses
  ordinary Arabic digits, so — like the Russian block — no digit remap is needed.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, Persian,
Hindi, Bengali, and Russian. Greek writes chapters as `Κεφάλαιο N` in a distinct
script with no current support, so Greek books get no heading detection and fall
back to length splitting.
Closes #n/a (no tracking issue).

## How it works (Required for anything non-trivial)
`_EL_CHAPTER` anchors on the line start (after an optional `#`/`==` prefix, via
the same second-pass strip the other matchers use), requires the label
`Κεφάλαιο` (case-insensitive) then whitespace and a number. The fourth letter is
written `[άα]` because **all-caps Greek drops the accent** — `ΚΕΦΑΛΑΙΟ` has a
plain `Α`, not `Ά`, and case-folding alone would not bridge `Ά`↔`Α`; the class
matches both the accented (title/lower case) and unaccented (all-caps) forms.
Requiring whitespace + a number keeps prose that merely uses the word (which also
means "capital") from matching: `Σε αυτό το κεφάλαιο…` and a bare `Κεφάλαιο` are
both rejected.

## Evidence (Required)
- **Tests:** three cases in `TestDetectStructure` — `Κεφάλαιο`/`ΚΕΦΑΛΑΙΟ`
  detected including the all-caps accent-dropped form (3 chapters);
  Markdown-prefixed `## Κεφάλαιο N` (2 chapters); and a false-positive guard
  (`Σε αυτό το κεφάλαιο …` and a bare `Κεφάλαιο` → not a heading).

```
$ pytest -q tests/test_book_to_skill.py
231 passed
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the Russian pattern (dedicated label matcher, Arabic digits, no numeral
map). The only Greek-specific wrinkle is the `[άα]` class for the all-caps
accent-drop. Kept v1 to the digit form to avoid false positives from Greek
letter-numerals (`Κεφάλαιο Α΄`). `CHANGELOG.md` untouched — git-cliff generates
it from the title (#104). No open PR touches Greek chapter detection.
