### PR TITLE
fix(deps): honor alternative parser availability

### DIFF
--- a/book_to_skill/dependencies.py
+++ b/book_to_skill/dependencies.py
@@ -157,12 +157,21 @@ def offer_dependency_install(
     module_names: list[str],
     fallback: str | None,
     install_mode: str,
+    any_of_modules: bool = False,
 ) -> None:
-    packages = missing_python_packages(module_names)
-    if not packages:
+    missing_packages = missing_python_packages(module_names)
+    if not missing_packages or (
+        any_of_modules and len(missing_packages) < len(module_names)
+    ):
         return
 
-    message = f"{feature} uses {', '.join(packages)} if installed"
+    package_choices = [PYTHON_DEPENDENCIES[name] for name in module_names]
+    if any_of_modules:
+        message = f"{feature} uses one of {', '.join(package_choices)} if installed"
+        packages = missing_packages[:1]
+    else:
+        message = f"{feature} uses {', '.join(missing_packages)} if installed"
+        packages = missing_packages
     if fallback:
         message += f", otherwise {fallback}"
     message += "."
@@ -187,7 +196,12 @@ def offer_dependency_install(
 
     if install_python_packages(packages):
         still_missing = missing_python_packages(module_names)
-        if not still_missing:
+        dependencies_satisfied = (
+            len(still_missing) < len(module_names)
+            if any_of_modules
+            else not still_missing
+        )
+        if dependencies_satisfied:
             print("Package installation complete.")
             return
         print(f"Package installation incomplete; still missing: {', '.join(still_missing)}", file=sys.stderr)
@@ -213,6 +227,7 @@ def prepare_dependencies(ext: str, extraction_mode: str, install_mode: str) -> N
             module_names=["pypdf", "pdfminer"],
             fallback="any installed Python PDF parser; extraction fails if none are available",
             install_mode=install_mode,
+            any_of_modules=True,
         )
 
     if ext == ".epub":
@@ -226,9 +241,10 @@ def prepare_dependencies(ext: str, extraction_mode: str, install_mode: str) -> N
     if ext in HTML_EXTENSIONS:
         offer_dependency_install(
             feature="HTML extraction",
-            module_names=["bs4"],
+            module_names=["trafilatura", "bs4"],
             fallback="a stdlib HTML parser",
             install_mode=install_mode,
+            any_of_modules=True,
         )
 
     if ext == ".docx":

--- a/tests/test_dependency_install_semantics.py
+++ b/tests/test_dependency_install_semantics.py
@@ -1,0 +1,69 @@
+"""Runtime dependency prompts should match the extractor fallback semantics."""
+
+from book_to_skill import dependencies
+
+
+def _fail_install(packages):
+    raise AssertionError(f"unexpected dependency installation: {packages}")
+
+
+def test_pdf_preflight_accepts_one_available_python_parser(monkeypatch):
+    monkeypatch.setattr(dependencies.shutil, "which", lambda _command: None)
+    monkeypatch.setattr(
+        dependencies,
+        "python_module_available",
+        lambda module: module == "pypdf",
+    )
+    monkeypatch.setattr(dependencies, "install_python_packages", _fail_install)
+
+    dependencies.prepare_dependencies(".pdf", "text", "yes")
+
+
+def test_html_preflight_accepts_available_trafilatura(monkeypatch):
+    monkeypatch.setattr(
+        dependencies,
+        "python_module_available",
+        lambda module: module == "trafilatura",
+    )
+    monkeypatch.setattr(dependencies, "install_python_packages", _fail_install)
+
+    dependencies.prepare_dependencies(".html", "text", "yes")
+
+
+def test_any_of_group_installs_only_the_preferred_parser(monkeypatch):
+    installed = []
+    monkeypatch.setattr(dependencies, "python_module_available", lambda _module: False)
+    monkeypatch.setattr(
+        dependencies,
+        "install_python_packages",
+        lambda packages: installed.append(packages) or False,
+    )
+
+    dependencies.offer_dependency_install(
+        feature="HTML extraction",
+        module_names=["trafilatura", "bs4"],
+        fallback="the stdlib HTML parser",
+        install_mode="yes",
+        any_of_modules=True,
+    )
+
+    assert installed == [["trafilatura"]]
+
+
+def test_all_required_group_still_installs_every_missing_package(monkeypatch):
+    installed = []
+    monkeypatch.setattr(dependencies, "python_module_available", lambda _module: False)
+    monkeypatch.setattr(
+        dependencies,
+        "install_python_packages",
+        lambda packages: installed.append(packages) or False,
+    )
+
+    dependencies.offer_dependency_install(
+        feature="EPUB extraction",
+        module_names=["ebooklib", "bs4"],
+        fallback="a stdlib ZIP/HTML parser",
+        install_mode="yes",
+    )
+
+    assert installed == [["ebooklib", "beautifulsoup4"]]


### PR DESCRIPTION
## Summary (Required)

Make runtime dependency prompts honor alternative parser chains. An available PDF
or HTML parser now satisfies preflight, and a completely missing any-of chain
installs only its first preferred parser while cumulative dependency groups keep
their existing behavior.

## Type of change (Required)

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)

- **Fixes:** Runtime preflight previously interpreted PDF and HTML fallback parsers as all-required dependencies, even though `DEPENDENCY_GROUPS` and the extractors treat them as alternatives.
- **Improves:** With one usable parser installed, redundant install attempts drop from one to zero. With none installed, an any-of group installs one preferred parser instead of every alternative.
- **Adds:** Four deterministic tests covering satisfied PDF and HTML chains, preferred any-of installation, and unchanged cumulative EPUB installation.

## Motivation & context (Required)

Closes #207

Users should not be prompted to install another fallback parser when extraction can
already proceed. The runtime prompt should agree with the dependency report's
existing `any_of_modules` semantics.

## How it works (Required for anything non-trivial)

`offer_dependency_install` accepts an `any_of_modules` flag. Such a group returns
as soon as any listed module is importable; if none is present, only the first
ordered module is installed and post-install verification succeeds when any module
becomes available. PDF and HTML opt into this behavior. EPUB and other cumulative
groups retain the default all-required behavior.

The module order is reused as the preference order (`pypdf` before `pdfminer`, and
`trafilatura` before `bs4`) instead of introducing a second source of parser
priority.

## Evidence (Required)

- **Tests:** `tests/test_dependency_install_semantics.py` verifies both already-satisfied chains, preferred single-parser installation, and the EPUB regression boundary.
- **Before / after:** The new targeted suite failed in three places before the implementation and passes all four tests after it. The full Linux suite and repository gates pass.

```text
Before:
3 failed, 1 passed
- attempted ['pdfminer.six'] while pypdf was available
- attempted ['beautifulsoup4'] while trafilatura was available
- offer_dependency_install had no any_of_modules semantics

After:
4 passed in 0.03s

Full Linux/WSL gate:
624 passed, 7 skipped in 2.84s
All checks passed!  # ruff check .
SKILL.md: no Claude Code-breaking issues (1 pre-existing soft length warning)
```

## Screenshots / output

The behavior is terminal-only; the before/after output is included in the evidence
block above.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

`SKILL.md` is unchanged. On native Windows, the current upstream Hermes Bash-path
tests have 12 pre-existing failures; the same complete suite passes under Linux/WSL
as shown above. This PR does not touch Hermes support.
