### PR TITLE
fix(pdf): discard stale inspection metadata

### DIFF
--- a/book_to_skill/pdf_inspector_integration.py
+++ b/book_to_skill/pdf_inspector_integration.py
@@ -191,12 +191,15 @@ def install_pdf_inspector_hook(utils_module: Any | None = None) -> None:
         return
 
     def wrapped(input_path: Path, extraction_mode: str, install_mode: str) -> dict[str, Any]:
+        inspection_key = str(input_path.resolve())
+        _INSPECTIONS.pop(inspection_key, None)
+
         if not _looks_like_pdf(input_path):
             return original(input_path, extraction_mode, install_mode)
 
         markdown, inspection = inspect_pdf(input_path)
         if inspection is not None:
-            _INSPECTIONS[str(input_path.resolve())] = inspection
+            _INSPECTIONS[inspection_key] = inspection
 
         if extraction_mode == "text" and markdown and inspection:
             result = _result_from_inspector(utils_module, input_path, markdown, inspection)

--- a/tests/test_pdf_inspector_integration.py
+++ b/tests/test_pdf_inspector_integration.py
@@ -102,6 +102,43 @@ def test_hook_uses_existing_pipeline_when_inspector_metadata_is_invalid(
     assert integration._INSPECTIONS == {}
 
 
+def test_failed_reinspection_does_not_reuse_stale_metadata(tmp_path, monkeypatch):
+    integration._reset_state_for_tests()
+    pdf = tmp_path / "book.pdf"
+    pdf.write_bytes(b"%PDF-1.7\nfixture")
+    inspections = iter(
+        [
+            (None, {"engine": "pdf-inspector", "confidence": 0.5}),
+            (None, None),
+        ]
+    )
+    monkeypatch.setattr(integration, "inspect_pdf", lambda _path: next(inspections))
+
+    fake_utils = SimpleNamespace(
+        extract_single_file=lambda *_args: {"extraction_method": "legacy"}
+    )
+    integration.install_pdf_inspector_hook(fake_utils)
+
+    fake_utils.extract_single_file(pdf, "text", "no")
+    fake_utils.extract_single_file(pdf, "text", "no")
+
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "total_sources": 1,
+                "sources": [{"source_file": str(pdf.resolve())}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    integration.enrich_pdf_inspector_metadata(metadata_path)
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+    assert "pdf_inspector" not in metadata
+    assert "pdf_inspector" not in metadata["sources"][0]
+
+
 def test_hook_uses_inspector_for_clean_text_pdf(tmp_path, monkeypatch):
     integration._reset_state_for_tests()
     pdf = tmp_path / "book.pdf"


### PR DESCRIPTION
## Summary (Required)

Invalidate a path's cached pdf-inspector result before every new extraction
attempt. A failed or unavailable reinspection can no longer leak an earlier
run's provenance into a fresh `metadata.json`.

## Type of change (Required)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Fixes:** The process-level inspection cache retained metadata for a path when a later preflight for that same path returned no result.
- **Adds:** A repeated-run regression test proving that fresh output is not enriched with stale pdf-inspector provenance.

## Motivation & context (Required)

`_INSPECTIONS` bridges extraction and the later metadata-enrichment step, but it
persists for the lifetime of the Python process. Embedded callers and tests can
invoke the pipeline more than once. Metadata should describe the current run,
not the last successful inspection of the same path.

Closes #219

## How it works (Required for anything non-trivial)

The wrapper computes the resolved input key once and removes only that key
before deciding whether or how to inspect the file. It writes the key back only
when the current `inspect_pdf()` call returns metadata. Per-file invalidation
preserves inspection results already collected for other sources in the same
batch.

No inspection schema, routing threshold, extractor behavior, or public API is
changed.

## Evidence (Required)
- **Tests:** Added `test_failed_reinspection_does_not_reuse_stale_metadata`, which runs the same path twice, makes the second preflight return no result, enriches fresh metadata, and asserts that neither metadata level receives a stale `pdf_inspector` entry.
- **Before / after:** The new regression fails on merged `master` because the first result is reused; it passes after per-path invalidation.

```text
# Before
1 failed, 9 passed in 0.08s

# After (targeted)
10 passed in 0.04s

# Full clean Linux gate
634 passed, 8 skipped in 1.21s
All checks passed!  # ruff check .
SKILL.md: no Claude Code-breaking issues (one existing soft length warning)
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] PR title follows Conventional Commits (`fix:`, `feat:`, `docs:`… — it becomes the changelog entry; do NOT edit `CHANGELOG.md` by hand)
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Breaking changes & back-compat (Optional)

None. Current-run inspection results are still recorded and enriched exactly as
before; only stale results from an earlier attempt are discarded.

## Notes for reviewers (Optional)

The cache is invalidated per resolved path rather than globally so processing a
later source does not remove provenance already collected for other PDFs in the
same batch.

