### PR TITLE
feat(extractor): detect Telugu (అధ్యాయము) chapter headings

### DIFF
--- a/book_to_skill/utils.py
+++ b/book_to_skill/utils.py
@@ -210,6 +210,18 @@ _TA_CHAPTER = re.compile(
     rf"^\s*(?:#{{1,6}}\s+)?அத்தியாயம்\s*([0-9{_TA_DIGITS}]+)\b"
 )
 
+# Telugu chapter headings: "అధ్యాయము 1", "అధ్యాయం ౧", "## అధ్యాయం 2".
+# The chapter word has two common spellings — అధ్యాయము (formal) and అధ్యాయం
+# (modern), sharing the stem అధ్యాయ — so both endings are matched. Telugu digits
+# (U+0C66-U+0C6F) are positional like the other Indic blocks above, so only a
+# digit remap is needed. Requiring the full word then a number keeps prose (or an
+# inflected form like "అధ్యాయంలో", a different suffix) from matching.
+_TE_DIGITS = "౦-౯"
+_TE_DIGIT_MAP = str.maketrans("౦౧౨౩౪౫౬౭౮౯", "0123456789")
+_TE_CHAPTER = re.compile(
+    rf"^\s*(?:#{{1,6}}\s+)?అధ్యాయ(?:ము|ం)\s*([0-9{_TE_DIGITS}]+)\b"
+)
+
 # Russian (Cyrillic) chapter headings: "Глава 1", "ГЛАВА 12", "## Глава 2".
 # "Глава" ("chapter") + a number. Cyrillic uses ordinary Arabic digits, so —
 # unlike the Devanagari/Bengali blocks above — no digit remap is needed. A
@@ -596,6 +608,9 @@ def _match_chapter_number(line: str) -> int | None:
     tam = _TA_CHAPTER.match(s)
     if tam:
         return int(tam.group(1).translate(_TA_DIGIT_MAP))
+    tem = _TE_CHAPTER.match(s)
+    if tem:
+        return int(tem.group(1).translate(_TE_DIGIT_MAP))
     rum = _RU_CHAPTER.match(s)
     if rum:
         return int(rum.group(1))
@@ -623,6 +638,7 @@ def _chapter_number(line: str) -> int | None:
     "## บทที่ ๑"), Hindi ("अध्याय 1", "अध्याय १", "## अध्याय 2"),
     Bengali ("অধ্যায় 1", "অধ্যায় ১", "## অধ্যায় 2"),
     Tamil ("அத்தியாயம் 1", "அத்தியாயம் ௧", "## அத்தியாயம் 2"),
+    Telugu ("అధ్యాయము 1", "అధ్యాయం ౧", "## అధ్యాయం 2"),
     Russian ("Глава 1", "ГЛАВА 12", "## Глава 2"),
     Greek ("Κεφάλαιο 1", "ΚΕΦΑΛΑΙΟ 12", "## Κεφάλαιο 2"),
     Korean ("제1장 총칙", "## 제4장 근로시간과 휴식"), and

--- a/tests/test_book_to_skill.py
+++ b/tests/test_book_to_skill.py
@@ -688,6 +688,26 @@ class TestDetectStructure:
         assert _chapter_number("இந்த அத்தியாயத்தில் நாம் பார்ப்போம்") is None
         assert _chapter_number("அத்தியாயம்") is None
 
+    def test_detects_telugu_chapters(self):
+        """Telugu headings: both spellings (అధ్యాయము/అధ్యాయం), Telugu or Arabic digits."""
+        text = (
+            "అధ్యాయము ౧ పరిచయం\nసారాంశం\n"
+            "అధ్యాయం ౨ పద్ధతులు\nసారాంశం\n"
+            "అధ్యాయం 3 ఫలితాలు\nసారాంశం"
+        )
+        assert detect_structure(text)["chapters_detected"] == 3
+
+    def test_telugu_markdown_prefix(self):
+        text = "## అధ్యాయం ౧ మొదటి\nసారాంశం\n## అధ్యాయం ౨ రెండవ\nసారాంశం"
+        assert detect_structure(text)["chapters_detected"] == 2
+
+    def test_telugu_prose_is_not_a_chapter_heading(self):
+        """An inflected form (అధ్యాయంలో) or a bare word is not a heading."""
+        from book_to_skill.utils import _chapter_number
+
+        assert _chapter_number("ఈ అధ్యాయంలో మనం చర్చిస్తాము") is None
+        assert _chapter_number("అధ్యాయం") is None
+
     def test_detects_russian_chapters(self):
         """Russian headings: `Глава N`, case-insensitive, with Arabic digits."""
         text = (


### PR DESCRIPTION
## Summary (Required)

Telugu chapter headings were not detected — `అధ్యాయము 1` / `అధ్యాయం ౧` /
`## అధ్యాయం 2` all returned no chapter, so Telugu books fell back to length-based
splitting. This adds an `అధ్యాయము`/`అధ్యాయం` + number matcher, following the same
per-script pattern as the Hindi / Bengali / Tamil branches.

## Type of change (Required)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does (Required)
- **Adds** `_TE_CHAPTER` (and `_TE_DIGIT_MAP`) to `book_to_skill/utils.py` and a
  dispatch branch in `_chapter_number`: the Telugu word for "chapter" followed by
  a number, in Telugu digits (U+0C66–U+0C6F) or ASCII, with an optional Markdown
  `#` prefix. The word has two common spellings — `అధ్యాయము` (formal) and
  `అధ్యాయం` (modern), sharing the stem `అధ్యాయ` — so both endings are matched.
  Telugu digits are positional, so — like the Bengali/Tamil blocks — only a digit
  remap is needed, no numeral composition.

## Motivation & context (Required)
Chapter detection already covers Latin, Roman, CJK, Thai, Korean, Persian,
Hindi, Bengali, Russian, Greek, and Tamil. Telugu (~80M speakers) is the
adjacent Indic-script gap with no support, so Telugu books get no heading
detection and fall back to length splitting. Grouped with the other Brahmic
scripts (Hindi, Bengali, Tamil).

## How it works (Required for anything non-trivial)
`_TE_CHAPTER` anchors on the line start (after an optional `#`/`==` prefix, via
the same second-pass strip the other matchers use), requires the label
`అధ్యాయ(?:ము|ం)` immediately followed by a number, and remaps Telugu digits to
ASCII before `int()`. Scoped to the digit form and requiring both the full word
and a number, so prose that merely uses the word — including an inflected form
such as `అధ్యాయంలో` ("in the chapter"), a different suffix — does not match. A
bare `అధ్యాయం` is likewise rejected.

## Evidence (Required)
- **Tests:** three cases in `TestDetectStructure` — both spellings
  (`అధ్యాయము`/`అధ్యాయం`) with Telugu and ASCII digits detected (3 chapters);
  Markdown-prefixed `## అధ్యాయం N` (2 chapters); and a false-positive guard
  (`ఈ అధ్యాయంలో …` and a bare `అధ్యాయం` → not a heading).

```
$ pytest -q tests/test_book_to_skill.py
237 passed
$ ruff check .
All checks passed!
```

## Checklist (Required — all must be checked)
- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers (Optional)
Follows the Hindi/Bengali/Tamil pattern (label + positional-digit remap), grouped
with them in the Indic-script block. The only Telugu-specific wrinkle is matching
both the `ము`/`ం` word endings. Kept v1 to the digit form to avoid false positives
from word ordinals. `CHANGELOG.md` untouched — git-cliff generates it from the
title (#104). No open PR touches Telugu chapter detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
