### PR TITLE
fix(evals): stop scoring crashing on, and inventing counts from, recorded data

### DIFF
--- a/tests/evals/test_score_robustness.py
+++ b/tests/evals/test_score_robustness.py
@@ -1,0 +1,185 @@
+"""Scoring must consume whatever a harness recorded, without crashing or inventing.
+
+`tools/evals/score.py` documents itself as scoring "without loading files or
+deriving missing observations", and `aggregate` promises to "never estimate
+missing usage". Two things broke that contract.
+
+1. `opens.index(target)` was called unguarded. It is only reached when
+   `route_correct` and `answer_correct` are both true — but `route_correct` is
+   only *derived* from `opens` when the harness did not record it. A harness that
+   records `route_correct` itself, while `opens` does not contain the target
+   verbatim, raised `ValueError` and killed the entire scoring run rather than
+   one question.
+
+2. `isinstance(value, int)` accepted `True`, because `bool` subclasses `int` in
+   Python. A JSON `true` in a usage field was therefore treated as a recorded
+   count and summed as 1 — precisely the estimate the module promises not to make.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "tools"))
+
+from evals.score import UNKNOWN, aggregate, score, score_trajectory
+
+RECORDED = {"route_correct": True, "evidence_reached": True, "answer_correct": True}
+
+
+def _trajectory(question_id, target, opens, **observed):
+    return {
+        "question_id": question_id,
+        "expected": {"target": target},
+        "observed": dict(observed, opens=opens),
+    }
+
+
+class TestTargetMissingFromOpens:
+    """Recorded booleans must be trusted, not cross-checked into a crash."""
+
+    @pytest.mark.parametrize(
+        "opens, label",
+        [
+            (["chapters/ch01.md"], "a different file was opened"),
+            ([], "nothing was opened"),
+            (["./chapters/ch02.md"], "path normalisation differs"),
+            (["chapters/CH02.MD"], "case differs"),
+        ],
+    )
+    def test_does_not_crash(self, opens, label):
+        result = score_trajectory(
+            _trajectory("q", "chapters/ch02.md", opens, **RECORDED)
+        )
+
+        assert result["classification"] == "correct", label
+
+    def test_recorded_flags_are_passed_through_unchanged(self):
+        result = score_trajectory(
+            _trajectory("q", "b.md", ["a.md"], **RECORDED)
+        )
+
+        assert result["routing_correct"] is True
+        assert result["evidence_reached"] is True
+        assert result["answer_correct"] is True
+
+    def test_a_single_bad_row_does_not_kill_the_run(self):
+        """One unscoreable question used to abort every other question."""
+        trajectories = [
+            _trajectory("q1", "a.md", ["a.md"], **RECORDED),
+            _trajectory("q2", "b.md", ["a.md"], **RECORDED),
+            _trajectory("q3", "c.md", ["c.md"], **RECORDED),
+        ]
+
+        report = score(trajectories)
+
+        assert [item["question_id"] for item in report["questions"]] == ["q1", "q2", "q3"]
+        assert report["aggregate"]["questions"] == 3
+
+
+class TestDerivedRoutingUnchanged:
+    """When the harness did NOT record routing, it is still derived from opens."""
+
+    def test_target_absent_is_wrong_routing(self):
+        result = score_trajectory(
+            _trajectory("q", "a.md", ["b.md"], answer_correct=True)
+        )
+
+        assert result["classification"] == "wrong_routing"
+        assert result["routing_correct"] is False
+
+    def test_target_first_is_correct(self):
+        result = score_trajectory(
+            _trajectory("q", "a.md", ["a.md", "b.md"], answer_correct=True)
+        )
+
+        assert result["classification"] == "correct"
+
+    def test_target_after_others_is_flagged(self):
+        result = score_trajectory(
+            _trajectory("q", "b.md", ["a.md", "b.md"], answer_correct=True)
+        )
+
+        assert result["classification"] == "irrelevant_opens_before_target"
+
+    def test_duplicate_opens_use_the_first_position(self):
+        result = score_trajectory(
+            _trajectory("q", "b.md", ["b.md", "a.md", "b.md"], answer_correct=True)
+        )
+
+        assert result["classification"] == "correct"
+
+    def test_missing_answer_is_unknown(self):
+        result = score_trajectory(_trajectory("q", "a.md", ["a.md"]))
+
+        assert result["classification"] == UNKNOWN
+
+    def test_wrong_answer_still_reported(self):
+        result = score_trajectory(
+            _trajectory("q", "a.md", ["a.md"], answer_correct=False)
+        )
+
+        assert result["classification"] == "wrong_answer"
+
+
+class TestUsageCountsRejectBooleans:
+    """`bool` is an `int`; a recorded `true` is not a count."""
+
+    @pytest.mark.parametrize("field", ["input_tokens", "output_tokens", "calls"])
+    def test_true_is_not_a_count(self, field):
+        usage = {"input_tokens": 5, "output_tokens": 1, "calls": 2}
+        usage[field] = True
+
+        result = score_trajectory(
+            _trajectory("q", "a", ["a"], answer_correct=True, usage=usage)
+        )
+
+        assert result["usage"][field] == UNKNOWN
+
+    def test_false_is_not_a_count(self):
+        result = score_trajectory(
+            _trajectory("q", "a", ["a"], answer_correct=True, usage={"calls": False})
+        )
+
+        assert result["usage"]["calls"] == UNKNOWN
+
+    def test_booleans_are_not_summed_into_totals(self):
+        results = [
+            score_trajectory(
+                _trajectory("q1", "a", ["a"], answer_correct=True,
+                            usage={"calls": True, "input_tokens": 10,
+                                   "output_tokens": 2})
+            ),
+            score_trajectory(
+                _trajectory("q2", "a", ["a"], answer_correct=True,
+                            usage={"calls": 3, "input_tokens": 20,
+                                   "output_tokens": 4})
+            ),
+        ]
+
+        summary = aggregate(results)
+
+        # Only the genuine 3 is counted, and only one observation is recorded.
+        assert summary["recorded_usage"]["calls"] == 3
+        assert summary["usage_observations"]["calls"] == 1
+        assert summary["recorded_usage"]["input_tokens"] == 30
+        assert summary["usage_observations"]["input_tokens"] == 2
+
+    def test_genuine_integers_still_recorded(self):
+        result = score_trajectory(
+            _trajectory("q", "a", ["a"], answer_correct=True,
+                        usage={"input_tokens": 7, "output_tokens": 0, "calls": 1})
+        )
+
+        assert result["usage"] == {"input_tokens": 7, "output_tokens": 0, "calls": 1}
+
+    def test_non_numeric_usage_is_unknown(self):
+        result = score_trajectory(
+            _trajectory("q", "a", ["a"], answer_correct=True,
+                        usage={"calls": "3", "input_tokens": 1.5})
+        )
+
+        assert result["usage"]["calls"] == UNKNOWN
+        assert result["usage"]["input_tokens"] == UNKNOWN

--- a/tools/evals/score.py
+++ b/tools/evals/score.py
@@ -12,6 +12,16 @@ def _state(value: Any) -> Any:
     return value if isinstance(value, bool) else UNKNOWN
 
 
+def _count(value: Any) -> Any:
+    """Keep only explicit integer counts; absence remains unknown.
+
+    ``bool`` is a subclass of ``int``, so a JSON ``true`` would otherwise pass an
+    ``isinstance(value, int)`` test and then be summed as 1 -- inventing a usage
+    number this module promises never to estimate.
+    """
+    return value if isinstance(value, int) and not isinstance(value, bool) else UNKNOWN
+
+
 def score_trajectory(trajectory: Dict[str, Any]) -> Dict[str, Any]:
     """Score one trajectory without loading files or deriving missing observations."""
     expected = trajectory.get("expected", {})
@@ -22,6 +32,16 @@ def score_trajectory(trajectory: Dict[str, Any]) -> Dict[str, Any]:
         any(opened == target for opened in opens)
         if isinstance(opens, list) and target is not None
         else UNKNOWN
+    )
+    # Where the target appears among the opens, or None when it does not appear
+    # at all. `opens.index(target)` was called unguarded further down, so a
+    # harness that recorded route_correct itself -- while `opens` did not contain
+    # the target verbatim (an empty list, a "./" prefix, any path normalisation
+    # difference) -- raised ValueError and killed the whole scoring run.
+    target_position = (
+        opens.index(target)
+        if isinstance(opens, list) and target is not None and target in opens
+        else None
     )
     answer_correct = _state(observed.get("answer_correct"))
     route_correct = _state(observed.get("route_correct"))
@@ -37,7 +57,7 @@ def score_trajectory(trajectory: Dict[str, Any]) -> Dict[str, Any]:
         classification = "wrong_routing"
     elif not answer_correct:
         classification = "wrong_answer"
-    elif isinstance(opens, list) and target is not None and opens.index(target) > 0:
+    elif target_position is not None and target_position > 0:
         classification = "irrelevant_opens_before_target"
     else:
         classification = "correct"
@@ -50,7 +70,7 @@ def score_trajectory(trajectory: Dict[str, Any]) -> Dict[str, Any]:
         "routing_correct": route_correct,
         "evidence_reached": evidence_reached,
         "answer_correct": answer_correct,
-        "usage": {key: usage.get(key) if isinstance(usage.get(key), int) else UNKNOWN
+        "usage": {key: _count(usage.get(key))
                   for key in ("input_tokens", "output_tokens", "calls")},
     }
 


### PR DESCRIPTION
## Summary

`tools/evals/score.py` calls `opens.index(target)` unguarded, so a trajectory whose `route_correct` was **recorded** by the harness while `opens` does not contain the target verbatim raises `ValueError` — and because `score()` maps over every trajectory, one such row aborts the entire scoring run. Separately, `isinstance(value, int)` accepts `True`, so a JSON `true` in a usage field is summed as a count.

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ Feature (non-breaking change that adds capability)
- [ ] ⚡ Performance (faster / cheaper, no behavior change)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs only
- [ ] 🔒 Security
- [ ] 🧹 Chore / CI / tooling
- [ ] 💥 Breaking change (changes existing behavior or a public interface)

## What it does

- **Fixes (1):** an unguarded `list.index()` on a value that may legitimately be absent.
- **Fixes (2):** `bool` passing an `int` type check, which fabricates a usage number the module explicitly promises never to estimate.

## Motivation & context

Closes n/a — found while auditing the new `tools/evals` modules; no existing issue.

Both defects contradict the module's own stated contract. Its docstring says it scores *"without loading files or deriving missing observations"*, and `aggregate` says it *"never estimate[s] missing usage"*. The whole design — `_state()` keeping only explicit booleans, `UNKNOWN` for everything else — is about trusting what the harness recorded and refusing to infer. So:

- **(1)** is a cross-check the design says should not happen. `route_correct` is only *derived* from `opens` when the harness did not record it (`if "route_correct" not in observed`). When the harness *does* record it, the code proceeds to index `opens` by the target anyway. A harness that judges routing by its own criterion, or that records paths with any normalisation difference, is well within contract and gets a crash.
- **(2)** silently invents data. `bool` is a subclass of `int` in Python, so a recorded `true` is accepted as an observation, counted in `usage_observations`, and added to `recorded_usage` as 1.

The blast radius of (1) is what makes it worth fixing rather than tolerating: `score()` is a list comprehension over every trajectory, so a single unscoreable question takes down the whole report.

## How it works

**(1)** The position is computed once, guarded by membership:

```python
target_position = (
    opens.index(target)
    if isinstance(opens, list) and target is not None and target in opens
    else None
)
...
elif target_position is not None and target_position > 0:
    classification = "irrelevant_opens_before_target"
```

Absence now means what it should: there is no evidence of irrelevant opens *before* the target, so the classification falls through to `correct` — which is the right answer when all three recorded booleans are true. It does not override or second-guess the harness.

**(2)** A `_count()` helper mirroring the existing `_state()`:

```python
def _count(value: Any) -> Any:
    return value if isinstance(value, int) and not isinstance(value, bool) else UNKNOWN
```

Rejected alternative for (1): treating a missing target as `wrong_routing`. That would override an explicit recorded observation with an inference — the exact thing `_state()` exists to prevent — and would silently rewrite a harness's own judgement.

## Evidence

**Before / after**, `score_trajectory` with `route_correct` / `evidence_reached` / `answer_correct` all recorded true:

```
                                       before                     after
target not among opens                 CRASH ValueError           correct
empty opens list                       CRASH ValueError           correct
path normalisation differs ("./")      CRASH ValueError           correct
case differs                           CRASH ValueError           correct
target IS among opens (control)        correct                    correct
derived routing, target absent         wrong_routing              wrong_routing
```

**Usage counts:**

```
usage = {"calls": true, "input_tokens": 5, "output_tokens": 1}
  before -> {'input_tokens': 5, 'output_tokens': 1, 'calls': True}
  after  -> {'input_tokens': 5, 'output_tokens': 1, 'calls': 'unknown'}
```

and in `aggregate`, a recorded true alongside a genuine 3 previously produced `recorded_usage.calls == 4` from two "observations"; it now produces 3 from one.

**Tests** — new `tests/evals/test_score_robustness.py`, 19 cases in three groups:

- `TestTargetMissingFromOpens` — four parametrized absence cases, recorded flags passed through unchanged, and a three-question run proving one bad row no longer kills the other two.
- `TestDerivedRoutingUnchanged` — the regression net: target absent is still `wrong_routing`, target-first is `correct`, target-after-others is still `irrelevant_opens_before_target`, duplicate opens use the first position, missing answer is `unknown`, wrong answer still reported.
- `TestUsageCountsRejectBooleans` — true/false rejected per field, not summed into totals, genuine integers (including 0) still recorded, strings and floats still `unknown`.

RED against `master` (`01f8a74`): **11 failed, 8 passed**. GREEN:

```
$ python -m pytest tests/evals -q
49 passed in 3.75s

$ python -m pytest tests/ -q --ignore=tests/test_hermes_host_support.py
629 passed, 11 skipped in 19.27s

$ ruff check .
All checks passed!
```

## Screenshots / output

The before/after tables above are the output; this is a scoring function with nothing visual to capture.

## Checklist

- [x] One focused change (one feature/fix per PR; not a stack of unrelated work)
- [x] Branch is rebased on the latest `master` and has no merge conflicts
- [x] Tests added/updated for behavior changes
- [x] `pytest -q` is green on a clean checkout
- [x] `ruff check .` is clean
- [x] `python3 tools/validate_skill.py SKILL.md` passes (if `SKILL.md` changed) — n/a, `SKILL.md` untouched
- [x] PR title follows Conventional Commits — `CHANGELOG.md` not edited by hand
- [x] No raw book text shipped; no net `SKILL.md` bloat without justification

## Notes for reviewers

**On the `--ignore` in the test command above.** `tests/test_hermes_host_support.py` has **12 failures on `master` before this branch** — I verified that by stashing my change and re-running. They are a Windows artifact, not a product bug and not mine: those tests shell out to `bash -c` with Windows paths in `HOME` / `HERMES_HOME`, the candidate loop resolves nothing, and stdout comes back empty. They presumably pass on the Linux CI matrix. Flagging it only because it makes the suite red for anyone developing on Windows — happy to open a separate issue or send a portability fix if that is useful.

**Two smaller things in the same subsystem I left alone**, to keep this to one change — say the word and I will send either:

- `replay.py` does `from score import score`, a bare top-level import that only resolves when `tools/evals` itself is on `sys.path`, while the tests import `evals.score`. The two entry points disagree about the package layout.
- `replay()` reads `fixture["fixture_version"]` but `load_fixture()` validates only `schema_version` and `trajectories`, so a fixture missing `fixture_version` raises `KeyError` instead of the module's own `ValueError("unsupported fixture …")` style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
