### PR TITLE
feat(skill): allow choosing project-local skill path

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -78,7 +78,7 @@ This converter can run from multiple skill systems. When looking for this conver
 9. Hermes Agent personal skills: `$HERMES_HOME/skills/` (defaults to `~/.hermes/skills/`)
 10. Hermes Agent project skills: `.hermes/skills/` or `.agents/skills/`
 
-For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists, ask the user once and remember the answer for the session — do not silently default.
+For **generated** book skills, pick a destination that the user's host agent can actually discover (see Step 5). When more than one valid root exists — or when both personal and project-local roots are valid — ask the user once which scope to use and remember the answer for the session — do not silently default. Set `BOOK_TO_SKILL_SCOPE=project` or `personal` to skip the prompt (e.g. for automation).
 
 ---
 
@@ -338,7 +338,17 @@ Otherwise, propose two options and let the user choose:
 
 Default to author-concept format if the book has a strong methodological identity.
 
-Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem for existing skill homes and pick by **the host the user is running in**:
+Choose the destination skill root (`SKILLS_HOME`). First resolve **scope**, then probe **host**:
+
+**Scope** — personal (global, available in every project) vs project-local (only this project, shareable via git):
+1. If the user already said "project-local", "project", "personal" or "global" in the current conversation, or if `BOOK_TO_SKILL_SCOPE` is set to `project` or `personal`, use that scope — do not re-ask.
+2. Otherwise ask once and remember for the session:
+   > "Where should this skill be saved?
+   > 1. **Personal (global)** — `~/.claude/skills`, `~/.agents/skills`, etc. — available everywhere, no extra approval.
+   > 2. **Project-local** — `.claude/skills`, `.agents/skills`, `.github/skills` — only this project, check into git for team sharing (requires host approval to write inside the project)."
+   Project-local is preferred for project-specific skills; personal is preferred for reusable knowledge. If unsure, default to personal.
+
+Probe the filesystem for existing skill homes and pick by **the host the user is running in** within the chosen scope:
 
 | Host agent | Personal skill root (probe in order) | Project-local root |
 |---|---|---|
@@ -350,10 +360,10 @@ Choose the destination skill root (`SKILLS_HOME`). Probe the user's filesystem f
 
 For Hermes Agent, use the active profile's `HERMES_HOME` and choose a category that matches the generated skill's subject. Do not construct profile paths manually. If the user selects a project-local Hermes root, run `hermes skills trust <project-root>` after generation and verify discovery with `hermes skills list`; project skills remain unavailable until the project is trusted.
 
-Selection rules:
-1. If **exactly one** of the host's candidate roots exists on disk, use it without asking.
-2. If **none** exist (fresh machine), ask the user which root to create — present the host-appropriate options and remember the choice for the session. Do not silently pick.
-3. If the user explicitly asked for project-local output, prefer the project-local row.
+Selection rules (within chosen scope):
+1. If **exactly one** candidate root for this scope exists on disk, use it without asking.
+2. If **none** exist (fresh machine), create the first root in the table for this scope after confirming with the user — present the host-appropriate options and remember the choice. Do not silently pick.
+3. If **multiple** roots exist in the chosen scope, ask the user which one to use and remember for the session.
 4. If you cannot identify the host, ask: "Which agent are you running this in — Hermes Agent, GitHub Copilot CLI, Amp, Codex, or Claude Code?"
 
 Set `SKILLS_HOME` to the selected root and check if `$SKILLS_HOME/<skill_name>/` already exists.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,13 +37,14 @@ document into clean text + metadata; the agent turns that into a structured skil
             └────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
-                <SKILLS_HOME>/<slug>/  ← chosen per host:
-                  ~/.copilot/skills/   GitHub Copilot CLI
-                  ~/.agents/skills/    Copilot CLI or Amp (cross-agent)
-                  ~/.claude/skills/    Claude Code
-                  $HERMES_HOME/skills/<category>/  Hermes Agent
-                  .github/skills/ | .claude/skills/ | .agents/skills/  project-local
+                 <SKILLS_HOME>/<slug>/  ← chosen per host + scope:
+                  ~/.copilot/skills/   GitHub Copilot CLI (personal)
+                  ~/.agents/skills/    Copilot CLI or Amp (cross-agent, personal)
+                  ~/.claude/skills/    Claude Code (personal)
+                  $HERMES_HOME/skills/<category>/  Hermes Agent (personal)
+                  .github/skills/ | .claude/skills/ | .agents/skills/  project-local (any host)
                   .hermes/skills/<category>/                         Hermes project-local
+                  scope: personal vs project-local (Step 5, BOOK_TO_SKILL_SCOPE)
                   SKILL.md         core frameworks + chapter & topic index (~4K)
                   chapters/*.md    on-demand, loaded only when asked
                   glossary.md      terms

--- a/docs/install.md
+++ b/docs/install.md
@@ -76,7 +76,11 @@ Or manually using standard `git clone` (ensures modular engine files are fetched
 
 ```bash
 git clone https://github.com/virgiliojr94/book-to-skill.git ~/.claude/skills/book-to-skill
+# Project-local (share with team via git):
+# git clone https://github.com/virgiliojr94/book-to-skill.git .claude/skills/book-to-skill
 ```
+
+> **Generated book skills — where do they go?** By default the converter asks: **Personal (global)** `~/.claude/skills/<slug>/` etc. vs **Project-local** `.claude/skills/<slug>/`, `.agents/skills/<slug>/`, `.github/skills/<slug>/`. Project-local is preferred for project-specific skills (check into git), but requires host approval to write inside the project. Set `BOOK_TO_SKILL_SCOPE=project` or `personal` to skip the prompt (useful for automation).
 
 Then in any agent session:
 


### PR DESCRIPTION
## Summary

Preserve the established personal-skill default while allowing an explicit project-local destination for generated skills.

## Type of change (Required)

- [x] ✨ Feature (non-breaking change that adds capability)

## What it does (Required)

- Keeps `~/.agents/skills` as the default personal destination for non-Hermes hosts.
- Treats project-local output as an explicit choice, using a clear project request or `BOOK_TO_SKILL_SCOPE=project`.
- Supports `BOOK_TO_SKILL_SCOPE=personal` for automation without introducing a mandatory scope prompt.
- Documents that the selected destination may require host approval before writing.
- Adds a concrete scope-selection check to the installation documentation.

## Motivation & context (Required)

The original change asked every user to choose between personal and project-local output, which conflicts with the accepted default-root decision in #125. Project-local output is still useful for repository-specific, shareable skills, but it should remain opt-in. The documentation also must not claim that personal writes need no approval when the host gates writes outside the working directory.

## How it works (Required for anything non-trivial)

Step 5 resolves scope from an explicit user request or `BOOK_TO_SKILL_SCOPE`. If neither is present, it preserves the existing personal default and then applies the host-specific root rules. An explicit project-local request selects the project-local row. The documentation records the before/after behavior:

```text
Before: no scope request or BOOK_TO_SKILL_SCOPE → personal default (~/.agents/skills)
After:  BOOK_TO_SKILL_SCOPE=project or an explicit project-local request → project-local host root
```

## Evidence (Required)

- `python tools/validate_skill.py SKILL.md` — passes with one existing soft line-count warning.
- `python -m pytest tests/test_validate_skill.py tests/test_scope_selection_contract.py -q` — 12 passed.
- `ruff check --select E9,F --target-version py310 book_to_skill/ scripts/ tests/ tools/` — passed.
- `git diff --check` — passed.

## Screenshots / output (Required if behavior or output changes — Optional for pure internal refactor)

No generated output or UI changes.

## Checklist (Required — all must be checked)

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification
