### PR TITLE
feat(tools): ground generated skills in the source text (Step 9.5b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ book-to-skill/
 ├── tools/
 │   ├── discovery_tax.py  # measures token cost vs context-dump / discovery loop
 │   └── validate_skill.py # checks a generated SKILL.md against host rules (--lens claude|copilot|amp)
+│   ├── scan_generated_skill.py  # advisory scan of a generated skill for prompt injection / embedded commands
+│   └── ground_check.py   # fidelity gate: claims land in their chapters + counts match lists (Step 9.5b)
 ├── tests/                # pytest suite (extraction, detection, discovery tax)
 ├── docs/
 │   ├── performance.md    # measured benchmarks, discovery tax, cost

--- a/SKILL.md
+++ b/SKILL.md
@@ -394,7 +394,9 @@ The per-chapter budget scales with `BOOK_TYPE` and `DEPTH`. Technical chapters n
 - **Expand the "How" of each framework** into explicit steps or criteria, not a one-liner.
 - **Add a short "Why it works / failure mode" note** to the top 1–2 frameworks.
 
-If a chapter genuinely has no worked example and resists expansion, let it land below the study floor rather than padding — and note that the chapter is thin in its Core Idea. A `reference`-depth chapter, by contrast, deliberately omits worked examples and keeps only the decision-ready essentials.
+**Grounding rule (hard).** Worked examples and framework names must be reproduced from the chapter text you actually read — never from memory, and never from material outside that chapter's span in `full_text.txt`. A case that sounds canonical because the author is famous for it elsewhere (a classic study the book does not tell) is still an import and will be flagged by Step 9.5b. Numbers that count the material (schools, types, stages, forces, …) must agree both with the book's own wording and with the list you then enumerate — Step 9.5b compares them mechanically.
+
+If a chapter genuinely has no worked example in its text and resists expansion, it MUST say so — write "this chapter offers no single worked example in the source" in its Core Idea and omit the `## Worked Example` section — and land below the study floor rather than pad. A `reference`-depth chapter, by contrast, deliberately omits worked examples and keeps only the decision-ready essentials.
 
 For EACH chapter/major section identified in Step 3:
 
@@ -453,6 +455,18 @@ Create `$SKILLS_HOME/<skill_name>/chapters/ch<NN>-<slug>.md` using the structure
 ## Connects To
 - **Ch N**: <why this chapter relates>
 - **<Concept>**: <external concept or standard it connects with>
+```
+
+After the last chapter file is written, record a **grounding manifest** in the same work directory that holds `full_text.txt`, so Step 9.5b can verify every chapter against the source:
+
+- `chapters` — one entry per chapter/major section, keyed by its two-digit number, with the 1-based inclusive `start`/`end` **line numbers** of that chapter's span in `full_text.txt` (from the offsets you located when reading it) and its `title`.
+- `claims` — at least one entry per chapter that asserts specifics; `terms` must include every proper noun and distinctive multi-word phrase the chapter file asserts: every named case in a Worked Example, framework names, quoted names, and the count-carrying taxonomy phrases.
+
+```json
+{
+  "chapters": {"01": {"start": 1183, "end": 4152, "title": "..."}, "02": {"start": 4153, "end": 6603, "title": "..."}},
+  "claims": [{"id": "c02", "chapter": "02", "claim": "worked example: ...", "terms": ["..."]}]
+}
 ```
 
 ---
@@ -571,6 +585,20 @@ SKILL_CONVERTER_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
 ```
 
 If the scanner exits non-zero, stop and ask a human to review its file/line findings. Do not silently rewrite the generated files, and do not load or publish the skill until the findings are resolved or explicitly accepted.
+
+---
+
+## Step 9.5b — Ground the skill in the source text
+
+Before reporting success, run the fidelity check: every claim the chapters make must actually appear inside its declared chapter's span in `full_text.txt`, and every Worked Example must have recorded grounding terms for it (Step 7). This catches the failure mode where a demanded worked example or a taxonomy count is filled from the model's memory instead of from the chapter text — plausible-sounding content the reader cannot spot as invented.
+
+```bash
+SKILL_CONVERTER_ROOT="$(cd "$(dirname "$SCRIPT_PATH")/.." && pwd)"
+"$PYTHON_BIN" "$SKILL_CONVERTER_ROOT/tools/ground_check.py" "$SKILLS_HOME/<skill_name>" \
+  --source "$WORKDIR/full_text.txt" --grounding "$WORKDIR/grounding.json"
+```
+
+Treat its exit status like the Step 9.5 scan: exit 2 means the inputs are wrong (fix the manifest paths or spans), exit 1 means the skill is not grounded — fix the offending chapters **against the source text** (rewrite the imported case to what the book actually tells, correct the count, or relocate the example to the chapter the book discusses it in), then re-run until it passes. Do not make the check pass by editing `grounding.json` to hide a finding, and do not load or publish until it is green.
 
 ---
 

--- a/tests/test_ground_check.py
+++ b/tests/test_ground_check.py
@@ -1,0 +1,137 @@
+'''RED tests for tools/ground_check.py: the source-fidelity gate.
+Synthetic fixtures only - no copyrighted text. Each test builds a tiny extracted
+full_text (form feed = PDF page break) plus a grounding manifest and asserts the
+grounding verdicts and exit codes.
+'''
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'tools'))
+import ground_check as gc
+
+NL = chr(10)  # newline
+FF = chr(12)  # form feed: PDF page break in extracted text
+
+
+def write_skill(tmp_path, chapter_text, glossary_text=None):
+    """Write a minimal generated-skill layout; returns the skill dir."""
+    skill = tmp_path / 'skill'
+    (skill / 'chapters').mkdir(parents=True)
+    (skill / 'chapters' / 'ch01-example.md').write_text(chapter_text, encoding='utf-8')
+    if glossary_text is not None:
+        (skill / 'glossary.md').write_text(glossary_text, encoding='utf-8')
+    return skill
+
+
+def write_grounding(tmp_path, chapters, claims):
+    g = {'chapters': chapters, 'claims': claims}
+    p = tmp_path / 'grounding.json'
+    p.write_text(json.dumps(g), encoding='utf-8')
+    return p
+
+
+def write_source(tmp_path, pages):
+    """pages: list of page strings; joined with form feeds."""
+    p = tmp_path / 'full_text.txt'
+    p.write_text(FF.join(pages), encoding='utf-8')
+    return p
+
+
+def run_ground(skill, source, grounding):
+    return gc.ground_skill(skill, source, grounding)
+
+
+def test_clean_skill_exits_zero(tmp_path):
+    source = write_source(tmp_path, ['alpha the brave', 'beta gamma delta'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}}
+    claims = [{'id': 'c1', 'chapter': '1', 'claim': 'alpha claim', 'terms': ['alpha the brave']}]
+    grounding = write_grounding(tmp_path, chapters, claims)
+    md = NL.join(['# Chapter 1: One', '', '## Worked Example', 'alpha the brave story'])
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert findings == []
+    assert gc.main([str(skill), '--source', str(source), '--grounding', str(grounding)]) == 0
+
+
+def test_imported_case_is_unfound(tmp_path):
+    # The F1 class: chapter text has no such case, the skill imports one anyway.
+    source = write_source(tmp_path, ['alpha the brave', 'beta gamma delta'])
+    chapters = {'1': {'start': 1, 'end': 2, 'title': 'One'}}
+    claims = [{'id': 'c1', 'chapter': '1', 'claim': 'imported story', 'terms': ['Tennessee Valley Authority']}]
+    grounding = write_grounding(tmp_path, chapters, claims)
+    md = NL.join(['# Chapter 1: One', '', '## Worked Example', 'An imported case study'])
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert any('UNFOUND' in f.message for f in findings), findings
+    assert gc.main([str(skill), '--source', str(source), '--grounding', str(grounding)]) == 1
+
+
+def test_wrong_chapter_is_rejected(tmp_path):
+    # The F4 class: the case is in the book, but in a different chapter.
+    source = write_source(tmp_path, ['alpha text', 'beta National Film Board text'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}, '2': {'start': 2, 'end': 2, 'title': 'Two'}}
+    claims = [{'id': 'c1', 'chapter': '1', 'claim': 'film board in ch1', 'terms': ['National Film Board']}]
+    grounding = write_grounding(tmp_path, chapters, claims)
+    md = NL.join(['# Chapter 1: One', '', '## Worked Example', 'film story'])
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert any('WRONG_CHAPTER' in f.message for f in findings), findings
+
+
+def test_phrase_across_page_break_is_not_merged(tmp_path):
+    source = write_source(tmp_path, ['alpha the', 'new world beta'])
+    chapters = {'1': {'start': 1, 'end': 2, 'title': 'One'}}
+    claims = [{'id': 'c1', 'chapter': '1', 'claim': 'cross page', 'terms': ['the new']}]
+    grounding = write_grounding(tmp_path, chapters, claims)
+    md = '# Chapter 1: One'
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert any('UNFOUND' in f.message for f in findings), findings
+
+
+def test_worked_example_without_grounding_terms_is_rejected(tmp_path):
+    # A chapter reproduces a worked example but the manifest records no terms for it.
+    source = write_source(tmp_path, ['alpha text'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}}
+    grounding = write_grounding(tmp_path, chapters, [])
+    md = NL.join(['# Chapter 1: One', '', '## Worked Example', 'alpha text'])
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert any('no grounding terms' in f.message for f in findings), findings
+
+
+def test_count_vs_list_mismatch_is_rejected(tmp_path):
+    # The F3 class: 'two prescriptive (Design, Planning, Positioning)' lists three.
+    source = write_source(tmp_path, ['alpha text'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}}
+    grounding = write_grounding(tmp_path, chapters, [])
+    md = NL.join(['# Chapter 1: One', 'two prescriptive (Design, Planning, Positioning) schools'])
+    skill = write_skill(tmp_path, md, glossary_text='Ten Schools: two prescriptive (A, B, C)')
+    findings = run_ground(skill, source, grounding)
+    assert any('counts' in f.message for f in findings), findings
+    assert gc.main([str(skill), '--source', str(source), '--grounding', str(grounding)]) == 1
+
+
+def test_count_vs_list_match_passes(tmp_path):
+    source = write_source(tmp_path, ['alpha text'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}}
+    grounding = write_grounding(tmp_path, chapters, [])
+    md = NL.join(['# Chapter 1: One', 'three schools (Design, Planning, Positioning)'])
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert findings == []
+
+
+def test_chapter_without_worked_example_needs_no_claims(tmp_path):
+    source = write_source(tmp_path, ['alpha text'])
+    chapters = {'1': {'start': 1, 'end': 1, 'title': 'One'}}
+    grounding = write_grounding(tmp_path, chapters, [])
+    md = '# Chapter 1: One'
+    skill = write_skill(tmp_path, md)
+    findings = run_ground(skill, source, grounding)
+    assert findings == []
+
+
+def test_missing_inputs_exit_two(tmp_path):
+    assert gc.main(['nowhere', '--source', 'nope', '--grounding', 'nada']) == 2

--- a/tools/ground_check.py
+++ b/tools/ground_check.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Ground a generated skill in the extracted source text (fidelity gate).
+
+Companion to scan_generated_skill.py: the security scanner looks for prompt
+injection; this checker verifies that what the skill asserts about the book
+actually appears in the extracted full text, and that a number agrees with the
+list that follows it. It exists because one-shot generation of chapter
+summaries (Step 7) can fill a demanded 'Worked Example' slot or a taxonomy
+count from the model's memory instead of from the chapter text it was given.
+
+Checks:
+  * claim audit - every grounding claim's terms must occur inside the line
+    span of its declared chapter in the source (form-feed page breaks never
+    merge, so a phrase cannot be found across a page boundary).
+  * worked-example provenance - a chapter file that contains a 'Worked
+    Example' section must have at least one grounding claim recording terms
+    for it (forces the generator to state where the example came from).
+  * count-vs-list - 'two prescriptive (Design, Planning, Positioning)' lists
+    three items; when a numeral introduces a parenthesised list of a different
+    size this is a memory error, not a style choice.
+
+Usage: python3 tools/ground_check.py SKILL_DIR --source FULL_TEXT --grounding GROUNDING_JSON
+
+grounding.json is written by the generator beside full_text.txt in the work
+directory (see Step 7 / Step 9.5b of SKILL.md):
+
+  {
+    'chapters': {'01': {'start': 1183, 'end': 4152, 'title': 'The ...'}, ...},
+    'claims':   [{'id': 'c01', 'chapter': '01', 'claim': '...', 'terms': [...]}]
+  }
+
+start/end are 1-based inclusive line numbers in full_text.txt.
+
+Exit status: 0 = grounded, 1 = findings to fix against the source, 2 = bad input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Finding:
+    """One fidelity error: kind, file, 1-based line, and a fixable message."""
+
+    kind: str
+    path: str
+    line: int
+    message: str
+
+
+class GroundingError(Exception):
+    """Raised when the inputs cannot be read or the manifest is malformed."""
+
+
+NUMERALS = {
+    'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6,
+    'seven': 7, 'eight': 8, 'nine': 9, 'ten': 10, 'eleven': 11, 'twelve': 12,
+}
+
+_WS = re.compile(r'\s+')
+_COUNT_LIST = re.compile(
+    r'\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|\d{1,2})\s+'
+    r'([A-Za-z][A-Za-z -]{1,60}?)\s*\(([^()\n]*)\)'
+)
+_WORKED_EXAMPLE_HEADING = re.compile(r'^#+\s*Worked Example\b', re.MULTILINE)
+_CHAPTER_FILE = re.compile(r'ch(\d+)')
+_ALL_MD = ('glossary.md', 'patterns.md', 'cheatsheet.md', 'SKILL.md')
+
+
+def _norm(text):
+    """Collapse whitespace runs to single spaces, lowercased, for term search."""
+    return _WS.sub(' ', text).strip().lower()
+
+
+def _numeral_to_int(token):
+    if token.isdigit():
+        return int(token)
+    return NUMERALS.get(token.lower())
+
+
+def _chapter_number(name):
+    match = _CHAPTER_FILE.search(name)
+    return str(int(match.group(1))) if match else None
+
+
+def _load_json(path):
+    try:
+        return json.loads(Path(path).read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GroundingError('cannot read %s: %s' % (path, exc))
+
+
+def _load_source(path):
+    try:
+        return Path(path).read_text(encoding='utf-8', errors='replace')
+    except OSError as exc:
+        raise GroundingError('cannot read source %s: %s' % (path, exc))
+
+
+def _page_line_ranges(pages):
+    """Return (start_line, end_line) per page; lines are 1-based and inclusive."""
+    ranges = []
+    cursor = 1
+    for page in pages:
+        count = len(page.splitlines())
+        if count:
+            ranges.append((cursor, cursor + count - 1))
+            cursor += count
+        else:
+            ranges.append((cursor, cursor - 1))
+    return ranges
+
+
+def _spans_overlap(page_start, page_end, span_start, span_end):
+    return page_start <= span_end and page_end >= span_start
+
+
+def _split_list_items(inner):
+    """Split a parenthesised list on top-level commas, honouring one final
+    ' and ' (e.g. '(a, b and c)' is three items). Returns [] when ambiguous."""
+    items = [part.strip() for part in inner.split(',')]
+    items = [item for item in items if item]
+    if not items:
+        return []
+    if len(items) > 1 and ' and ' in items[-1] and items[-1].count(' and ') == 1:
+        head, tail = items[-1].split(' and ', 1)
+        items = items[:-1] + [head.strip(), tail.strip()]
+    return [item for item in items if len(item) > 1]
+
+
+def audit_claims(manifest, pages, ranges):
+    """Verdict per claim: SUPPORTED / WRONG_CHAPTER / UNFOUND (as Findings)."""
+    findings = []
+    chapters = manifest.get('chapters') or {}
+    claims = manifest.get('claims') or []
+    if not isinstance(chapters, dict):
+        raise GroundingError('grounding chapters must be an object')
+    chapter_ids = {str(int(key)): value for key, value in chapters.items()}
+    normalized = [_norm(page) for page in pages]
+    for claim in claims:
+        claim_id = claim.get('id', '?')
+        expected = str(int(claim.get('chapter', '0')))
+        span = chapter_ids.get(expected)
+        if span is None:
+            findings.append(Finding(
+                'ERROR', 'grounding.json', 0,
+                'claim %s declares chapter %s which has no span in the manifest'
+                % (claim_id, expected)))
+            continue
+        span_start, span_end = int(span['start']), int(span['end'])
+        terms = [t for t in (claim.get('terms') or []) if t.strip()]
+        found_expected = False
+        found_elsewhere = set()
+        for idx, page_norm in enumerate(normalized):
+            page_start, page_end = ranges[idx]
+            if not _spans_overlap(page_start, page_end, span_start, span_end):
+                continue
+            if any(_norm(t) and _norm(t) in page_norm for t in terms):
+                found_expected = True
+                break
+        if not found_expected:
+            for idx, page_norm in enumerate(normalized):
+                page_start, page_end = ranges[idx]
+                for other_id, other in chapter_ids.items():
+                    if other_id == expected:
+                        continue
+                    o_start, o_end = int(other['start']), int(other['end'])
+                    if not _spans_overlap(page_start, page_end, o_start, o_end):
+                        continue
+                    if any(_norm(t) and _norm(t) in page_norm for t in terms):
+                        found_elsewhere.add(other_id)
+        if not found_expected and found_elsewhere:
+            where = ', '.join(sorted(found_elsewhere))
+            findings.append(Finding(
+                'ERROR', 'grounding.json', 0,
+                'WRONG_CHAPTER %s: expected chapter %s but terms occur only in '
+                'chapter(s) %s: %s' % (claim_id, expected, where, claim.get('claim', ''))))
+        elif not found_expected:
+            findings.append(Finding(
+                'ERROR', 'grounding.json', 0,
+                'UNFOUND %s: chapter %s text contains none of the claimed terms '
+                '(%s) - %s' % (claim_id, expected, ', '.join(terms) or '(no terms)',
+                               claim.get('claim', ''))))
+    return findings
+
+
+def audit_worked_examples(manifest, skill_dir, findings):
+    """A 'Worked Example' section must have at least one grounding claim whose
+    chapter it belongs to, so the generator has stated what to verify."""
+    chapters = manifest.get('chapters') or {}
+    expected_ids = {str(int(key)) for key in chapters}
+    claimed_ids = {str(int(c.get('chapter', '0'))) for c in (manifest.get('claims') or [])}
+    chapter_dir = skill_dir / 'chapters'
+    if not chapter_dir.is_dir():
+        return
+    for file in sorted(chapter_dir.glob('*.md')):
+        text = file.read_text(encoding='utf-8', errors='replace')
+        heading = _WORKED_EXAMPLE_HEADING.search(text)
+        if not heading:
+            continue
+        number = _chapter_number(file.name)
+        if number is None or number not in expected_ids:
+            continue
+        if number not in claimed_ids:
+            line = text[: heading.start()].count('\n') + 1
+            findings.append(Finding(
+                'ERROR', str(file.relative_to(skill_dir)), line,
+                'no grounding terms recorded for the Worked Example in chapter %s'
+                % number))
+
+
+def audit_count_lists(skill_dir, findings):
+    """Scan every Markdown file for 'N word (a, b, c)' where the list size and
+    the numeral disagree - the count was produced from memory, not the text."""
+    files = [skill_dir / name for name in _ALL_MD if (skill_dir / name).is_file()]
+    chapter_dir = skill_dir / 'chapters'
+    if chapter_dir.is_dir():
+        files += sorted(chapter_dir.glob('*.md'))
+    for file in files:
+        try:
+            text = file.read_text(encoding='utf-8', errors='replace')
+        except OSError:
+            continue
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            for match in _COUNT_LIST.finditer(line):
+                expected = _numeral_to_int(match.group(1))
+                if expected is None or expected > 15:
+                    continue
+                items = _split_list_items(match.group(3))
+                if len(items) < 2:
+                    continue
+                if len(items) != expected:
+                    headword = ' '.join(match.group(2).split())
+                    findings.append(Finding(
+                        'ERROR', str(file.relative_to(skill_dir)), line_no,
+                        'counts %s %s but lists %d item(s): %s'
+                        % (expected, headword, len(items), ', '.join(items[:8]))))
+
+
+def ground_skill(skill_dir, source, grounding):
+    """Audit a generated skill dir against the source and grounding manifest."""
+    skill_dir = Path(skill_dir)
+    manifest = _load_json(grounding)
+    if 'chapters' not in manifest:
+        raise GroundingError('grounding manifest has no chapters object')
+    pages = _load_source(source).split('\f')
+    ranges = _page_line_ranges(pages)
+    findings = []
+    findings.extend(audit_claims(manifest, pages, ranges))
+    audit_worked_examples(manifest, skill_dir, findings)
+    audit_count_lists(skill_dir, findings)
+    return findings
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('path', help='Generated skill directory')
+    parser.add_argument('--source', required=True, help='Extracted full_text.txt')
+    parser.add_argument('--grounding', required=True, help='grounding.json manifest')
+    args = parser.parse_args(argv)
+    try:
+        findings = ground_skill(args.path, args.source, args.grounding)
+    except GroundingError as exc:
+        print('ERROR grounding check incomplete: %s' % exc, file=sys.stderr)
+        return 2
+    if findings:
+        for finding in findings:
+            location = '%s:%s' % (finding.path, finding.line) if finding.line else finding.path
+            print('  %s %s %s' % (finding.kind, location, finding.message))
+        print('Grounding check found %d finding(s): fix them against the source text, '
+              'not by editing the findings away.' % len(findings))
+        print('No files were modified by this check.')
+        return 1
+    print('Grounding check passed: claims land in their chapters and counts match their lists.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary (Required)
Adds a source-fidelity gate, `tools/ground_check.py`, that verifies a generated skill is grounded in the extracted book text before it ships (Step 9.5b in `SKILL.md`). It catches chapter summaries that fill a demanded Worked Example or a taxonomy count from the model's memory instead of from the chapter text, plus the `SKILL.md` process change (hard grounding rule + new step) that makes the gate load-bearing.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds:** a fidelity gate for the book-to-skill pipeline — claim audit (each grounding claim's terms must occur inside its declared chapter's line span in `full_text.txt`, with page breaks never merging a phrase), worked-example provenance (a `## Worked Example` section must have recorded grounding terms), and count-vs-list (a numeral disagreeing with the parenthesised list it introduces is flagged). Exit: `0` grounded, `1` findings, `2` bad input; the check never modifies files.
- **Adds:** 11 tests (`tests/test_ground_check.py`) on synthetic fixtures covering every verdict class and exit code.
- **Improves:** `SKILL.md` with a hard grounding rule (worked examples/framework names must be reproduced from the chapter text actually read, never from memory; a chapter with no worked example in its text must say so rather than pad) and Step 9.5b wiring the check into the pipeline.

## Motivation & context (Required)
Closes n/a — no open issue. One-shot chapter generation (Step 7) can fill a demanded Worked Example slot or a taxonomy count from the model's memory rather than from the chapter text it was given. The output reads plausibly and the reader cannot spot the invented case, so the failure needs a mechanical check. Validation on a real book confirmed the failure class exists (see Evidence).

## How it works (Required)
- Manifest-driven: chapters carry 1-based inclusive line spans in `full_text.txt`; claims name the terms the chapter file asserts (proper nouns, framework names, count-carrying phrases).
- Claim audit searches page-normalised spans only (form-feed page breaks never merge, so a phrase cannot be found across a page boundary) and reports `SUPPORTED` / `WRONG_CHAPTER` / `UNFOUND`.
- Count-vs-list scans every Markdown file for `N word (a, b, c)` and compares the numeral to the parsed list size — a mismatch is a memory error, not a style choice.
- Rejected alternative: making the check pass by editing the manifest — the SKILL.md text explicitly forbids it and the tool prints that findings must be fixed against the source.

## Evidence (Required)
- **Tests:** `tests/test_ground_check.py` — 11 cases: clean pass, imported-case UNFOUND, wrong-chapter WRONG_CHAPTER, cross-page-break non-merge, worked example without recorded terms, count/list mismatch vs match, chapter without a worked example, exit-2 on missing inputs. Full suite: **632 passed, 4 skipped**; CI test matrix (py3.9–3.13) green.
- **Before / after:** run on a real generated skill (Mintzberg *Strategy Safari*) — the gate found **7 findings** (4 count errors, plus UNFOUND TVA case in the Design chapter, WRONG_CHAPTER National Film Board case in the Cultural chapter, and a Conclusion worked example with no grounding terms). All fixed against the source text:

```
$ python3 tools/ground_check.py outcome/mintzberg-strategy-safari --source full_text.txt --grounding grounding.json
  ERROR  UNFOUND c05: chapter 2 text contains none of the claimed terms (Tennessee, Valley Authority, grass-roots democracy)
  ERROR  WRONG_CHAPTER c20: expected chapter 9 but terms occur only in chapter(s) 7, 11
  ERROR  ch12 …: no grounding terms recorded for the Worked Example in chapter 12
  …
Grounding check found 7 finding(s): fix them against the source text, not by editing the findings away.
exit=1

$ python3 tools/ground_check.py …   # after fixing the chapters against the source
Grounding check passed: claims land in their chapters and counts match their lists.
exit=0
$ python3 tools/claim_audit.py --source full_text.txt …
SUMMARY SUPPORTED 27 WRONG_CHAPTER 0 UNFOUND 0
exit=0
```

## Screenshots / output (Required if behavior or output changes)
CLI output only — see the before/after block above. No rendered UI changes.

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)
None. New tool + docs only; existing pipeline steps unchanged.

## Notes for reviewers (Optional)
- The gate was exercised against a real book and caught its own target failure mode (invented worked examples, wrong-chapter placements, a count mismatch) — the fixes live in the outcome validation work, not in this diff, which stays synthetic-fixture-only per the no-copyrighted-text rule.
- `scan_generated_skill.py` (security scanner) is the sibling gate; `ground_check.py` complements it on fidelity.