### PR TITLE
fix(pdf): fall back on invalid inspector metadata

### DIFF
--- a/book_to_skill/pdf_inspector_integration.py
+++ b/book_to_skill/pdf_inspector_integration.py
@@ -58,6 +58,41 @@ def inspect_pdf(path: str | Path) -> tuple[str | None, dict[str, Any] | None]:
 
     try:
         result = pdf_inspector.process_pdf(str(path))
+        pdf_type = _normalise_pdf_type(getattr(result, "pdf_type", None))
+        confidence = float(getattr(result, "confidence", 0.0) or 0.0)
+        pages_needing_ocr = list(getattr(result, "pages_needing_ocr", None) or [])
+        has_encoding_issues = bool(getattr(result, "has_encoding_issues", False))
+        markdown = getattr(result, "markdown", None)
+
+        native_markdown_trusted = bool(
+            isinstance(markdown, str)
+            and markdown.strip()
+            and pdf_type == "text_based"
+            and confidence >= _MIN_NATIVE_CONFIDENCE
+            and not pages_needing_ocr
+            and not has_encoding_issues
+        )
+
+        metadata: dict[str, Any] = {
+            "engine": "pdf-inspector",
+            "version": _package_version(),
+            "pdf_type": pdf_type,
+            "confidence": round(confidence, 4),
+            "native_markdown_trusted": native_markdown_trusted,
+            "pages_needing_ocr": pages_needing_ocr,
+            "ocr_reasons_by_page": _ocr_reasons(
+                getattr(result, "ocr_reasons_by_page", None)
+            ),
+            "pages_with_tables": list(
+                getattr(result, "pages_with_tables", None) or []
+            ),
+            "pages_with_columns": list(
+                getattr(result, "pages_with_columns", None) or []
+            ),
+            "has_encoding_issues": has_encoding_issues,
+            "is_complex_layout": bool(getattr(result, "is_complex_layout", False)),
+            "page_count": int(getattr(result, "page_count", 0) or 0),
+        }
     except Exception as exc:
         print(
             f"  [warn] pdf-inspector preflight failed: {type(exc).__name__}: {exc}",
@@ -65,37 +100,6 @@ def inspect_pdf(path: str | Path) -> tuple[str | None, dict[str, Any] | None]:
         )
         return None, None
 
-    pdf_type = _normalise_pdf_type(getattr(result, "pdf_type", None))
-    confidence = float(getattr(result, "confidence", 0.0) or 0.0)
-    pages_needing_ocr = list(getattr(result, "pages_needing_ocr", None) or [])
-    has_encoding_issues = bool(getattr(result, "has_encoding_issues", False))
-    markdown = getattr(result, "markdown", None)
-
-    native_markdown_trusted = bool(
-        isinstance(markdown, str)
-        and markdown.strip()
-        and pdf_type == "text_based"
-        and confidence >= _MIN_NATIVE_CONFIDENCE
-        and not pages_needing_ocr
-        and not has_encoding_issues
-    )
-
-    metadata: dict[str, Any] = {
-        "engine": "pdf-inspector",
-        "version": _package_version(),
-        "pdf_type": pdf_type,
-        "confidence": round(confidence, 4),
-        "native_markdown_trusted": native_markdown_trusted,
-        "pages_needing_ocr": pages_needing_ocr,
-        "ocr_reasons_by_page": _ocr_reasons(
-            getattr(result, "ocr_reasons_by_page", None)
-        ),
-        "pages_with_tables": list(getattr(result, "pages_with_tables", None) or []),
-        "pages_with_columns": list(getattr(result, "pages_with_columns", None) or []),
-        "has_encoding_issues": has_encoding_issues,
-        "is_complex_layout": bool(getattr(result, "is_complex_layout", False)),
-        "page_count": int(getattr(result, "page_count", 0) or 0),
-    }
     return (markdown if native_markdown_trusted else None), metadata
 
 

--- a/tests/test_pdf_inspector_integration.py
+++ b/tests/test_pdf_inspector_integration.py
@@ -2,6 +2,8 @@ import json
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 import book_to_skill.pdf_inspector_integration as integration
 
 
@@ -53,6 +55,51 @@ def test_inspect_pdf_rejects_native_markdown_when_ocr_is_recommended(monkeypatch
     assert metadata["ocr_reasons_by_page"] == [
         {"page": 7, "reasons": ["suspected_garbled_text"]}
     ]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"confidence": "not-a-number"},
+        {"page_count": "not-an-integer"},
+        {"pages_needing_ocr": object()},
+    ],
+)
+def test_inspect_pdf_falls_back_on_invalid_metadata(monkeypatch, capsys, overrides):
+    fake_module = SimpleNamespace(
+        process_pdf=lambda _path: _fake_result(**overrides)
+    )
+    monkeypatch.setitem(sys.modules, "pdf_inspector", fake_module)
+
+    assert integration.inspect_pdf("book.pdf") == (None, None)
+    assert "pdf-inspector preflight failed" in capsys.readouterr().err
+
+
+def test_hook_uses_existing_pipeline_when_inspector_metadata_is_invalid(
+    tmp_path, monkeypatch
+):
+    integration._reset_state_for_tests()
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.7\nfixture")
+    fake_module = SimpleNamespace(
+        process_pdf=lambda _path: _fake_result(confidence="not-a-number")
+    )
+    monkeypatch.setitem(sys.modules, "pdf_inspector", fake_module)
+
+    original_calls = []
+
+    def original(*args):
+        original_calls.append(args)
+        return {"extraction_method": "legacy"}
+
+    fake_utils = SimpleNamespace(extract_single_file=original)
+
+    integration.install_pdf_inspector_hook(fake_utils)
+    result = fake_utils.extract_single_file(pdf, "text", "no")
+
+    assert result == {"extraction_method": "legacy"}
+    assert original_calls == [(pdf, "text", "no")]
+    assert integration._INSPECTIONS == {}
 
 
 def test_hook_uses_inspector_for_clean_text_pdf(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary (Required)

Make the optional pdf-inspector preflight fail closed when its returned metadata
cannot be normalised. Invalid result fields now trigger the existing warning and
delegate to Book-to-Skill's established PDF extraction chain instead of escaping
as `ValueError` or `TypeError`.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** Metadata conversions performed after `process_pdf()` were outside the adapter's exception boundary, so malformed or incompatible optional-dependency results could abort extraction rather than fall back.
- **Adds:** Regression coverage for invalid confidence, page count, and iterable fields, plus an end-to-end hook assertion that the original extraction function is called.

## Motivation & context (Required)

pdf-inspector is an optional preflight. Its failure should never take authority
away from the existing extractor, consistent with the project's graceful
degradation design. Protecting both the library call and result normalisation
keeps that boundary intact without changing successful pdf-inspector behavior.

Closes #217

## How it works (Required for anything non-trivial)

The existing `try` block now covers both `process_pdf()` and all reads and
normalisation of its returned object. Any ordinary exception follows the already
established warning path and returns `(None, None)`; the hook therefore invokes
the original extractor. Valid metadata and trusted native Markdown follow the
same path as before.

The change deliberately does not alter confidence thresholds, PDF routing,
metadata shape, or the legacy extraction implementation.

## Evidence (Required)
- **Tests:** Added three parameterised adapter cases (`confidence`, `page_count`, and `pages_needing_ocr`) and one hook-level fallback case.
- **Before / after:** The new tests fail on current master with uncaught `ValueError`/`TypeError`; all pass after the exception boundary is extended.

```text
# Before
4 failed, 5 passed in 0.11s

# After
9 passed in 0.05s

# Full Linux/WSL gate from a clean `git archive` of the commit
633 passed, 8 skipped in 1.18s
All checks passed!  # ruff check .
SKILL.md: no Claude Code-breaking issues (one existing soft length warning)
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)

None. Valid pdf-inspector results retain their existing behavior; only failures
while consuming an optional result now use the existing fallback.

## Notes for reviewers (Optional)

The test uses deliberately malformed stub results to exercise the adapter
boundary. The supported pdf-inspector API documents typed fields; this PR does
not claim that a specific released version currently returns malformed values.

